### PR TITLE
Remove tables that aren't being used

### DIFF
--- a/db/migrate/20141112193333_cleanup_dead_tables.rb
+++ b/db/migrate/20141112193333_cleanup_dead_tables.rb
@@ -1,0 +1,20 @@
+class CleanupDeadTables < ActiveRecord::Migration
+  def up
+    drop_table :author_paper
+    drop_table :rails_admin_histories
+  end
+
+  def down
+    create_table :author_paper
+    create_table :rails_admin_histories do |t|
+      t.text :message
+      t.string :username
+      t.integer :item
+      t.string :table
+      t.integer :month, limit: 2
+      t.integer :year, limit: 8
+      t.timestamps
+    end
+    add_index :rails_admin_histories, ["item", "table", "month", "year"], name: "index_rails_admin_histories"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141106201601) do
+ActiveRecord::Schema.define(version: 20141112193333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,9 +43,6 @@ ActiveRecord::Schema.define(version: 20141106201601) do
     t.string   "title"
     t.string   "caption"
     t.string   "status",          default: "processing"
-  end
-
-  create_table "author_paper", force: true do |t|
   end
 
   create_table "authors", force: true do |t|
@@ -266,19 +263,6 @@ ActiveRecord::Schema.define(version: 20141106201601) do
   end
 
   add_index "questions", ["task_id"], name: "index_questions_on_task_id", using: :btree
-
-  create_table "rails_admin_histories", force: true do |t|
-    t.text     "message"
-    t.string   "username"
-    t.integer  "item"
-    t.string   "table"
-    t.integer  "month",      limit: 2
-    t.integer  "year",       limit: 8
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "rails_admin_histories", ["item", "table", "month", "year"], name: "index_rails_admin_histories", using: :btree
 
   create_table "roles", force: true do |t|
     t.string   "name"


### PR DESCRIPTION
Doing some spelunking and it doesn't appear these tables are being used. Nuke 'em.
