### PR TITLE
Support namespaces models for tasks

### DIFF
--- a/app/assets/javascripts/models/tasks.js.coffee
+++ b/app/assets/javascripts/models/tasks.js.coffee
@@ -10,6 +10,7 @@ ETahi.Task = DS.Model.extend
   role: a('string')
   title: a('string')
   type: a('string')
+  qualifiedType: a('string')
 
   isMessage: Ember.computed.equal('type', 'MessageTask')
   paper: Ember.computed.alias('phase.paper')
@@ -29,6 +30,7 @@ ETahi.PaperAdminTask = ETahi.Task.extend
 
 ETahi.AuthorsTask = ETahi.Task.extend
   authors: Ember.computed.alias('paper.authorsArray')
+  qualifiedType: "StandardTasks::AuthorsTask"
 
 ETahi.DeclarationTask = ETahi.Task.extend
   declarations: Ember.computed.alias('paper.declarations')
@@ -57,5 +59,7 @@ ETahi.RegisterDecisionTask = ETahi.Task.extend
 ETahi.ReviewerReportTask = ETahi.Task.extend
   paperReview: DS.belongsTo('paperReview')
 
-ETahi.TechCheckTask = ETahi.Task.extend()
+ETahi.TechCheckTask = ETahi.Task.extend
+  qualifiedType: "StandardTasks::TechCheckTask"
+
 ETahi.UploadManuscriptTask = ETahi.Task.extend()

--- a/app/assets/javascripts/serializers/task_serializer.js.coffee
+++ b/app/assets/javascripts/serializers/task_serializer.js.coffee
@@ -1,7 +1,19 @@
 ETahi.TaskSerializer = DS.ActiveModelSerializer.extend ETahi.SerializesHasMany,
+  normalize: (type, hash) ->
+    hash.qualified_type = hash.type
+    hash.type = hash.type.replace(/.+::/, '')
+    this._super.apply(this, arguments)
+
   serializeIntoHash: (data, type, record, options) ->
       root = 'task'
       data[root] = this.serialize(record, options)
+
+  serialize: (record, options) ->
+    json = this._super(record, options)
+    if json.qualified_type
+      json.type = json.qualified_type
+      delete json.qualified_type
+    return json
 
   coerceId: (id) ->
     (if not id? then null else id + "")
@@ -32,9 +44,11 @@ ETahi.TaskSerializer = DS.ActiveModelSerializer.extend ETahi.SerializesHasMany,
 
       #jshint loopfunc:true
       for hash in payload[prop]
-        hash.foobar = 'hello!'
+        # hash.foobar = 'hello!'
         # custom code starts here
         typeName = if hash.type
+          hash.qualified_type = hash.type
+          hash.type = hash.type.replace(/.+::/, '')
           @typeForRoot hash.type
         else
           @typeForRoot prop

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -8,13 +8,7 @@ class TaskSerializer < ActiveModel::Serializer
     'task'
   end
 
-  def type
-    # Client doesn't need to know about the task's namespace.
-    object.type.gsub(/.+::/,'')
-  end
-
   def paper_title
     object.paper.display_title
   end
-
 end


### PR DESCRIPTION
- Tasks are serialized as-is from the server
- Tasks in Ember contain a qualifiedType attr which contains the fully qualified type name
- When existing tasks are normalized in Ember, their qualifiedType is set from the type field
- When new/updated tasks are serialized, their qualifiedType is used to populate the type field
