### PR TITLE
Security Fix: Do not allow arbitrary task types from params to be constantized directly

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -60,9 +60,9 @@ class TasksController < ApplicationController
   end
 
   def build_task
-    task_type = params[:task][:type]
-    sanitized_params = task_params task_type.constantize.new
-    TaskFactory.build_task task_type, sanitized_params, current_user
+    task_type = TaskType.find_by(kind: params[:task][:type])
+    sanitized_params = task_params(task_type.kind.constantize.new)
+    TaskFactory.build_task(task_type, sanitized_params, current_user)
   end
 
   def render_404

--- a/app/services/task_factory.rb
+++ b/app/services/task_factory.rb
@@ -1,6 +1,6 @@
 module TaskFactory
   def self.build_task(task_type, task_params, user)
-    task_factories[task_type.to_sym].build task_params, user
+    task_factories[task_type.kind.to_sym].build(task_params, user)
   end
 
   def self.task_factories

--- a/app/services/task_services/create_task_types.rb
+++ b/app/services/task_services/create_task_types.rb
@@ -19,6 +19,7 @@ module TaskServices
         {kind: "StandardTasks::TechCheckTask",                  default_role: "admin",    default_title: "Tech Check"},
         {kind: "SupportingInformation::Task",                   default_role: "author",   default_title: "Supporting Info"},
         {kind: "Task",                                          default_role: nil,        default_title: "Ad-Hoc"},
+        {kind: "MessageTask",                                   default_role: nil,        default_title: "Message Task"},
         {kind: "UploadManuscript::Task",                        default_role: "author",   default_title: "Upload Manuscript"},
       ]
 


### PR DESCRIPTION
# Description

Do not allow user to pass in whatever they want from the front end to be constantized and used within the app.
# References
- https://www.pivotaltracker.com/story/show/80334890
# Notes
- We really need an authoritative source for what are valid/allowed task types.  We essentially have that in our `TaskType` factory except for one lone holdout, the good 'ol `MessageTask`.  I decided to add it with these changes so that we can allow it to be verified before creation.
