### PR TITLE
replace edit route with index if paper has been submitted

### DIFF
--- a/app/assets/javascripts/routes/paper_edit_route.js.coffee
+++ b/app/assets/javascripts/routes/paper_edit_route.js.coffee
@@ -11,7 +11,7 @@ ETahi.PaperEditRoute = ETahi.AuthorizedRoute.extend
       paper.get('tasks').then((tasks) -> resolve(paper)))
 
   afterModel: (model) ->
-    @transitionTo('paper.index', model) if model.get('submitted')
+    @replaceWith('paper.index', model) if model.get('submitted')
 
   setupController: (controller, model) ->
     controller.set('model', model)


### PR DESCRIPTION
[Fixes #73419388]

https://www.pivotaltracker.com/story/show/7341938

Makes the back button useful again. 
