### PR TITLE
Prevent application.js.erb from crashing on init

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -96,7 +96,7 @@
   }
 
   ETahi.environment = "<%= Rails.env %>";
-  <% if Tahi::Application.config.ihat_supported_formats.present? %>
+  <% if Tahi::Application.config.try(:ihat_supported_formats) %>
     ETahi.supportedDownloadFormats = JSON.parse('<%= Tahi::Application.config.ihat_supported_formats %>');
   <% end %>
 })(window);


### PR DESCRIPTION
The ihat_supported_formats url is unreachable and is causing init to crash
