### PR TITLE
:raised_hands: Add support for multiple sidekiqs

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -22,3 +22,4 @@
 # S3_URL="http://localhost:${CAPYBARA_SERVER_PORT}/fake_s3"
 # SENDGRID_USERNAME=username
 # SENDGRID_PASSWORD=password
+# REDIS_PROVIDER="redis://localhost:6379"

--- a/.env.test
+++ b/.env.test
@@ -12,3 +12,4 @@ OXGARAGE_URL='http://oxgarage.example.com/ege-webservice/Conversions/docx%3Aappl
 RAILS_SECRET_TOKEN=secret-token-goes-here
 S3_BUCKET=tahi-test
 S3_URL="http://localhost:${CAPYBARA_SERVER_PORT}/fake_s3"
+REDIS_PROVIDER="redis://localhost:6379"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,13 @@
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV['REDIS_PROVIDER'],
+    namespace: "tahi_#{Rails.env}"
+  }
+end
+ 
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: ENV['REDIS_PROVIDER'],
+    namespace: "tahi_#{Rails.env}"
+  }
+end


### PR DESCRIPTION
This is so we can have iHat and tahi running on the same machine without one sidekiq fighting over the other.

Make sure to have `REDIS_PROVIDER` set in your .env.
