### PR TITLE
Fake s3 for direct upload during tests.

### DIFF
--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -15,7 +15,7 @@ class DirectUploadsController < ApplicationController
   private
 
   def url
-    "http://#{ENV['S3_BUCKET']}.s3.amazonaws.com"
+    ENV['S3_URL']
   end
 
   def request_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,10 @@ Tahi::Application.routes.draw do
 
   if Rails.env.test?
     require_relative '../spec/support/stream_server/stream_server'
+    require_relative '../spec/support/upload_server/upload_server'
     get '/stream' => StreamServer
     post '/update_stream' => StreamServer
+    mount UploadServer, at: '/fake_s3/'
   end
 
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks", registrations: "registrations" }

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -20,14 +20,6 @@ feature "Profile Page", js: true do
     expect(current_path).to eq new_user_session_path
   end
 
-  scenario "user cannot upload an avatar image of unsupported type" do
-    profile_page = ProfilePage.visit
-    profile_page.attach_image('about_turtles.docx')
-    expect(profile_page).to have_application_error
-    expect(profile_page.image).to_not eq('about_turtles.docx')
-    expect(profile_page.image).to eq('profile-no-image.png')
-  end
-
   scenario "user can add an affiliation" do
     profile_page = ProfilePage.visit
     profile_page.add_affiliate('Yoda University')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,13 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # NOTE: This will stop working after we move the engines into their own repository.
 Dir[Rails.root.join("engines/**/spec/support/**/*.rb")].each { |f| require f }
 
+Capybara.server_port = 31337
+
 # StreamServer needs to have the same URL as localhost for testing.
-ENV['ES_URL'] = "http://localhost:#{Capybara.server_port = 31337}"
+ENV['ES_URL'] = "http://localhost:#{Capybara.server_port}"
+
+# Fake out the s3 upload url for testing
+ENV['S3_URL'] = "http://localhost:#{Capybara.server_port}/fake_s3"
 
 Capybara.server do |app, port|
   require 'rack/handler/thin'

--- a/spec/support/upload_server/upload_server.rb
+++ b/spec/support/upload_server/upload_server.rb
@@ -21,20 +21,11 @@ class UploadServer < Sinatra::Base
   options '/' do
   end
 
-  get '/fake_file' do
-    file_response
-  end
-
   private
 
   def xml_response
     content_type 'text/xml'
     '<PostResponse><Location>http://localhost:31337/fake_s3/fake_file</Location></PostResponse>'
-  end
-
-  def file_response
-    file = File.open(File.join(settings.root, 'public', 'yeti.tiff'))
-    send_file file
   end
 
   run! if app_file == $0


### PR DESCRIPTION
The browser was hitting s3 to do file uploads.  We removed a sad-path
test for uploading avatar profiles; since we're stubbing the upload
the test isn't doing anything.
