### PR TITLE
[Fixes #74409550] Close overlays on esc

### DIFF
--- a/app/assets/javascripts/routes/application_route.js.coffee
+++ b/app/assets/javascripts/routes/application_route.js.coffee
@@ -55,3 +55,6 @@ ETahi.ApplicationRoute = Ember.Route.extend ETahi.AnimateElement,
         @disconnectOutlet
           outlet: 'overlay'
           parentView: 'application'
+
+    closeAction: ->
+      @send('closeOverlay')


### PR DESCRIPTION
### CW & CT
- Add app level handler for closeAction that closes the overlay
