### PR TITLE
Float overlay checkbox right

### DIFF
--- a/app/assets/stylesheets/ui/overlay.css.scss
+++ b/app/assets/stylesheets/ui/overlay.css.scss
@@ -101,6 +101,7 @@
 .overlay-completed-checkbox {
   @extend .col-xs-3;
   text-align: right;
+  float: right;
 
   label {
     color: $tahi-primary;


### PR DESCRIPTION
Overlay checkbox wasn't to the right in the declaration card because we were relying on the assignees dropdown to push it over. So, I floated it to the right.
