### PR TITLE
Add Redis to local Procfile

### DIFF
--- a/Procfile.local
+++ b/Procfile.local
@@ -1,3 +1,4 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq
 event_source: go run $GOPATH/src/github.com/tahi-project/golang-eventsource/server.go -p=8080 -token=token123
+redis: redis-server /usr/local/etc/redis.conf


### PR DESCRIPTION
The Redis command works with Redis installed via Homebrew on OS X. You'll need to kill any existing running Redis servers (ie: launched with `launchctl`).
