### PR TITLE
Fix scroll position on transition

### DIFF
--- a/app/assets/javascripts/controllers/application_controller.js.coffee
+++ b/app/assets/javascripts/controllers/application_controller.js.coffee
@@ -18,6 +18,10 @@ ETahi.ApplicationController = Ember.Controller.extend
     @set('error', null)
   ).observes('currentPath')
 
+  resetScrollPosition:( ->
+    window.scrollTo(0,0)
+  ).observes('currentPath')
+
   overlayBackground: Ember.computed.defaultTo('defaultBackground')
 
   overlayRedirect: []


### PR DESCRIPTION
On long pages, if you're scrolled half-way down and then transition to a different route, you will still be at the same scroll position (since it's not an actual page reload). This fix ensures you are scrolled to the top whenever the route changes.
