### PR TITLE
Remove `url` key from Sidekiq configuration

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,13 +1,11 @@
 Sidekiq.configure_server do |config|
   config.redis = {
-    url: ENV['REDIS_PROVIDER'],
     namespace: "tahi_#{Rails.env}"
   }
 end
  
 Sidekiq.configure_client do |config|
   config.redis = {
-    url: ENV['REDIS_PROVIDER'],
     namespace: "tahi_#{Rails.env}"
   }
 end


### PR DESCRIPTION
This way, Sidekiq uses its own conventions to work it out.
