### PR TITLE
Ensure /admin page only allows admin users

### DIFF
--- a/app/assets/javascripts/routes/admin_route.js.coffee
+++ b/app/assets/javascripts/routes/admin_route.js.coffee
@@ -1,3 +1,3 @@
-ETahi.AdminRoute = Ember.Route.extend
+ETahi.AdminRoute = ETahi.AdminAuthorizedRoute.extend
   model: ->
     @store.find('journal')

--- a/spec/features/journal_administration_spec.rb
+++ b/spec/features/journal_administration_spec.rb
@@ -16,6 +16,15 @@ feature "Journal Administration", js: true do
       journal_names = [journal, another_journal].map(&:name)
       expect(admin_page.journal_names).to match_array(journal_names)
     end
+
+    context "when the user is not an admin" do
+      let(:admin) { create :user }
+      scenario "user is redirected to the dashboard page" do
+        visit AdminDashboardPage.path
+        expect(page).to have_text "Welcome,"
+        expect(page).to_not have_text "Journal Administration"
+      end
+    end
   end
 
   describe "Visiting a journal" do

--- a/spec/support/pages/admin_dashboard_page.rb
+++ b/spec/support/pages/admin_dashboard_page.rb
@@ -1,6 +1,10 @@
 class AdminDashboardPage < Page
+  def self.path
+    "/admin"
+  end
+
   def self.visit
-    page.visit "/admin"
+    page.visit path
     new
   end
 


### PR DESCRIPTION
Journal admin card https://www.pivotaltracker.com/story/show/67437644 was rejected because it was still possible to visit /admin by typing in the url. This commit introduces authorization on /admin and all routes under it.
