### PR TITLE
Reduce card title rollovers

### DIFF
--- a/app/assets/stylesheets/ui/cards.css.scss
+++ b/app/assets/stylesheets/ui/cards.css.scss
@@ -57,7 +57,7 @@
   position: relative;
   display: block;
   border-radius: 5px;
-  padding: 10px 15px;
+  padding: 10px 10px;
   color: $tahi-primary-hover;
   font-size: 20px;
   word-wrap: break-word;


### PR DESCRIPTION
Keep task card from rolling over onto two lines by slightly reducing padding.

[refs #72518282]

![tahi 2014-06-03 11-33-17 2014-06-03 11-33-44](https://cloud.githubusercontent.com/assets/18446/3162352/74ff1d1e-eb34-11e3-8286-4cffe62cdec3.jpg)

![tahi 2014-06-03 11-30-54 2014-06-03 11-32-42](https://cloud.githubusercontent.com/assets/18446/3162336/4e28e224-eb34-11e3-8e62-88ff5f57a037.jpg)
