### PR TITLE
Cancel affiliation creation

### DIFF
--- a/app/assets/javascripts/controllers/profile_controller.js.coffee
+++ b/app/assets/javascripts/controllers/profile_controller.js.coffee
@@ -5,6 +5,7 @@ ETahi.ProfileController = Ember.ObjectController.extend
 
   actions:
     toggleAffiliationForm: ->
+      @set('newAffiliation', {})
       @set('hideAffiliationForm', !@hideAffiliationForm)
 
     removeAffiliation: (affiliation) ->

--- a/app/assets/javascripts/templates/user/affiliation_form.hbs
+++ b/app/assets/javascripts/templates/user/affiliation_form.hbs
@@ -13,6 +13,7 @@
   placeholder='Email Address'
   class='affiliation-field form-control'}}
 </div>
+<a class="btn-link author-cancel" {{action 'toggleAffiliationForm'}}>cancel</a>
 <div class="form-group">
   <button class="secondary-button" {{action 'createAffiliation'}}>done</button>
 </div>

--- a/app/assets/javascripts/templates/user/profile.hbs
+++ b/app/assets/javascripts/templates/user/profile.hbs
@@ -28,7 +28,7 @@
             <div>{{a.email}}</div>
           </div>
         {{/each}}
-        <a class="btn btn-default btn-xs btn-affiliation" {{action 'toggleAffiliationForm'}}>
+        <a class="btn btn-default btn-xs" {{action 'toggleAffiliationForm'}}>
           <span class="glyphicon glyphicon-plus-sign"></span>
           Add new
         </a>

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -54,7 +54,7 @@ feature "Profile Page", js: true do
   scenario "affiliation errors are handled" do
     profile_page = ProfilePage.visit
     profile_page.add_affiliate(' ')
-    expect(page).to have_content /name can't be blank/i
+    expect(page).to have_content(/name can't be blank/i)
   end
 
   scenario "user can delete an affiliation" do
@@ -64,4 +64,20 @@ feature "Profile Page", js: true do
     expect(page).to_not have_content(/Yoda University/)
   end
 
+  describe "canceling affiliation creation" do
+    let(:uni) { 'Yoda University' }
+    before do
+      ProfilePage.visit.set_affiliate(uni)
+      find('a', text: 'cancel').click
+    end
+
+    it "hides the form" do
+      expect(page).to_not have_content(/new affiliation/i)
+    end
+
+    it "clears the form" do
+      find('a', text: 'Add new').click
+      expect(page).to_not have_content(uni)
+    end
+  end
 end

--- a/spec/support/pages/profile_page.rb
+++ b/spec/support/pages/profile_page.rb
@@ -13,10 +13,14 @@ class ProfilePage < Page
     all('#profile-email h4').last.text
   end
 
-  def add_affiliate(name)
-    find('#profile-affiliations').find(".btn-affiliation").click
+  def set_affiliate name
+    find('a', text: 'Add new').click
     fill_in("Affiliation Name", with: name)
-    find_button("done").click
+  end
+
+  def add_affiliate(name)
+    set_affiliate name
+    click_button "done"
   end
 
   def remove_affiliate(name)


### PR DESCRIPTION
Add a cancel button on the profile page to close and clear the affiliation form.
