### PR TITLE
allow custom task card generation in custom directories

### DIFF
--- a/lib/generators/task/task_generator.rb
+++ b/lib/generators/task/task_generator.rb
@@ -1,32 +1,38 @@
 class TaskGenerator < Rails::Generators::Base
   source_root File.expand_path('../templates', __FILE__)
   argument :task_name, type: :string
-  attr_accessor :engine_name
+  attr_accessor :engine_name, :path_name
 
   def get_user_info
-    @engine_name = ask('What engine would you like to create? (To add to an existing engine, use the folder name, e.g. "standard_tasks")')
-    raise 'Please specify the folder to place your new Task within' unless @engine_name.present?
-    standalone_task_with_engine(engine_name)
+    @engine_name = ARGV.first
+    puts "You have specified an Engine name of: \"#{@engine_name}\""
+    puts "By default, your Engine will be created in the folder \"#{default_path}\""
+    @path_name = ask("Would you like to create your Engine in a different folder? If so, specify the folder name here. (defaults to #{Rails.root}/#{default_engine_dir})")
+    @path_name = @path_name.present? ? @path_name : default_engine_dir
+    create_engine_task
   end
 
   def generate_files
-    template "model.rb",            "engines/#{engine_file_name}/app/models/#{engine_file_name}/#{file_name}_task.rb"
-    template "serializer.rb",       "engines/#{engine_file_name}/app/serializers/#{engine_file_name}/#{file_name}_task_serializer.rb"
-    template "ember/model.js",      "engines/#{engine_file_name}/app/assets/javascripts/#{engine_file_name}/models/#{file_name}_task.js"
-    template "ember/view.js",       "engines/#{engine_file_name}/app/assets/javascripts/#{engine_file_name}/views/overlays/#{file_name}_overlay_view.js"
-    template "ember/controller.js", "engines/#{engine_file_name}/app/assets/javascripts/#{engine_file_name}/controllers/overlays/#{file_name}_overlay_controller.js"
-    template "ember/serializer.js", "engines/#{engine_file_name}/app/assets/javascripts/#{engine_file_name}/serializers/#{file_name}_task_serializer.js"
-    template "ember/adapter.js",    "engines/#{engine_file_name}/app/assets/javascripts/#{engine_file_name}/adapters/#{file_name}_task_adapter.js"
-    template "ember/overlay.hbs",   "engines/#{engine_file_name}/app/assets/javascripts/#{engine_file_name}/templates/overlays/#{file_name}_overlay.hbs"
+    template "model.rb",            "#{new_path}/app/models/#{engine_file_name}/#{file_name}_task.rb"
+    template "serializer.rb",       "#{new_path}/app/serializers/#{engine_file_name}/#{file_name}_task_serializer.rb"
+    template "ember/model.js",      "#{new_path}/app/assets/javascripts/#{engine_file_name}/models/#{file_name}_task.js"
+    template "ember/view.js",       "#{new_path}/app/assets/javascripts/#{engine_file_name}/views/overlays/#{file_name}_overlay_view.js"
+    template "ember/controller.js", "#{new_path}/app/assets/javascripts/#{engine_file_name}/controllers/overlays/#{file_name}_overlay_controller.js"
+    template "ember/serializer.js", "#{new_path}/app/assets/javascripts/#{engine_file_name}/serializers/#{file_name}_task_serializer.js"
+    template "ember/adapter.js",    "#{new_path}/app/assets/javascripts/#{engine_file_name}/adapters/#{file_name}_task_adapter.js"
+    template "ember/overlay.hbs",   "#{new_path}/app/assets/javascripts/#{engine_file_name}/templates/overlays/#{file_name}_overlay.hbs"
   end
 
-  def append_files
-    inject_into_file "app/services/task_services/create_task_types.rb", before: "]" do
-      "{kind: '#{engine_class_name}::#{class_name}Task', default_role: 'author', default_title: '#{class_name}'},\n"
-    end
-  end
 
   private
+
+  def default_engine_dir
+    'engines/'
+  end
+
+  def default_path
+    File.join default_engine_dir, engine_file_name
+  end
 
   def file_name
     @task_name.underscore
@@ -44,14 +50,24 @@ class TaskGenerator < Rails::Generators::Base
     @engine_name.camelize
   end
 
-  def standalone_task_with_engine(engine)
-    return if engine_exists?(engine)
-    cmd = "rails plugin new engines/#{engine} --full --mountable --skip-test-unit"
-    puts cmd
-    system cmd
+  def new_path
+    File.join(path_name, engine_file_name)
   end
 
   def engine_exists?(engine)
     File.directory?("engines/#{engine}")
+  end
+
+  def path_exists?(path)
+    File.directory?(path)
+  end
+
+  def create_engine_task
+    return if path_exists?(default_path) ||
+              path_exists?(new_path)
+
+    cmd = "rails plugin new #{new_path} --full --mountable --skip-test-unit"
+    puts cmd
+    system cmd
   end
 end


### PR DESCRIPTION
# RW

Moving away from defaulting a custom Task card into the /standard_tasks directory,
this PR will default a custom Task card engine to /engines/<name_of_card>, or take a directory from the user.

This PR also removes the modification of create_task_types.rb, so that required step is now a manual step.
