### PR TITLE
Authorize manuscript_manager during route transition

### DIFF
--- a/app/assets/javascripts/routes/paper_manage_route.js.coffee
+++ b/app/assets/javascripts/routes/paper_manage_route.js.coffee
@@ -1,4 +1,13 @@
-ETahi.PaperManageRoute = Ember.Route.extend
+ETahi.PaperManageRoute = ETahi.AuthorizedRoute.extend
+  afterModel: (paper, transition) ->
+    # Ping manuscript_manager url for authorization
+    promise = new Ember.RSVP.Promise (resolve, reject) ->
+      Ember.$.ajax
+        method:  'GET'
+        url:     "/papers/#{paper.get('id')}/manuscript_manager"
+        success: (json) -> Ember.run(null, resolve, json)
+        error:   (xhr, status, error) -> Ember.run(null, reject, xhr)
+
   actions:
     viewCard: (task) ->
       paper = @modelFor('paper')


### PR DESCRIPTION
Protect manuscript manager against url hacking. Will redirect to dashboard if current user isn't authorized to view the manuscript manager

https://www.pivotaltracker.com/story/show/75451406
