### PR TITLE
Fix VCR / rspec OxParser Errors [references #71325688]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :test do
   gem 'factory_girl_rails'
   gem "codeclimate-test-reporter", require: nil
   gem 'vcr'
-  gem 'typhoeus'
+  gem 'webmock'
 
   # For testing event streaming.
   gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     compass-rails (1.1.7)
       compass (>= 0.12.2)
       sprockets (<= 2.11.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     daemons (1.1.9)
     database_cleaner (1.2.0)
     debug_inspector (0.0.2)
@@ -128,8 +130,6 @@ GEM
     ember-source (1.5.0)
       handlebars-source (~> 1.0)
     erubis (2.7.0)
-    ethon (0.7.0)
-      ffi (>= 1.3.0)
     eventmachine (1.0.3)
     excon (0.28.0)
     execjs (2.0.2)
@@ -354,8 +354,6 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    typhoeus (0.6.8)
-      ethon (>= 0.7.0)
     tzinfo (1.1.0)
       thread_safe (~> 0.1)
     uglifier (2.5.0)
@@ -372,6 +370,9 @@ GEM
     vcr (2.9.0)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (1.17.4)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
     websocket (1.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -431,8 +432,8 @@ DEPENDENCIES
   teaspoon
   thin
   timeliness
-  typhoeus
   uglifier (~> 2.5.0)
   unf
   unicorn
   vcr
+  webmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,8 @@ ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
-  config.hook_into :typhoeus
-  config.allow_http_connections_when_no_cassette = true
+  config.hook_into :webmock
+  config.allow_http_connections_when_no_cassette = false
   config.default_cassette_options = { record: :new_episodes }
   config.configure_rspec_metadata!
   config.ignore_localhost = true # Makes Selenium work


### PR DESCRIPTION
This issue started with semaphore ci failures on master when nothing related to this code had changed.

Found two issues:
1.  oxgarage server process died and therefore no longer responded to port 8080
which made the second problem evident ...
2.  vcr was ignoring typhoeus (but nobody knew this), so when tests were running, it was actually making live requests

So when the service went down, everything started to fail.

Fixes in this pull request:
1.  change vcr to use webmock instead of typhoeus (we couldn't get vcr to hook into typhoeus successfully)
2.  fail loudly if a live request is attempted to be made when running tests
