### PR TITLE
Change “Supporting Information” -> “Supporting Info”

### DIFF
--- a/engines/supporting_information/app/models/supporting_information/task.rb
+++ b/engines/supporting_information/app/models/supporting_information/task.rb
@@ -1,6 +1,6 @@
 module SupportingInformation
   class Task < ::Task
-    title "Supporting Information"
+    title "Supporting Info"
     role "author"
 
     def file_access_details

--- a/engines/supporting_information/spec/models/supporting_information/task_spec.rb
+++ b/engines/supporting_information/spec/models/supporting_information/task_spec.rb
@@ -4,7 +4,7 @@ module SupportingInformation
   describe Task do
     describe "defaults" do
       subject(:task) { SupportingInformation::Task.new }
-      specify { expect(task.title).to eq 'Supporting Information' }
+      specify { expect(task.title).to eq 'Supporting Info' }
       specify { expect(task.role).to eq 'author' }
     end
 

--- a/lib/tasks/task_migrations.rake
+++ b/lib/tasks/task_migrations.rake
@@ -20,4 +20,8 @@ namespace :data do
     end
   end
 
+  task :shorten_supporting_information do
+    Task.where(title: "Supporting Information").update_all(title: "Supporting Info")
+  end
+
 end


### PR DESCRIPTION
Shorten title so that it stays on one line.  Add rake task to change existing Supporting Information titles  -> Supporting Info

[refs #72518282]
