### PR TITLE
[#78159156] Delay updating paper striking image till ‘Save’ is clicked

### DIFF
--- a/app/assets/javascripts/components/figure_thumbnail_component.js.coffee
+++ b/app/assets/javascripts/components/figure_thumbnail_component.js.coffee
@@ -5,3 +5,8 @@ ETahi.FigureThumbnailComponent = ETahi.AttachmentThumbnailComponent.extend
     toggleStrikingImageFromCheckbox: (checkbox)->
       newValue = if checkbox.get('checked') then checkbox.get('attachment.id') else null
       @sendAction('action', newValue)
+
+    saveAttachment: ->
+      @get('attachment').save().then =>
+        @sendAction('saveAttachment')
+      @set('editState', false)

--- a/engines/standard_tasks/app/assets/javascripts/standard_tasks/controllers/overlays/figure_overlay_controller.js.coffee
+++ b/engines/standard_tasks/app/assets/javascripts/standard_tasks/controllers/overlays/figure_overlay_controller.js.coffee
@@ -18,4 +18,7 @@ ETahi.FigureOverlayController = ETahi.TaskController.extend ETahi.FileUploadMixi
       @get('paper.figures').pushObject(figure)
 
     changeStrikingImage: (newValue) ->
-      @get('paper').set('strikingImageId', newValue).save()
+      @get('paper').set('strikingImageId', newValue)
+
+    updateStrikingImage: ->
+      @get('paper').save()

--- a/engines/standard_tasks/app/assets/javascripts/standard_tasks/templates/overlays/figure_overlay.hbs
+++ b/engines/standard_tasks/app/assets/javascripts/standard_tasks/templates/overlays/figure_overlay.hbs
@@ -23,6 +23,7 @@
   {{#each figure in figures}}
     {{figure-thumbnail attachment=figure
                        action="changeStrikingImage"
+                       saveAttachment="updateStrikingImage"
                        uploadFinished="uploadFinished"
                        uploadStarted="uploadStarted"
                        uploadProgress="uploadProgress"}}


### PR DESCRIPTION
References: https://www.pivotaltracker.com/story/show/78159156

Approach: bubble up the saveAttachment action so that the controller can save the paper when 'Save' is clicked instead of as soon as the checkbox is changed.
