### PR TITLE
Fix figure replacing.  

### DIFF
--- a/app/assets/javascripts/components/attachment_thumbnail_component.js.coffee
+++ b/app/assets/javascripts/components/attachment_thumbnail_component.js.coffee
@@ -5,6 +5,8 @@ ETahi.AttachmentThumbnailComponent = Ember.Component.extend
   editState: false
   uploadingState: false
 
+  attachmentType: 'attachment'
+
   attachmentUrl: (->
     "/figures/#{@get('attachment.id')}/update_attachment"
   ).property('attachment.id')
@@ -76,7 +78,7 @@ ETahi.AttachmentThumbnailComponent = Ember.Component.extend
 
     attachmentUploaded: (data) ->
       store = @get('attachment.store')
-      store.pushPayload 'attachment', data
+      store.pushPayload @get('attachmentType') , data
       @set('uploadingState', false)
 
     togglePreview: ->

--- a/app/assets/javascripts/components/figure_thumbnail_component.js.coffee
+++ b/app/assets/javascripts/components/figure_thumbnail_component.js.coffee
@@ -1,4 +1,6 @@
 ETahi.FigureThumbnailComponent = ETahi.AttachmentThumbnailComponent.extend
+  attachmentType: 'figure'
+
   actions:
     toggleStrikingImageFromCheckbox: (checkbox)->
       newValue = if checkbox.get('checked') then checkbox.get('attachment.id') else null


### PR DESCRIPTION
## AB & CW

[fixes #78372280]

'Attachment' is not an actual thing we can push into the store. Some of this will be changing via consistification, which we will move onto shortly. 
