### PR TITLE
Save on “Stop editing”

### DIFF
--- a/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
+++ b/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
@@ -1,5 +1,11 @@
 #= require controllers/paper_controller
 ETahi.PaperEditController = ETahi.PaperController.extend
+  visualEditor: null
+
+  setupVisualEditor: (->
+    @set('visualEditor', ETahi.VisualEditorService.create())
+  ).on("init")
+
   errorText: ""
 
   addAuthorsTask: (->
@@ -47,6 +53,7 @@ ETahi.PaperEditController = ETahi.PaperController.extend
   actions:
     toggleEditing: ->
       if @get('lockedBy')
+        @set('body', @get('visualEditor.bodyHtml'))
         @set('lockedBy', null)
       else
         @set('lockedBy', @getCurrentUser())
@@ -62,8 +69,8 @@ ETahi.PaperEditController = ETahi.PaperController.extend
           saveState: "Saved"
           savedAt: new Date()
 
-    updateDocumentBody: (documentBody) ->
-      @set('body', documentBody)
+    updateDocumentBody: (content) ->
+      @set('body', content)
       false
 
     confirmSubmitPaper: ->

--- a/app/assets/javascripts/services/visual_editor_service.js.coffee
+++ b/app/assets/javascripts/services/visual_editor_service.js.coffee
@@ -1,0 +1,27 @@
+ETahi.VisualEditorService = Em.Object.extend
+  init: ->
+    ve.init.platform.setModulesUrl('/visual-editor/modules')
+
+  update: ($parent, content) ->
+    container = $('<div>')
+    $parent.html('').append(container)
+    ve.debug = false # it's true by default, which adds a gray background
+                     # on initialize and update
+    target = new ve.init.sa.Target(
+      container,
+      ve.createDocumentFromHtml(content || '')
+    )
+    target.on('surfaceReady', ->
+      target.toolbar.disableFloatable()
+    )
+    @set('target', target)
+
+  bodyHtml: (->
+    surf = @get('target').surface
+    documentNode = ve.dm.converter.getDomFromModel(surf.getModel().getDocument())
+    $(documentNode).find('body').html()
+  ).property().volatile()
+
+  isEmpty: (->
+    Ember.isBlank Ember.$(@get('bodyHtml')).text()
+  ).property().volatile()


### PR DESCRIPTION
Makes the visual editor a service that is available to both the view and the controller, so that changes can be synced before saving.

[Fixes #75198670]
#### AC & CT

Ignore the "WIP" in the commit heading, this is ready for review.
