### PR TITLE
Use actual email regex for Devise.email_regexp

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ActiveRecord::Base
   after_create :add_flows
 
   validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
-  validates :email, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :email, format: Devise.email_regexp
 
   mount_uploader :avatar, AvatarUploader
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -143,7 +143,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@]+@[^@]+\z/
+  config.email_regexp = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
Prevent ludicrous emails from going through.
[Fixes #73069654]

![image](https://cloud.githubusercontent.com/assets/5796310/3456982/39fe92f4-01f4-11e4-8c52-bb91a69b681b.png)
