### PR TITLE
add `has_many collaborations` into `PaperEventStreamSerializer`

### DIFF
--- a/app/serializers/paper_event_stream_serializer.rb
+++ b/app/serializers/paper_event_stream_serializer.rb
@@ -11,9 +11,15 @@ class PaperEventStreamSerializer < ActiveModel::Serializer
   end
 
   has_many :tasks, embed: :ids, polymorphic: true
+  has_many :collaborations, embed: :ids, include: true, serializer: CollaborationSerializer
   has_one :journal, embed: :ids, include: false
   has_one :locked_by, embed: :id, include: true, root: :users
   has_one :striking_image, embed: :id, include: true, root: :figures
+
+  def collaborations
+    # we want the actual join record, not a list of users
+    object.paper_roles.collaborators
+  end
 
   def status
     object.manuscript.try(:status)


### PR DESCRIPTION
## Bug

When user clicks on start writing on paper.edit page, the collaborators on the side panel all go away.
## Cause

Event stream sends down a stripped down version of `PaperSerializer` that does not include `collaborations`. Within the `#updated` method in the event stream service in Ember, [we do a wholesale](https://github.com/Tahi-project/tahi/blob/master/app/assets/javascripts/services/event_stream.js.coffee#L53) `#pushPayload`, which blasts away the existing paper model with whatever is contained within the `PaperEventStreamSerializer`. Ideally, `store#push` or `store#update` should be used, but both of those methods need an object type as the first argument, which we don't have since there are several types of data being beamed down. 

Currently, `Paper` is the only object that has its own [event stream specific serializer](https://github.com/Tahi-project/tahi/blob/master/app/serializers/paper_event_stream_serializer.rb), which can easily start to miss necessary attributes as new ones are added to the `PaperSerializer`.
## Solution

Temporarily added `collaborations` into the `PaperEventStreamSerializer`. This can also be fixed by replacing the `PaperEventStreamSerializer` with the regular `PaperSerializer`. Long term, we should discuss on how data is sent via event stream (only send paper if a paper was updated, etc.) and change the `#updated` method to use `store#push` or `store#update` instead.

@Bestra + @jxa would you guys mind elaborating on why the paper model needs its own `EventStreamSerializer`? 
