### PR TITLE
Fix word wrapping in IE

### DIFF
--- a/app/assets/stylesheets/screens/flow_manager.css.scss
+++ b/app/assets/stylesheets/screens/flow_manager.css.scss
@@ -14,7 +14,7 @@
   margin: 10px;
   color: black;
   font-family: $tahi-article-font-family;
-  word-break: break-word;
+  word-wrap: break-word;
   font-size: 14px;
   line-height: 17px;
 }


### PR DESCRIPTION
IE doesn’t like “break-word” as a value for the word-break property. It likes “break-all”, but that isn’t the behavior we want. word-wrap is supported, and does what we want.

[Fixes #74995670]
#### -- AC & CT

before:
![before](https://cloud.githubusercontent.com/assets/5796310/3615645/baec3902-0dca-11e4-9f3d-96f591bff1d2.png)

after:
![after](https://cloud.githubusercontent.com/assets/5796310/3615644/baeb74ea-0dca-11e4-9b7a-691879e8d57f.png)
