### PR TITLE
Move inline edit h1 into component

### DIFF
--- a/app/assets/javascripts/components/inline_edit_h1.js.coffee
+++ b/app/assets/javascripts/components/inline_edit_h1.js.coffee
@@ -1,0 +1,17 @@
+ETahi.InlineEditH1Component = Em.Component.extend
+  editing: false
+
+  focusOnEdit: (->
+    if @get('editing')
+      Em.run.schedule 'afterRender', @, ->
+        @$('input[type=text]').focus()
+  ).observes('editing')
+
+  actions:
+    toggleEdit: ->
+      @get('model').rollback()
+      @toggleProperty 'editing'
+
+    save: ->
+      @get('model').save()
+      @toggleProperty 'editing'

--- a/app/assets/javascripts/controllers/overlays/ad_hoc_overlay_controller.js.coffee
+++ b/app/assets/javascripts/controllers/overlays/ad_hoc_overlay_controller.js.coffee
@@ -1,13 +1,1 @@
-ETahi.AdHocOverlayController = ETahi.TaskController.extend
-  editTitle: false
-
-  actions:
-    toggleEditTitle: ->
-      @get('model').rollback()
-      @toggleProperty('editTitle')
-      return null
-
-    save: ->
-      @get('model').save().then =>
-        @send('toggleEditTitle')
-
+ETahi.AdHocOverlayController = ETahi.TaskController.extend()

--- a/app/assets/javascripts/templates/components/inline-edit-h1.hbs
+++ b/app/assets/javascripts/templates/components/inline-edit-h1.hbs
@@ -1,0 +1,10 @@
+<h1 {{bind-attr class=":inline-edit-h1 editing"}}>
+  {{title}}
+  <span class="glyphicon glyphicon-pencil inline-edit-h1-icon" {{action "toggleEdit"}}></span>
+</h1>
+
+<div {{bind-attr class=":inline-edit-h1-form editing"}}>
+  {{input type="text" name="title" value=title action="save"}}
+  <div class="button-secondary button--green pull-right" {{action "save"}}>Save</div>
+  <div class="button-link button--green pull-right" {{action "toggleEdit"}}>cancel</div>
+</div>

--- a/app/assets/javascripts/templates/overlays/ad_hoc_overlay.hbs
+++ b/app/assets/javascripts/templates/overlays/ad_hoc_overlay.hbs
@@ -1,14 +1,2 @@
-{{#if editTitle}}
-  <div class="inline-edit-h1">
-    {{input type="text" name="title" value=title}}
-    <input type="submit" class="button-secondary button--green pull-right" value="Save" {{action "save"}}>
-    <input type="submit" class="button-link button--green pull-right" value="cancel" {{action "toggleEditTitle"}}>
-  </div>
-{{else}}
-  <h1>
-    {{title}}
-    <span class="glyphicon glyphicon-pencil edit-h1-icon"  {{action "toggleEditTitle"}}></span>
-  </h1>
-{{/if}}
-
+{{inline-edit-h1 title=title model=model}}
 <p>{{body}}</p>

--- a/app/assets/stylesheets/ui/inline-edit-h1.css.scss
+++ b/app/assets/stylesheets/ui/inline-edit-h1.css.scss
@@ -1,32 +1,41 @@
-h1 > .edit-h1-icon {
+.inline-edit-h1-icon {
   display: inline;
-}
-
-.edit-h1-icon {
   margin-left: 10px;
+  padding: 0.75rem;
   color: #d4d4d4;
   font-size: 16px;
   cursor: pointer;
   position: relative;
-  top: -8px;
+  top: -7px;
 
   &:hover {
     color: $tahi-primary-hover;
   }
 }
 
-.inline-edit-h1 {
-  overflow: hidden;
+.inline-edit-h1-form {
+  display: none;
   position: relative;
-  top: -14px;
-  left: -6px;
+  overflow: hidden;
   padding: 5px;
   background-color: #C3E7BF;
 
+  &.editing {
+    display: block;
+    top: -14px;
+    left: -6px;
+
+    input[type="text"] { display: block; }
+  }
+
   input[type="text"] {
+    display: none;
     width: 100%;
     margin-bottom: 4px;
     border: 0;
     font-size: 48px;
+    outline: none;
   }
 }
+
+.inline-edit-h1.editing { display: none; }

--- a/spec/support/pages/overlay.rb
+++ b/spec/support/pages/overlay.rb
@@ -15,7 +15,7 @@ class CardOverlay < Page
   end
 
   def title
-    find('main > h1').text
+    find('main h1').text
   end
 
   def body


### PR DESCRIPTION
Moved functionality into component for future reuse, ability to focus on text input on entering edit state, and ability to animate elements if needed.

Also added save on return key press.
