### PR TITLE
WIP Don't get back models when doing an auth check.

### DIFF
--- a/app/assets/javascripts/routes/application_route.js.coffee
+++ b/app/assets/javascripts/routes/application_route.js.coffee
@@ -3,7 +3,7 @@ ETahi.ApplicationRoute = Ember.Route.extend ETahi.AnimateElement,
     if @getCurrentUser? && @getCurrentUser()
       controller.set('canViewFlowManager', @getCurrentUser().get('admin'))
       authorize = (value) -> (result) -> controller.set('canViewAdminLinks', value)
-      @store.find('adminJournal').then(authorize(true), authorize(false))
+      Ember.$.ajax('/admin/journals/?authorization_check=true', success: authorize(true), error:authorize(false))
 
     @_super(model, controller)
 

--- a/app/controllers/admin/journals_controller.rb
+++ b/app/controllers/admin/journals_controller.rb
@@ -8,7 +8,11 @@ class Admin::JournalsController < ApplicationController
     journals = current_user.administered_journals.
       includes(:manuscript_manager_templates, {:journal_task_types => :task_type})
 
-    respond_with journals, each_serializer: AdminJournalSerializer, root: 'admin_journals'
+    if params[:authorization_check]
+      head 201
+    else
+      respond_with journals, each_serializer: AdminJournalSerializer, root: 'admin_journals'
+    end
   end
 
   def create


### PR DESCRIPTION
In general I don't think we should be calling a normal ember data route and loading models just to get a 403/200 response.  I think the next step is to pull this out of the controller and put it into a service object, but I wanted to get something into master sooner than later.   As a bonus skipping the serialization saves a few hundred milliseconds on the authorization request.  
