### PR TITLE
Add ability to remove a funder from Financial Disclosure

### DIFF
--- a/engines/standard_tasks/app/assets/javascripts/standard_tasks/controllers/funder_controller.js.coffee
+++ b/engines/standard_tasks/app/assets/javascripts/standard_tasks/controllers/funder_controller.js.coffee
@@ -29,3 +29,6 @@ ETahi.FunderController = Ember.ObjectController.extend ETahi.SavesDelayed,
     cancelAddingAuthor: ->
       @get('addingAuthor').deleteRecord()
       @set('addingAuthor', null)
+
+    removeFunder: ->
+      @get('model').destroyRecord()

--- a/engines/standard_tasks/app/assets/javascripts/standard_tasks/templates/funder.hbs
+++ b/engines/standard_tasks/app/assets/javascripts/standard_tasks/templates/funder.hbs
@@ -1,4 +1,5 @@
 <div class="dataset">
+  <a href="#" {{action "removeFunder"}} class="pull-right remove-funder-link">remove</a>
   {{input type="text" name="name" value=funder.name class="form-control" placeholder="Funder"}}
   {{input type="text" name="grant_number" value=funder.grantNumber class="form-control" placeholder="Grant Number"}}
   {{input type="text" name="website" value=funder.website class="form-control" placeholder="Website"}}

--- a/engines/standard_tasks/app/assets/stylesheets/standard_tasks/financial_disclosure.css.scss
+++ b/engines/standard_tasks/app/assets/stylesheets/standard_tasks/financial_disclosure.css.scss
@@ -5,3 +5,7 @@
 .add-new-funded-author {
   margin: 10px 0;
 }
+
+.remove-funder-link {
+  margin: -20px 0 10px 0;
+}

--- a/engines/standard_tasks/spec/features/financial_disclosure_task_spec.rb
+++ b/engines/standard_tasks/spec/features/financial_disclosure_task_spec.rb
@@ -4,9 +4,9 @@ feature "Financial Disclosures", js: true do
   let(:author) { FactoryGirl.create :user }
   let(:journal) { FactoryGirl.create :journal }
   let(:paper) { FactoryGirl.create :paper, :with_tasks, user: author, journal: journal }
+  let!(:task) { paper.phases.last.tasks.create!(type: "StandardTasks::FinancialDisclosureTask", assignee_id: author.id) }
 
   before do
-    paper.phases.last.tasks.create!(type: "StandardTasks::FinancialDisclosureTask", assignee_id: author.id)
     sign_in_page = SignInPage.visit
     sign_in_page.sign_in author
   end
@@ -29,6 +29,19 @@ feature "Financial Disclosures", js: true do
       overlay.received_funding.click
       overlay.add_author("Oscar", "Grouch")
       expect(overlay.selected_authors).to include("Oscar Grouch")
+    end
+  end
+
+  scenario "removing a funder" do
+    funder = task.funders.create!(name: "Monsanto")
+
+    edit_paper = EditPaperPage.visit paper
+    edit_paper.view_card 'Financial Disclosure' do |overlay|
+      overlay.received_funding.click
+      expect(overlay.received_funding).to be_checked
+      overlay.remove_funder
+      expect(overlay.received_no_funding).to be_checked
+      expect { StandardTasks::Funder.find(funder.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/engines/standard_tasks/spec/support/pages/overlays/financial_disclosure.rb
+++ b/engines/standard_tasks/spec/support/pages/overlays/financial_disclosure.rb
@@ -11,6 +11,10 @@ class FinancialDisclosureOverlay < CardOverlay
     find('.dataset')
   end
 
+  def remove_funder
+    dataset.click_link "remove"
+  end
+
   def add_author(first_name, last_name)
     click_button "Add Author"
     fill_in "first-name", with: first_name


### PR DESCRIPTION
Put a "remove" link in the top right corner of the funder box. It's possible to remove the last funder.
When the last funder is removed, change the answer of "Did any of the authors receive specific funding for this work?" to "No."

https://www.pivotaltracker.com/story/show/74081018
