### PR TITLE
Delete last column on flow manager

### DIFF
--- a/app/assets/javascripts/flow_manager.js.coffee
+++ b/app/assets/javascripts/flow_manager.js.coffee
@@ -28,9 +28,8 @@ Tahi.flowManager =
     saveFlows: ->
       flowTitles = _.map @state.flows, (flow) -> flow.title
       $.post 'user_settings',
+        flows: flowTitles
         _method: 'PATCH'
-        user_settings:
-          flows: flowTitles
 
     render: ->
       {ul, div} = React.DOM

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -3,7 +3,7 @@ class UserSettingsController < ApplicationController
 
   def update
     settings = UserSettings.where(user: current_user).first_or_initialize
-    settings_params = params.require(:user_settings).permit(flows: [])
+    settings_params = params.permit(flows: []).reverse_merge!(flows: [])
     settings.update settings_params
     head :no_content
   end

--- a/spec/controllers/user_settings_controller_spec.rb
+++ b/spec/controllers/user_settings_controller_spec.rb
@@ -6,17 +6,33 @@ describe UserSettingsController do
   before { sign_in user }
 
   describe "POST 'update'" do
-    subject(:do_request) do
-      patch :update, user_settings: { flows: ['Up for grabs'] }
+    context "without a flow" do
+      subject(:do_request) do
+        # jQuery will not send empty object params, {} or [], e.g
+        patch :update
+      end
+
+      specify { expect(do_request).to be_success }
+
+      it_behaves_like "when the user is not signed in"
+
+      it "updates the user's flow preferences" do
+        expect { do_request }.to change { user.reload.user_settings.flows }.to []
+      end
     end
 
-    specify { expect(do_request).to be_success }
+    context "with a flow" do
+      subject(:do_request) do
+        patch :update, flows: ['Up for grabs']
+      end
 
-    it_behaves_like "when the user is not signed in"
+      specify { expect(do_request).to be_success }
 
-    it "updates the user's flow preferences" do
-      expect { do_request }.to change { user.reload.user_settings.flows }.to ['Up for grabs']
+      it_behaves_like "when the user is not signed in"
+
+      it "updates the user's flow preferences" do
+        expect { do_request }.to change { user.reload.user_settings.flows }.to ['Up for grabs']
+      end
     end
   end
-
 end


### PR DESCRIPTION
The user settings controller was requiring the user settings params, but when you delete the last column and attempt to POST it, jQuery doesn't send that param (because it ~~doesn't exist~~ is an empty `[]`). So we reverse merge an empty array if the param is not sent.
