### PR TITLE
at-mentions

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -51,6 +51,7 @@
     LOG_TRANSITIONS_INTERNAL       : false,
     LOG_VIEW_LOOKUPS               : false,
     LOG_ACTIVE_GENERATION          : false,
+    LOG_RESOLVER                   : false,
     // Tahi
     LOG_RSVP_ERRORS                : true,
     LOG_VIEW_RENDERING_PERFORMANCE : true

--- a/app/assets/javascripts/components/task_comment_component.js.coffee
+++ b/app/assets/javascripts/components/task_comment_component.js.coffee
@@ -7,6 +7,11 @@ ETahi.TaskCommentComponent = Ember.Component.extend
   commenter: Ember.computed.alias 'comment.commenter'
   createdAt: Ember.computed.alias 'comment.createdAt'
   body: Ember.computed.alias 'comment.body'
+  highlightedBody: (->
+    body = @get('comment.body')
+    mentions = @get('comment.entities.user_mentions')
+    @highlightBody(body, mentions)
+  ).property('body')
 
   setUnreadState: ( ->
     Ember.run =>
@@ -18,3 +23,17 @@ ETahi.TaskCommentComponent = Ember.Component.extend
       else
         @set('unread', false)
   ).on('init')
+
+  highlightBody: (body, mentions) ->
+    if !mentions then return body
+    mentionStrings = []
+    for mention in mentions
+      first = mention.indices[0]
+      last = mention.indices[1]
+      mentionString = body.slice(first, last)
+      mentionStrings.push mentionString
+
+    for mention in mentionStrings
+      regex = new RegExp("(#{mention})")
+      body = body.replace(regex, '<strong>$1</strong>')
+    body

--- a/app/assets/javascripts/models/comment.js.coffee
+++ b/app/assets/javascripts/models/comment.js.coffee
@@ -5,6 +5,7 @@ ETahi.Comment = DS.Model.extend
   body: a('string')
   createdAt: a('date')
   commentLook: DS.belongsTo('commentLook')
+  entities: a()
 
   isUnreadBy: (user) ->
     if commentLook = @get('commentLook')

--- a/app/assets/javascripts/serializers/comment_serializer.js.coffee
+++ b/app/assets/javascripts/serializers/comment_serializer.js.coffee
@@ -1,1 +1,0 @@
-ETahi.CommentSerializer = ETahi.ApplicationSerializer.extend()

--- a/app/assets/javascripts/templates/components/task-comment.hbs
+++ b/app/assets/javascripts/templates/components/task-comment.hbs
@@ -1,4 +1,4 @@
 {{unbound user-thumbnail commenter}}
 <span class="comment-date">{{formattedTime createdAt}}</span>
 <span class="comment-name">{{commenter.fullName}} posted</span>
-<div class="comment-body">{{displayLineBreaks body}}</div>
+<div class="comment-body">{{displayLineBreaks highlightedBody}}</div>

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,5 +1,5 @@
 class CommentSerializer < ActiveModel::Serializer
-  attributes :id, :body, :created_at
+  attributes :id, :body, :created_at, :entities
 
   has_one :task, embed: :id, polymorphic: true
   has_one :commenter, serializer: UserSerializer, include: true, root: :users, embed: :id

--- a/bin/log.sh
+++ b/bin/log.sh
@@ -1,0 +1,1 @@
+tail -fn 100 log/development.log

--- a/db/migrate/20141110224736_add_comment_entities.rb
+++ b/db/migrate/20141110224736_add_comment_entities.rb
@@ -1,0 +1,5 @@
+class AddCommentEntities < ActiveRecord::Migration
+  def change
+    add_column :comments, :entities, :json
+  end
+end

--- a/db/migrate/20141111213530_escape_comment_body.rb
+++ b/db/migrate/20141111213530_escape_comment_body.rb
@@ -1,0 +1,8 @@
+class EscapeCommentBody < ActiveRecord::Migration
+  def change
+    Comment.all.each do |comment|
+      comment.escape_body
+      comment.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20141112193333) do
     t.datetime "updated_at"
     t.integer  "commenter_id"
     t.integer  "task_id"
+    t.json     "entities"
   end
 
   add_index "comments", ["commenter_id", "task_id"], name: "index_comments_on_commenter_id_and_task_id", using: :btree

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -13,6 +13,23 @@ describe Comment, redis: true do
     end
   end
 
+  context "creating a new Comment" do
+    it "#sanitize_body" do
+      body = "hi @#{author.username}. Trying to break comment with <script>alert('bad script')</script>"
+      comment = FactoryGirl.create(:comment, body: body)
+      expected = "hi @#{author.username}. Trying to break comment with &lt;script&gt;alert(&#39;bad script&#39;)&lt;/script&gt;"
+      expect(comment.body).to eq expected
+    end
+
+    it "#set_mentions" do
+      body = "hi @#{author.username}, @#{author2.username}, and @nonexistent_user"
+      comment = FactoryGirl.create(:comment, body: body)
+      expected = {:indices=>[3, 3+('@'+author.username).length]}
+      expect(comment.entities['user_mentions'][0]).to eq expected
+      expect(comment.entities['user_mentions'].length).to eq 2
+    end
+  end
+
   context "notifications" do
     before { ActionMailer::Base.deliveries.clear }
 

--- a/spec/services/message_task_factory_spec.rb
+++ b/spec/services/message_task_factory_spec.rb
@@ -30,7 +30,7 @@ describe TaskFactory::MessageTaskFactory do
         it "creates a new Comment for the MessageTask" do
           expect(result.comments.count).to eq 1
           c = result.comments.first
-          expect(c.body).to eq(msg_body)
+          expect(c.body).to eq("It&#39;s a test body.")
           expect(c.commenter).to eq(user)
         end
       end

--- a/vendor/assets/bower.json
+++ b/vendor/assets/bower.json
@@ -12,7 +12,7 @@
     "jquery-timeago": "latest",
     "bootstrap-datepicker": "latest",
     "event-source-polyfill": "latest",
-    "moment": "latest"
+    "moment": "latest",
     "select2": "latest"
   }
 }


### PR DESCRIPTION
— DT + RW

Comes with a migration to escape existing `comment.body`.

https://www.pivotaltracker.com/story/show/82072770

TODOs
- [x] get reviews from people
- [x] fixup into one commit, include tracker# in commit message
