### PR TITLE
Add reek for quality assurance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :development do
   gem 'rubocop', require: false
   gem 'scss-lint', require: false
   gem 'overcommit', require: false
+  gem 'reek', require: false
 end
 
 group :development, :test, :performance do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,11 @@ GEM
     redis (3.0.7)
     redis-namespace (1.4.1)
       redis (~> 3.0.4)
+    reek (1.4.0)
+      rainbow (>= 1.99, < 3.0)
+      ruby2ruby (>= 2.0.8, < 3.0)
+      ruby_parser (>= 3.5.0, < 4.0)
+      sexp_processor (~> 4.4)
     responders (1.1.1)
       railties (>= 3.2, < 4.2)
     rest_client (1.7.3)
@@ -429,6 +434,11 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.0)
+    ruby2ruby (2.1.3)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.6.3)
+      sexp_processor (~> 4.1)
     rubyzip (1.1.6)
     safe_yaml (1.0.3)
     sass (3.2.19)
@@ -448,6 +458,7 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sexp_processor (4.4.4)
     sidekiq (3.1.4)
       celluloid (>= 0.15.2)
       connection_pool (>= 2.0.0)
@@ -578,6 +589,7 @@ DEPENDENCIES
   rack-timeout
   rails (= 4.1.7)
   rails_12factor
+  reek
   rest_client (~> 1.7.3)
   rspec-collection_matchers
   rspec-instafail


### PR DESCRIPTION
Reek is required for overcommit's pre-commit Ruby hook

References:
https://www.pivotaltracker.com/story/show/82756738

This branch adds reek as a development dependency for pre-commit hook prerequisite statisfaction
