### PR TITLE
Don’t allow deletion of cards from flow manager

### DIFF
--- a/app/assets/javascripts/templates/flow_paper.hbs
+++ b/app/assets/javascripts/templates/flow_paper.hbs
@@ -8,12 +8,6 @@
           <div class="glyphicon glyphicon-ok completed-glyph"></div>
           <div class="task-title">{{task.title}}</div>
         </div>
-        <span {{action 'removeTask'}}
-          class="glyphicon glyphicon-remove-circle remove-card"
-          data-toggle="tooltip"
-          data-placement="right"
-          title="Delete Card">
-        </span>
       </div>
     {{/each}}
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/73073406

We missed the fact that the flow manager uses a different card view that still allows deletion of cards. This PR fixes it.
