### PR TITLE
Remove engine models

### DIFF
--- a/app/assets/javascripts/models/task.js.coffee
+++ b/app/assets/javascripts/models/task.js.coffee
@@ -29,15 +29,8 @@ ETahi.PaperAdminTask = ETahi.Task.extend
   admins: DS.hasMany('user')
   admin: DS.belongsTo('user')
 
-ETahi.AuthorsTask = ETahi.Task.extend
-  authors: Ember.computed.alias('paper.authorsArray')
-  qualifiedType: "StandardTasks::AuthorsTask"
-
 ETahi.DeclarationTask = ETahi.Task.extend
   declarations: Ember.computed.alias('paper.declarations')
-
-ETahi.FigureTask = ETahi.Task.extend
-  qualifiedType: "StandardTasks::FigureTask"
 
 ETahi.MessageTask = ETahi.Task.extend
   participants: DS.hasMany('user')
@@ -59,8 +52,5 @@ ETahi.RegisterDecisionTask = ETahi.Task.extend
 
 ETahi.ReviewerReportTask = ETahi.Task.extend
   paperReview: DS.belongsTo('paperReview')
-
-ETahi.TechCheckTask = ETahi.Task.extend
-  qualifiedType: "StandardTasks::TechCheckTask"
 
 ETahi.UploadManuscriptTask = ETahi.Task.extend()

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140414170614) do
+ActiveRecord::Schema.define(version: 20140428164422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 20140414170614) do
     t.integer  "journal_id",                           null: false
     t.string   "decision"
     t.text     "decision_letter"
+    t.datetime "published_at"
   end
 
   add_index "papers", ["journal_id"], name: "index_papers_on_journal_id", using: :btree

--- a/engines/standard_tasks/app/assets/javascripts/task.js.coffee
+++ b/engines/standard_tasks/app/assets/javascripts/task.js.coffee
@@ -1,9 +1,0 @@
-ETahi.AuthorsTask = ETahi.Task.extend
-  authors: Ember.computed.alias('paper.authorsArray')
-  qualifiedType: "StandardTasks::AuthorsTask"
-
-ETahi.FigureTask = ETahi.Task.extend
-  qualifiedType: "StandardTasks::FigureTask"
-
-ETahi.TechCheckTask = ETahi.Task.extend
-  qualifiedType: "StandardTasks::TechCheckTask"


### PR DESCRIPTION
Actually remove the js models (Authors, Figure, and TechCheck) from the main application and properly load the engine's js.
