### PR TITLE
Make sure to schedule column resizes after render, and then only once.

### DIFF
--- a/app/assets/javascripts/utils.js.coffee
+++ b/app/assets/javascripts/utils.js.coffee
@@ -12,16 +12,16 @@ Tahi.utils =
       @resizeColumnHeaders()
 
   resizeColumnHeaders: ->
-    $children = $('.columns .column-header')
-    return unless $children.length
+    $headers = $('.columns .column-header')
+    return unless $headers.length
 
-    $children.css('height', '')
-    heights = $children.find('h2').map ->
+    $headers.css('height', '')
+    heights = $headers.find('h2').map ->
       $(this).outerHeight()
 
     max = Math.max.apply(Math, heights)
 
-    $children.css('height', max)
+    $headers.css('height', max)
     $('.column-content').css('top', max)
 
   togglePropertyAfterDelay: (obj, prop, startVal, endVal, ms) ->

--- a/app/assets/javascripts/views/flow_manager_view.js.coffee
+++ b/app/assets/javascripts/views/flow_manager_view.js.coffee
@@ -1,5 +1,4 @@
 ETahi.FlowManagerView = Ember.View.extend
   columnCountDidChange: (->
-    Em.run.next ->
-      Tahi.utils.resizeColumnHeaders()
+    Ember.run.scheduleOnce('afterRender', this, Tahi.utils.resizeColumnHeaders)
   ).on('didInsertElement').observes('controller.model.@each')

--- a/app/assets/javascripts/views/paper_manage_view.js.coffee
+++ b/app/assets/javascripts/views/paper_manage_view.js.coffee
@@ -1,4 +1,4 @@
 ETahi.PaperManageView = Ember.View.extend
   setupColumnHeights:(->
-    Tahi.utils.resizeColumnHeaders()
+    Ember.run.scheduleOnce('afterRender', this, Tahi.utils.resizeColumnHeaders)
   ).on('didInsertElement').observes('controller.phases.@each')

--- a/app/assets/javascripts/views/phase_header_view.js.coffee
+++ b/app/assets/javascripts/views/phase_header_view.js.coffee
@@ -11,12 +11,10 @@ ETahi.PhaseHeaderView = Em.View.extend
       @set('oldPhaseName', @get('phase.name'))
 
   phaseNameDidChange: (->
-    Ember.run.schedule('afterRender' , this, ->
-      Tahi.utils.resizeColumnHeaders()
-    )
+    Ember.run.scheduleOnce('afterRender', this, Tahi.utils.resizeColumnHeaders)
   ).observes('phase.name')
 
-  currentHeaderHeight: Em.computed 'phase.name', -> $(@get 'element').find('.column-title').height()
+  currentHeaderHeight: Em.computed 'phase.name', -> @$().find('.column-title').height()
 
   input: (e) ->
     if @get('currentHeaderHeight') <= 58


### PR DESCRIPTION
[Fixes #74405330]

Dragging an Assign editor task from phase to phase was breaking the header resize. 

`Tahi.utils.resizeColumnHeaders` wasn't being scheduled on the afterRender queue and it was wreaking havoc on column height calculations.  We also used `scheduleOnce` instead of `schedule` to try to coalesce the calls as much as possible.  **--CW & JN**
