### PR TITLE
[#80334782] use \A and \z instead of ^ and $

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ActiveRecord::Base
   after_create :add_flows
 
   validates :username, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 255 }
-  validates_format_of :username, with: /^[A-Za-z\d_]+$/, multiline: true
+  validates_format_of :username, with: /\A[A-Za-z\d_]+\z/, multiline: true
   validates :email, format: Devise.email_regexp
   validates :first_name, length: { maximum: 255 }
   validates :last_name, length: { maximum: 255 }


### PR DESCRIPTION
Pretty complicated stuff.
-- DT ASB
