### PR TITLE
Scrub all existing user passwords when importing.

### DIFF
--- a/lib/tasks/database_import.rake
+++ b/lib/tasks/database_import.rake
@@ -6,6 +6,7 @@ namespace :db do
         target_db_name = ActiveRecord::Base.connection.current_database
         system("curl -o #{f.path} `heroku pgbackups:url --app tahi-staging`")
         system("pg_restore --clean --no-acl --no-owner -h localhost -d #{target_db_name} #{f.path}")
+        User.all.each { |u| u.password = "password"; u.save }
       end
     end
   end


### PR DESCRIPTION
Automatically change everyone's password to be "password" when doing a `rake db:import`.

Remember that password is non-activerecord attribute, so this can't be done with an update_all.
#### AC
