### PR TITLE
update code that had `submitted_papers` and `assigned_papers` unioning.

### DIFF
--- a/app/controllers/lite_papers_controller.rb
+++ b/app/controllers/lite_papers_controller.rb
@@ -14,6 +14,6 @@ class LitePapersController < ApplicationController
   end
 
   def paper_ids
-    current_user.submitted_papers.pluck(:id) | current_user.assigned_papers.pluck(:id)
+    current_user.assigned_papers.pluck :id
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ActiveRecord::Base
       Paper.all.pluck(:id)
     else
       admin_papers = Paper.where(journal: journals.merge(Role.can_view_all_manuscript_managers))
-      submitted_papers.pluck(:id) | assigned_papers.pluck(:id) | admin_papers.pluck(:id)
+      assigned_papers.pluck(:id) | admin_papers.pluck(:id)
     end
   end
 

--- a/app/serializers/dashboard_serializer.rb
+++ b/app/serializers/dashboard_serializer.rb
@@ -49,6 +49,6 @@ class DashboardSerializer < ActiveModel::Serializer
   private
 
   def total_paper_ids
-    @ids ||= user.submitted_papers.pluck(:id) | user.assigned_papers.pluck(:id)
+    @ids ||= user.assigned_papers.pluck :id
   end
 end

--- a/spec/factories/paper_factory.rb
+++ b/spec/factories/paper_factory.rb
@@ -20,6 +20,10 @@ FactoryGirl.define do
       paper.build_default_author_groups
     end
 
+    after(:create) do |paper|
+      paper.paper_roles.create!(user: paper.user, role: PaperRole::COLLABORATOR)
+    end
+
     trait(:with_tasks) do
       after(:create) do |paper|
         PaperFactory.new(paper, paper.user).apply_template

--- a/spec/features/add_collaborators_spec.rb
+++ b/spec/features/add_collaborators_spec.rb
@@ -30,7 +30,7 @@ feature "Editing paper", js: true do
     edit_paper = EditPaperPage.visit paper
     collaborators_overlay = edit_paper.show_collaborators
     expect(collaborators_overlay).to have_collaborators(collaborating_user)
-    collaborators_overlay.remove_collaborators(collaborating_user)
+    collaborators_overlay.remove_collaborators(collaborating_user, author)
     collaborators_overlay.save
     expect(edit_paper).to have_no_application_error
     sleep 0.2 #we can't figure out why clicking the link too quickly doesn't work.

--- a/spec/serializers/dashboard_serializer_spec.rb
+++ b/spec/serializers/dashboard_serializer_spec.rb
@@ -12,7 +12,7 @@ describe DashboardSerializer do
       submitted_paper = FactoryGirl.create(:paper, user: user)
       serialized_paper = first_serialized_paper(submitted_paper)
 
-      expect(serialized_paper.role_descriptions).to match_array ['My Paper']
+      expect(serialized_paper.role_descriptions).to match_array ['Collaborator', 'My Paper']
     end
 
     it "Should add role descriptions for papers the user associated to by paper_roles" do
@@ -28,7 +28,7 @@ describe DashboardSerializer do
       create(:paper_role, :reviewer, paper: associated_paper, user: user)
       serialized_paper = first_serialized_paper(associated_paper)
 
-      expect(serialized_paper.role_descriptions).to match_array ['Reviewer', 'My Paper']
+      expect(serialized_paper.role_descriptions).to match_array ['Collaborator', 'Reviewer', 'My Paper']
     end
 
     def first_serialized_paper(paper)


### PR DESCRIPTION
Only `assigned_papers` should be there now.
@jxa + @Bestra + @ryanstocker would you guys mind double checking to see this works? this is to address john's comment on the dashboard upload more feature PR.
