### PR TITLE
Only start application level processes via foreman

### DIFF
--- a/Procfile.local
+++ b/Procfile.local
@@ -1,5 +1,4 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq
 event_source: go run $GOPATH/src/github.com/tahi-project/golang-eventsource/server.go -p=8080 -token=token123
-redis: redis-server /usr/local/etc/redis.conf
 solr: bundle exec rake sunspot:solr:run


### PR DESCRIPTION
This pull request removes `redis-server` from the `Procfile`.

Starting `redis-server` via foreman when it's already running will cause `foreman start` to fail. Having redis already running is pretty common for a developer machine.

It seems foreman is meant for managing application level processes, not system level processes. Note that the Procfile (as is) doesn't include the symmetric postgresql process(es).

If you'd like to not think about having redis-server running, it's better to use existing OS level tooling to manage it.

**e.g** on OSX via homebrew `ln -sfv /usr/local/opt/redis/*.plist ~/Library/LaunchAgents`
