### PR TITLE
[#79119446] Remove just added role

### DIFF
--- a/app/assets/javascripts/controllers/admin_journal_user_controller.js.coffee
+++ b/app/assets/javascripts/controllers/admin_journal_user_controller.js.coffee
@@ -14,7 +14,7 @@ ETahi.AdminJournalUserController = Ember.ObjectController.extend
       name: userRole.get 'role.name'
       userRoleId: userRole.get 'id'
 
-  roles: Em.computed 'userRoles.@each', -> @get('userRoles').map @createRoleObject
+  roles: Em.computed 'userRoles.@each.id', -> @get('userRoles').map @createRoleObject
 
   isAddingRole: false
 


### PR DESCRIPTION
The id on the mapped role object wasn’t getting updated on save, so
store.getById was returning null. This fix keeps the mapped object in
sync.
