### PR TITLE
remove scheduleOnce and rely on didInsertElement

### DIFF
--- a/app/assets/javascripts/views/dashboard_link_view.js.coffee
+++ b/app/assets/javascripts/views/dashboard_link_view.js.coffee
@@ -2,8 +2,7 @@ ETahi.DashboardLinkView = Em.View.extend
   templateName: 'dashboard_link'
 
   setupTooltips: (->
-    Ember.run.scheduleOnce 'afterRender', @, =>
-      @$('.link-tooltip').tooltip('destroy').tooltip({placement: 'bottom'})
+    @$('.link-tooltip').tooltip('destroy').tooltip({placement: 'bottom'})
   ).on('didInsertElement').observes('content.unreadCommentsCount')
 
   badgeTitle: (->


### PR DESCRIPTION
the function in the scheduleOnce is called after the DOM has been removed, resulting in the error here (https://www.pivotaltracker.com/story/show/78220758) - basically the element no longer exists when this is called. [RW/MM]

Everything seems to work without the run-loop/scheduleOnce.
