### PR TITLE
Fix typo on supporting information card.

### DIFF
--- a/app/assets/javascripts/templates/components/figure-thumbnail.hbs
+++ b/app/assets/javascripts/templates/components/figure-thumbnail.hbs
@@ -37,7 +37,7 @@
     {{content-editable tagName="div"
                        class="figure-thumbnail-caption _empty"
                        value=figure.caption
-                       placeholder='There is no caption for this image.'
+                       placeholder='There is no caption for this file.'
                        plaintext="true"
                        preventEnterKey="true"}}
   </div>


### PR DESCRIPTION
Change 'image' to 'file' on supporting information card.
https://www.pivotaltracker.com/story/show/72118812
[finishes #72118812]
