### PR TITLE
Embiggen control-bar click areas

### DIFF
--- a/app/assets/javascripts/templates/flow_manager.hbs
+++ b/app/assets/javascripts/templates/flow_manager.hbs
@@ -2,10 +2,10 @@
   <div class="control-bar-inner-wrapper">
     <ul>
       <li class="control-bar-item">
-        <a href="#" class="add-flow-column-button control-bar-link control-bar-button" {{action "chooseNewFlowMangerColumn"}}>
-          <span class="glyphicon glyphicon-plus"></span>
-          &nbsp; Add New Column
-        </a>
+        <div class="control-bar-link add-flow-column-button __with-icon" {{action "chooseNewFlowMangerColumn"}}>
+          <div class="control-bar-link-icon"><span class="glyphicon glyphicon-plus"></span></div>
+          <div class="control-bar-link-text">Add New Column</div>
+        </div>
       </li>
     </ul>
   </div>

--- a/app/assets/stylesheets/screens/admin.css.scss
+++ b/app/assets/stylesheets/screens/admin.css.scss
@@ -371,10 +371,11 @@
 }
 
 .journal-admin-link {
-  margin-top: 7px;
   font-size: 24px;
 
   a {
+    display: inline-block;
+    padding: 12px 0;
     color: $tahi-blue;
   }
 }

--- a/app/assets/stylesheets/screens/papers.css.scss
+++ b/app/assets/stylesheets/screens/papers.css.scss
@@ -1,6 +1,6 @@
 #control-bar-paper-journal-logo {
   height: 71px;
-  margin-top: 7px;
+  margin-top: 9px;
   margin-right: 20px;
 
   div { padding-top: 6px; }
@@ -18,7 +18,7 @@
   h2 {
     overflow: hidden;
     width: 680px;
-    padding: 16px 0 0 5px;
+    padding: 20px 0 0 5px;
     font-family: $tahi-article-font-family;
     font-size: 18px;
     text-overflow: ellipsis;

--- a/app/assets/stylesheets/ui/control-bar.css.scss
+++ b/app/assets/stylesheets/ui/control-bar.css.scss
@@ -7,7 +7,6 @@
   width: 100%;
   height: $tahi-control-bar-height;
   border-bottom: 1px solid #F5F5F5;
-  padding: 2px 0 0 0;
   background: #fff;
   z-index: 2;
 
@@ -36,7 +35,8 @@
 .control-bar ul {
   list-style-type: none;
   float: left;
-  padding: 0 30px 0 0;
+  margin: 0; // bootstrap override
+  padding: 0;
 
   &:last-of-type { float: right; }
 }
@@ -45,13 +45,18 @@
   position: relative;
   float: left;
   display: block;
-  margin: 3px 0 0 0;
   font-size: 10px;
+}
+
+// creates bigger click area in top right corner of screen
+.control-bar ul:last-of-type .control-bar-item:last-of-type .control-bar-link {
+  padding-right: 30px;
 }
 
 .control-bar-link {
   display: block;
-  margin: 7px 0 0 45px;
+  margin: 0 0 0 45px;
+  padding: 11px 0;
   color: $tahi-green;
   font-weight: bold;
   text-align: center;


### PR DESCRIPTION
Buttons in the control bar now take up the full height of the bar. Also, the click area of the far right button expands all the way to the corner. Fitts's law bla, bla, bla.

OLD:
![screen shot 2014-10-16 at 10 41 19 am](https://cloud.githubusercontent.com/assets/3692/4664251/8f4807ee-5542-11e4-9ad3-5c130b6998ad.png)

NEW:
![screen shot 2014-10-16 at 10 40 30 am](https://cloud.githubusercontent.com/assets/3692/4664253/9361ee12-5542-11e4-9b6e-b0253b12862a.png)
