### PR TITLE
Add .truncated-field utility class and apply.

### DIFF
--- a/app/assets/javascripts/templates/user/profile.hbs
+++ b/app/assets/javascripts/templates/user/profile.hbs
@@ -7,12 +7,12 @@
     <div class="col-md-10">
       <div id="profile-name">
         <h4 class="secondary"><small>First and last name:</small></h4>
-        <h1>{{model.fullName}}</h1>
+        <h1 class="truncated-field">{{model.fullName}}</h1>
       </div>
 
       <div id="profile-username">
         <h4 class="secondary"><small>Username:</small></h4>
-        <h2>{{model.username}}</h2>
+        <h2 class="truncated-field">{{model.username}}</h2>
       </div>
       <div id="profile-email">
         <h4 class="secondary"><small>Email:</small></h4>

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -32,3 +32,9 @@
     margin-top: 65px;
   }
 }
+
+%truncates {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/app/assets/stylesheets/screens/profile.css.scss
+++ b/app/assets/stylesheets/screens/profile.css.scss
@@ -65,3 +65,7 @@
     margin: 15px 0;
   }
 }
+
+.truncated-field {
+  @extend %truncates;
+}


### PR DESCRIPTION
## CW & CT
- We now have a `%truncates` scss mixin and a `.truncated-field` that you can use to cut off long text.
  [Fixes #73070742]

![screen shot 2014-07-02 at 9 46 03 am](https://cloud.githubusercontent.com/assets/5796310/3456585/3fc8f818-01f0-11e4-840a-0132ac56350a.png)
