### PR TITLE
[#81632264] Move mmt authorization check to route.

### DIFF
--- a/app/assets/javascripts/controllers/base_paper_controller.js.coffee
+++ b/app/assets/javascripts/controllers/base_paper_controller.js.coffee
@@ -22,18 +22,6 @@ ETahi.BasePaperController = Ember.ObjectController.extend
 
   canViewManuscriptManager: false
 
-  showManuscriptManagerLink: (->
-    Ember.$.ajax
-      url: "/papers/#{@get('id')}/manuscript_manager"
-      method: 'GET'
-      headers:
-        'Tahi-Authorization-Check': true
-      success: (data) =>
-        @set('canViewManuscriptManager', true)
-      error: =>
-        @set('canViewManuscriptManager', false)
-  ).observes('model.id')
-
   assignedTasks: (->
     assignedTasks = @get('tasks').filter (task) =>
       task.get('participations').mapBy('participant').contains(@getCurrentUser())

--- a/app/assets/javascripts/routes/application_route.js.coffee
+++ b/app/assets/javascripts/routes/application_route.js.coffee
@@ -1,17 +1,8 @@
 ETahi.ApplicationRoute = Ember.Route.extend ETahi.AnimateElement,
   setupController: (controller, model) ->
+    controller.set('model', model)
     if @getCurrentUser? && @getCurrentUser()
-      authorize = (value) ->
-        (result) ->
-          Ember.run ->
-            controller.set('canViewAdminLinks', value)
-      Ember.$.ajax '/admin/journals/authorization',
-        headers:
-          'Tahi-Authorization-Check': true
-        success: authorize(true)
-        error:authorize(false)
-
-    @_super(model, controller)
+      ETahi.RESTless.authorize(controller, '/admin/journals/authorization', 'canViewAdminLinks')
 
   actions:
     loading: (transition, originRoute) ->

--- a/app/assets/javascripts/routes/paper_edit_route.js.coffee
+++ b/app/assets/javascripts/routes/paper_edit_route.js.coffee
@@ -22,6 +22,8 @@ ETahi.PaperEditRoute = ETahi.AuthorizedRoute.extend
   setupController: (controller, model) ->
     controller.set('model', model)
     controller.set('commentLooks', @store.all('commentLook'))
+    if @getCurrentUser? && @getCurrentUser()
+      ETahi.RESTless.authorize(controller, "/papers/#{model.get('id')}/manuscript_manager", 'canViewManuscriptManager')
 
   deactivate: ->
     @endHeartbeat()

--- a/app/assets/javascripts/routes/paper_index_route.js.coffee
+++ b/app/assets/javascripts/routes/paper_index_route.js.coffee
@@ -5,6 +5,8 @@ ETahi.PaperIndexRoute = ETahi.AuthorizedRoute.extend
   setupController: (controller, model) ->
     controller.set('model', model)
     controller.set('commentLooks', @store.all('commentLook'))
+    if @getCurrentUser? && @getCurrentUser()
+      ETahi.RESTless.authorize(controller, "/papers/#{model.get('id')}/manuscript_manager", 'canViewManuscriptManager')
 
   actions:
     viewCard: (task) ->

--- a/app/assets/javascripts/services/rest_less.js.coffee
+++ b/app/assets/javascripts/services/rest_less.js.coffee
@@ -24,3 +24,14 @@ ETahi.RESTless = Ember.Namespace.create
           Ember.keys(errors).forEach (key) ->
             modelErrors.add(key, errors[key])
         throw {status: xhr.status, model: model}
+
+  authorize: (controller, url, property) ->
+    authorize = (value) ->
+      (result) ->
+        Ember.run ->
+          controller.set(property, value)
+    Ember.$.ajax url,
+      headers:
+        'Tahi-Authorization-Check': true
+      success: authorize(true)
+      error:authorize(false)


### PR DESCRIPTION
--ASB & CW
https://www.pivotaltracker.com/story/show/81632264

Consolidate setupController auth checks into ETahi.RESTless

The user will still have to navigate away from the Paper page to have the MM authorization update (no event-stream style updates here), but they don't have to reload the page.  
