### PR TITLE
Ensure that the env config is not mutated after test

### DIFF
--- a/spec/initializers/ihat_supported_formats_spec.rb
+++ b/spec/initializers/ihat_supported_formats_spec.rb
@@ -9,6 +9,14 @@ describe IhatSupportedFormats do
                                     body: "blah",
                                     headers: {
                                       "content-type" => "text/html; charset=UTF-8" }) }
+  before(:all) do
+    @original_ihat_url = ENV['IHAT_URL']
+  end
+
+  after(:all) do
+    ENV['IHAT_URL'] = @original_ihat_url
+  end
+
   describe ".call" do
     context "when the IHAT_URL is present" do
       it "makes a request to the URL" do
@@ -23,13 +31,13 @@ describe IhatSupportedFormats do
 
       context "when connection fails" do
         it "warns unable to connect" do
-          VCR.use_cassette('ihat_404') do
-            ENV['IHAT_URL'] = "http://examplethatdoesntexistyet.com"
-            expect(Rails.logger)
-            .to receive(:warn)
-            .with("Unable to connect to http://examplethatdoesntexistyet.com")
-            IhatSupportedFormats.call
-          end
+          ENV['IHAT_URL'] = "http://examplethatdoesntexistyet.com"
+          expect(Faraday).to receive(:get).with(ENV['IHAT_URL']).and_raise(Faraday::ConnectionFailed.new("stuff"))
+
+          expect(Rails.logger)
+          .to receive(:warn)
+          .with("Unable to connect to http://examplethatdoesntexistyet.com")
+          IhatSupportedFormats.call
         end
       end
 


### PR DESCRIPTION
--FF & CW
Any test involving ENV['IHAT_URL'] was blowing up occasionally.
We were also unable to get a VCR cassette that would actually make Faraday throw a ConnectionFailed error, so we stubbed it. 
