### PR TITLE
Fix problem with slow paper update

### DIFF
--- a/app/assets/javascripts/views/paper_edit_view.js.coffee
+++ b/app/assets/javascripts/views/paper_edit_view.js.coffee
@@ -10,7 +10,13 @@ ETahi.PaperEditView = Ember.View.extend
 
   bindPlaceholderEvent: ->
     $('.editable').on "keyup", "div[contenteditable]", (e) =>
-      Ember.run.debounce(@, @updatePlaceholder, 1000)
+
+      # if we're currently showing placeholder we want it to go away
+      # when the user starts typing, without delay
+      if @get('controller.showPlaceholder')
+        @updatePlaceholder()
+      else
+        Ember.run.debounce(@, @updatePlaceholder, 1000)
 
   updatePlaceholder: ->
     @set('controller.showPlaceholder', @get('visualEditor.isEmpty'))


### PR DESCRIPTION
Placeholder text doesn't need to delay typing. Only update the placeholder after 1 second of inactivity.

https://www.pivotaltracker.com/story/show/75072874
