### PR TITLE
Do not explode if recipient has no email address

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -3,4 +3,10 @@ module MailerHelper
     return "Someone" unless user.present?
     user.full_name.presence || user.username
   end
+
+  def prevent_delivery_to_invalid_recipient
+    if mail.to.empty?
+      mail.perform_deliveries = false
+    end
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,6 +2,8 @@ class UserMailer < ActionMailer::Base
   include MailerHelper
   default from: ENV.fetch('FROM_EMAIL')
 
+  after_action :prevent_delivery_to_invalid_recipient
+
   def add_collaborator(invitor_id, invitee_id, paper_id)
     @paper = Paper.find(paper_id)
     invitor = User.find_by(id: invitor_id)
@@ -10,7 +12,7 @@ class UserMailer < ActionMailer::Base
     @invitee_name = display_name(invitee)
 
     mail(
-      to: invitee.email,
+      to: invitee.try(:email),
       subject: "You've been added as a collaborator to a paper on Tahi")
   end
 
@@ -22,7 +24,7 @@ class UserMailer < ActionMailer::Base
     @invitee_name = display_name(invitee)
 
     mail(
-      to: invitee.email,
+      to: invitee.try(:email),
       subject: "You've been added to a conversation on Tahi")
   end
 
@@ -32,7 +34,8 @@ class UserMailer < ActionMailer::Base
     @commentee = User.find(commentee_id)
 
     mail(
-      to: @commentee.email,
+      to: @commentee.try(:email),
       subject: "You've been mentioned on Tahi")
   end
+
 end


### PR DESCRIPTION
# References
- https://www.pivotaltracker.com/n/projects/880854/stories/80401056
# Notes
- This technically should not happen anymore (on new users) because user now has a validation on email address.  However, this is probably good practice to not explode if the recipient does not have an email address.  Also, this change makes it extremely easy to use on other mailers (one liner)

--- JN + AC
