### PR TITLE
Change paper edit initialization to reduce jank. Maybe.

### DIFF
--- a/spec/support/pages/edit_paper_page.rb
+++ b/spec/support/pages/edit_paper_page.rb
@@ -19,7 +19,7 @@ class EditPaperPage < Page
   path :edit_paper
 
   def initialize element = nil
-    expect(page).to have_css('#paper-title')
+    expect(page).to have_css('#paper-body', wait: 4)
     super
   end
 


### PR DESCRIPTION
**CW**
Try using another element and increasing the wait time on init.
Maybe the page is taking longer than 2 seconds to come up on CI.
