### PR TITLE
Fix code climate remote execution complaint

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -92,7 +92,7 @@ class TasksController < ApplicationController
 
   def enforce_policy_on_create
     return unless JournalTaskType.find_by!(kind: params[:task][:type])
-    task_klass =  params[:task][:type].constantize
+    task_klass = TaskType.constantize!(params[:task][:type])
     sanitized_params = task_params(task_klass.new)
     authorize_action!(task: Task.new(sanitized_params))
   end


### PR DESCRIPTION
Unsafe reflection method constantize called with parameter value.

Use existing STI type constantize method
