### PR TITLE
Move Ihat request to initializer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,6 @@ Bundler.require(:default, Rails.env)
 
 module Tahi
   class Application < Rails::Application
-    config.ihat_supported_formats = Faraday.get(ENV['IHAT_URL']).body unless Rails.env.test?
     config.autoload_paths += %W(#{config.root}/lib)
     config.autoload_paths += %W(#{config.root}/app/workers)
     config.assets.precompile << /\.(?:svg|eot|woff|ttf)$/

--- a/config/initializers/ihat_supported_formats.rb
+++ b/config/initializers/ihat_supported_formats.rb
@@ -1,0 +1,11 @@
+unless Rails.env.test?
+  begin
+    Tahi::Application.config.ihat_supported_formats = Faraday.get(ENV['IHAT_URL']).body
+  rescue Faraday::ConnectionFailed
+    if ENV['IHAT_URL']
+      Rails.logger.warn "Unable to connect to #{ENV['IHAT_URL']}"
+    else
+      Rails.logger.warn "ENV['IHAT_URL'] Not set, falling back to default document types…"
+    end
+  end
+end


### PR DESCRIPTION
Fail gracefully when the application starts by warning that
ENV['IHAT_URL'] has not been defined or the server cannot connect to the
specified server
