### PR TITLE
Switch stream to use journals

### DIFF
--- a/app/assets/javascripts/controllers/application_controller.js.coffee
+++ b/app/assets/javascripts/controllers/application_controller.js.coffee
@@ -10,8 +10,10 @@ ETahi.ApplicationController = Ember.Controller.extend
       url: '/event_stream'
       method: 'GET'
       success: (data) =>
-        source = new EventSource(data.url)
         data.eventNames.forEach (eventName) =>
+          source = new EventSource(data.url + "&stream=#{eventName}")
+          Ember.$(window).unload ->
+            source.close()
           source.addEventListener eventName, (msg) =>
             esData = JSON.parse(msg.data)
             @pushUpdate(esData)

--- a/app/controllers/event_streams_controller.rb
+++ b/app/controllers/event_streams_controller.rb
@@ -1,10 +1,10 @@
 class EventStreamsController < ApplicationController
   before_action :authenticate_user!
   def show
-    render json: EventStream.connection_info(paper_ids).to_json
+    render json: EventStream.connection_info(ids).to_json
   end
 
-  def paper_ids
-    current_user.papers.map &:id
+  def ids
+    current_user.journals.pluck(:id)
   end
 end

--- a/app/services/event_stream.rb
+++ b/app/services/event_stream.rb
@@ -1,18 +1,18 @@
 class EventStream
 
-  def self.post_event(paper_id, card_json)
+  def self.post_event(id, card_json)
     Thread.new do
       Net::HTTP.post_form(
         URI.parse(update_url),
-        card: card_json, stream: name(paper_id), token: token
+        card: card_json, stream: name(id), token: token
       )
     end
   end
 
-  def self.connection_info(paper_ids)
+  def self.connection_info(ids)
     {
       url: stream_url,
-      eventNames: names(paper_ids)
+      eventNames: names(ids)
     }
   end
 
@@ -20,8 +20,8 @@ class EventStream
     ids.map {|id| name id }
   end
 
-  def self.name(paper_id)
-    Digest::MD5.hexdigest "paper_#{paper_id}"
+  def self.name(id)
+    Digest::MD5.hexdigest "paper_#{id}"
   end
 
   def self.token

--- a/config/initializers/event_stream_subscriptions.rb
+++ b/config/initializers/event_stream_subscriptions.rb
@@ -2,7 +2,7 @@ ActiveSupport::Notifications.subscribe('updated') do |name, start, finish, id, p
   task = Task.find(payload[:id])
   serializer = task.active_model_serializer.new(task)
   EventStream.post_event(
-    task.paper.id,
+    task.journal.id,
     serializer.to_json
   )
 end

--- a/spec/features/event_stream_spec.rb
+++ b/spec/features/event_stream_spec.rb
@@ -7,6 +7,7 @@ feature "Event streaming", js: true do
   let(:upload_task) { paper.tasks_for_type(UploadManuscriptTask).first }
 
   before do
+    JournalRole.create! user: author, journal: paper.journal, admin: true
     sign_in_page = SignInPage.visit
     sign_in_page.sign_in author.email
   end


### PR DESCRIPTION
Make a connection for each journal the user is connected to. This is in preparation for changes coming to the event source server. Please pull down this branch and verify that it still works with the current event source server on heroku. It worked for me when running this branch locally against the heroku event source.
