### PR TITLE
Set figure preview max width to 420 px.

### DIFF
--- a/app/assets/stylesheets/overlays/figures_overlay.css.scss
+++ b/app/assets/stylesheets/overlays/figures_overlay.css.scss
@@ -51,6 +51,7 @@
   .preview {
     margin: auto;
     max-height: 200px;
+    max-width: 420px;
     cursor: pointer;
     display: block;
   }


### PR DESCRIPTION
Wide figures overflow and cover the caption, etc.
https://www.pivotaltracker.com/story/show/72737386
[Finishes #72737386]

before ![image](https://cloud.githubusercontent.com/assets/18446/3218866/7684725a-efef-11e3-9f28-98e9e93e3c42.png)

after
![image](https://cloud.githubusercontent.com/assets/18446/3218871/8414c53c-efef-11e3-882c-3bab1ec8ff49.png)
