### PR TITLE
Disable further author editing on inevitable form.

### DIFF
--- a/app/assets/javascripts/components/author_view_component.js.coffee
+++ b/app/assets/javascripts/components/author_view_component.js.coffee
@@ -1,7 +1,7 @@
 ETahi.AuthorViewComponent = Ember.Component.extend DragNDrop.Dragable,
   tagName: 'li'
   showEditAuthorForm: false
-  classNameBindings: ['showEditAuthorForm::edit-inactive']
+  classNameBindings: ['showEditAuthorForm::edit-inactive', 'isEditable:editable']
 
   attachHover: ( ->
     toggleHoverClass = (e) ->

--- a/app/assets/javascripts/templates/author_group.hbs
+++ b/app/assets/javascripts/templates/author_group.hbs
@@ -3,6 +3,7 @@
   {{view ETahi.AuthorGroupDropTargetView group=group index=0}}
   {{#each author in sortedAuthors}}
     {{author-view
+      isEditable=isEditable
       institutions=institutions
       delete='removeAuthor'
       save='saveAuthor'

--- a/app/assets/javascripts/templates/overlays/authors_overlay.hbs
+++ b/app/assets/javascripts/templates/overlays/authors_overlay.hbs
@@ -6,9 +6,11 @@
     {{render 'author_group' group}}
   {{/each}}
 </ul>
-<div class="add-remove-groups">
-  <button class="secondary-button remove-group glyphicon glyphicon-minus" {{action 'removeAuthorGroup'}}>
-  </button>
-  <button class="secondary-button add-group glyphicon glyphicon-plus" {{action 'addAuthorGroup'}}>
-  </button>
-</div>
+{{#if isEditable}}
+  <div class="add-remove-groups">
+    <button class="secondary-button remove-group glyphicon glyphicon-minus" {{action 'removeAuthorGroup'}}>
+    </button>
+    <button class="secondary-button add-group glyphicon glyphicon-plus" {{action 'addAuthorGroup'}}>
+    </button>
+  </div>
+{{/if}}

--- a/app/assets/javascripts/views/author_group_drop_target_view.js.coffee
+++ b/app/assets/javascripts/views/author_group_drop_target_view.js.coffee
@@ -1,8 +1,10 @@
 ETahi.AuthorGroupDropTargetView = Ember.View.extend DragNDrop.Droppable,
   tagName: 'div'
-  classNames: ['author-drop-target']
+  classNameBindings: [':author-drop-target', 'isEditable::hidden']
 
   authorGroup: Ember.computed.alias('controller.model')
+  isEditable: Ember.computed.alias('controller.isEditable')
+
   position: ( ->
     @get('index') + 1
   ).property('index')

--- a/app/assets/stylesheets/overlays/authors_overlay.css.scss
+++ b/app/assets/stylesheets/overlays/authors_overlay.css.scss
@@ -47,7 +47,7 @@
       }
     }
 
-    &.edit-inactive.hover {
+    &.edit-inactive.editable.hover {
       background: $tahi-primary;
       opacity: 0.7;
       .author-edit {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/72476250
When the authors card isn't editable users can't
- add or remove author groups
- edit authors or delete authors
  [finishes #72476250]
