### PR TITLE
[#82700892] Admin can save DOI pattern & number for a journal

### DIFF
--- a/app/assets/javascripts/controllers/journal_index_controller.js.coffee
+++ b/app/assets/javascripts/controllers/journal_index_controller.js.coffee
@@ -59,3 +59,6 @@ ETahi.JournalIndexController = Ember.ObjectController.extend
       @set('epubCssSaveStatus', '')
       @set('pdfCssSaveStatus', '')
       @set('manuscriptCssSaveStatus', '')
+
+    saveDOI: ->
+      @get("model").save()

--- a/app/assets/javascripts/models/admin_journal.js.coffee
+++ b/app/assets/javascripts/models/admin_journal.js.coffee
@@ -14,3 +14,6 @@ ETahi.AdminJournal = DS.Model.extend
   paperCount: a('number')
   createdAt: a('date')
   journalTaskTypes: DS.hasMany('journalTaskType')
+  doiJournalPrefix: a('string')
+  doiPublisherPrefix: a('string')
+  doiStartNumber: a('number')

--- a/app/assets/javascripts/templates/journal/index.hbs
+++ b/app/assets/javascripts/templates/journal/index.hbs
@@ -32,6 +32,37 @@
 
   {{render "manuscript_manager_template/index" manuscriptManagerTemplates}}
 
+  <div class="admin-section doi-form">
+    <h2 class="admin-section-title">
+      DOI
+    </h2>
+
+    <div class="admin-doi-setting-section">
+      Publisher DOI Prefix:
+      <br>
+      {{input type="text" class="doi_publisher_prefix" value=doiPublisherPrefix}}
+      <br><br>
+
+      Journal Prefix:
+      <br>
+      {{input type="text" class="doi_journal_prefix" value=doiJournalPrefix}}
+      <br><br>
+
+      Start Number:
+      <br>
+      {{input type="text" class="doi_start_number" value=doiStartNumber}}
+    </div>
+
+    <div class="alert alert-info" style="margin-top: 25px;">
+      Careful! You can only save this once.
+    </div>
+
+    <div class="admin-doi-setting-section">
+      <button class="button-primary button--blue"
+        {{action "saveDOI"}}>Save DOI</button>
+    </div>
+  </div>
+
   <div class="admin-section">
     <h2 class="admin-section-title">Style Settings</h2>
 

--- a/app/controllers/admin/journals_controller.rb
+++ b/app/controllers/admin/journals_controller.rb
@@ -49,6 +49,16 @@ class Admin::JournalsController < ApplicationController
   private
 
   def journal_params
-    params.require(:admin_journal).permit(:name, :description, :epub_cover, :epub_css, :pdf_css, :manuscript_css)
+    params.require(:admin_journal).permit(
+      :name,
+      :description,
+      :epub_cover,
+      :epub_css,
+      :pdf_css,
+      :manuscript_css,
+      :doi_publisher_prefix,
+      :doi_journal_prefix,
+      :doi_start_number
+    )
   end
 end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -7,6 +7,11 @@ class Journal < ActiveRecord::Base
   has_many :journal_task_types, inverse_of: :journal, dependent: :destroy
 
   validates_presence_of :name, message: 'Please include a journal name'
+  validates_uniqueness_of :doi_journal_prefix,
+    scope: [:doi_publisher_prefix],
+    if: Proc.new { |j|
+      j.doi_journal_prefix.present? && j.doi_publisher_prefix.present?
+    }
 
   after_create :setup_defaults
   before_destroy :destroy_roles

--- a/app/serializers/admin_journal_serializer.rb
+++ b/app/serializers/admin_journal_serializer.rb
@@ -9,6 +9,9 @@ class AdminJournalSerializer < ActiveModel::Serializer
              :pdf_css,
              :manuscript_css,
              :description,
+             :doi_publisher_prefix,
+             :doi_journal_prefix,
+             :doi_start_number,
              :paper_count,
              :created_at
   has_many :manuscript_manager_templates, embed: :ids, include: true

--- a/db/migrate/20141117233411_add_paper_doi.rb
+++ b/db/migrate/20141117233411_add_paper_doi.rb
@@ -1,0 +1,7 @@
+class AddPaperDoi < ActiveRecord::Migration
+  def change
+    add_column :journals, :doi_publisher_prefix, :string
+    add_column :journals, :doi_journal_prefix, :string
+    add_column :journals, :doi_start_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141113145629) do
+ActiveRecord::Schema.define(version: 20141117233411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,9 @@ ActiveRecord::Schema.define(version: 20141113145629) do
     t.text     "pdf_css"
     t.text     "manuscript_css"
     t.text     "description"
+    t.string   "doi_publisher_prefix"
+    t.string   "doi_journal_prefix"
+    t.string   "doi_start_number"
   end
 
   create_table "manuscript_manager_templates", force: true do |t|

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -5,4 +5,46 @@ describe "Journal" do
     journal = build(:journal)
     expect(journal).to be_valid
   end
+
+  describe "DOI" do
+    before do
+      @journal = build(:journal)
+      @journal.doi_publisher_prefix = "PPREFIX"
+      @journal.doi_journal_prefix = "JPREFIX"
+      @journal.doi_start_number = "100001"
+      @journal.save!
+    end
+
+    it "can save a DOI" do
+      expect(@journal.doi_publisher_prefix).to eq "PPREFIX"
+      expect(@journal.doi_journal_prefix).to eq "JPREFIX"
+      expect(@journal.doi_start_number).to eq "100001"
+    end
+
+    describe "additional Journals" do
+      before do
+        @journal = build(:journal)
+        @journal.doi_publisher_prefix = "PPREFIX"
+        @journal.doi_journal_prefix = "JPREFIX"
+      end
+
+      it "does not accept duplicate journal prefixes" do
+        expect {
+          @journal.save!
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    describe "more Journals" do
+      it "which do not have DOI set" do
+        journal = build(:journal)
+        expect(journal).to be_valid
+        journal.save!
+
+        journal = build(:journal)
+        expect(journal).to be_valid
+        journal.save!
+      end
+    end
+  end
 end

--- a/test/javascripts/integration/admin_journal_test.js.coffee
+++ b/test/javascripts/integration/admin_journal_test.js.coffee
@@ -1,0 +1,180 @@
+module 'Integration: Admin Journal Test',
+
+  teardown: -> ETahi.reset()
+  setup: ->
+    setupApp integration: true
+    TahiTest.journalId = 209
+    TahiTest.editorRoleId = 8
+    TahiTest.reviewerRoleId = 9
+
+    journalRoles =
+      [
+        id: 7
+        kind: "admin"
+        name: "Admin"
+        required: true
+        can_administer_journal: true
+        can_view_assigned_manuscript_managers: false
+        can_view_all_manuscript_managers: true
+        can_view_flow_manager: true
+        journal_id: TahiTest.journalId
+      ,
+        id: TahiTest.editorRoleId
+        kind: "editor"
+        name: "Editor"
+        required: true
+        can_administer_journal: false
+        can_view_assigned_manuscript_managers: false
+        can_view_all_manuscript_managers: false
+        can_view_flow_manager: false
+        journal_id: TahiTest.journalId
+      ,
+        id: TahiTest.reviewerRoleId
+        kind: "reviewer"
+        name: "Reviewer"
+        required: true
+        can_administer_journal: false
+        can_view_assigned_manuscript_managers: false
+        can_view_all_manuscript_managers: false
+        can_view_flow_manager: false
+        journal_id: TahiTest.journalId
+      ,
+        id: TahiTest.reviewerRoleId
+        kind: "flow manager"
+        name: "Flow Manager"
+        required: true
+        can_administer_journal: false
+        can_view_assigned_manuscript_managers: false
+        can_view_all_manuscript_managers: false
+        can_view_flow_manager: true
+        journal_id: TahiTest.journalId
+      ]
+
+    adminJournal =
+      id: TahiTest.journalId
+      name: "Test Journal of America"
+      logo_url: "foo"
+      paper_types: ["Research"]
+      task_types: [ "FinancialDisclosure::Task" ]
+      description: "This is a test journal"
+      paper_count: 3
+      created_at: "2014-06-16T22:23:16.320Z"
+      manuscript_manager_templates: [
+        id: 5
+        paper_type: "Research"
+        template: {}
+        journal_id: TahiTest.journalId
+      ]
+      role_ids: [7, TahiTest.editorRoleId, TahiTest.reviewerRoleId]
+      doi_publisher_prefix: undefined
+      doi_journal_prefix: undefined
+      doi_start_number: undefined
+
+    adminJournalPayload =
+      roles: journalRoles
+      admin_journal: adminJournal
+
+    adminJournalsPayload =
+      roles: journalRoles
+      admin_journals: [adminJournal]
+
+    TahiTest.userRoleId = 99
+    TahiTest.adminUserId = 923
+    userRoleResponse =
+      user_role:
+        id: TahiTest.userRoleId
+        user_id: TahiTest.adminUserId
+        role_id: TahiTest.editorRoleId
+
+    adminJournalUserResponse =
+      user_roles: [
+        id: TahiTest.userRoleId
+        user_id: TahiTest.adminUserId
+        role_id: TahiTest.reviewerRoleId
+      ]
+      admin_journal_users: [
+        id: TahiTest.adminUserId
+        username: "fakeuser"
+        first_name: "Fake"
+        last_name: "User"
+        info: "Test String"
+        user_role_ids: [TahiTest.userRoleId]
+      ]
+
+    TahiTest.query = 'User'
+
+    server.respondWith 'GET', "/admin/journals", [
+      200, "Content-Type": "application/json",
+      JSON.stringify adminJournalsPayload
+    ]
+
+    server.respondWith 'PUT', "/admin/journals/#{TahiTest.journalId}", [
+      200, "Content-Type": "application/json",
+      JSON.stringify adminJournalPayload
+    ]
+
+    server.respondWith 'GET', "/admin/journals/#{TahiTest.journalId}", [
+      200, "Content-Type": "application/json",
+      JSON.stringify adminJournalPayload
+    ]
+
+    server.respondWith 'GET', "/admin/journals/authorization", [
+      204, "Content-Type": "application/html", ""
+    ]
+
+    server.respondWith 'GET', "/admin/journal_users?journal_id=#{TahiTest.journalId}", [
+      200, "Content-Type": "application/json",
+      JSON.stringify adminJournalUserResponse
+    ]
+
+    server.respondWith 'GET', "/admin/journal_users?query=#{TahiTest.query}", [
+      200, "Content-Type": "application/json",
+      JSON.stringify adminJournalUserResponse
+    ]
+
+    admin_journal_users = "/admin/journal_users"
+    query = "?query=#{TahiTest.query}&journal_id=#{TahiTest.journalId}"
+    server.respondWith 'GET', admin_journal_users + query, [
+      200, "Content-Type": "application/json",
+      JSON.stringify adminJournalUserResponse
+    ]
+
+    server.respondWith 'POST', "/user_roles", [
+      201, "Content-Type": "application/json", JSON.stringify userRoleResponse
+    ]
+
+    server.respondWith 'DELETE', "/user_roles/#{TahiTest.userRoleId}", [
+      204, "Content-Type": "application/json", JSON.stringify {}
+    ]
+
+test 'admin sees the complete DOI form', ->
+  # assert that the admin page has the 3 fields
+  visit "/admin/journals/#{TahiTest.journalId}"
+  .then ->
+    ok find('.admin-doi-setting-section')
+    ok find('.admin-doi-setting-section .doi_publisher_prefix')
+    ok find('.admin-doi-setting-section .doi_journal_prefix')
+    ok find('.admin-doi-setting-section .doi_start_number')
+
+test 'admin can set DOI doi_publisher_prefix, doi_journal_prefix, doi_start_number', ->
+  PPREFIX = "PPREFIX"
+  JPREFIX = "JPREFIX"
+  doi_start_number = "10000"
+  adminPage = "/admin/journals/#{TahiTest.journalId}"
+  visit adminPage
+  .then ->
+    ok find('.admin-doi-setting-section .doi_publisher_prefix').val(PPREFIX)
+    ok find('.admin-doi-setting-section .doi_journal_prefix').val(JPREFIX)
+    ok find('.admin-doi-setting-section .doi_start_number').val(doi_start_number)
+    button = find('.admin-doi-setting-section button')
+    ok button
+    click button
+  andThen ->
+    url = "/admin/journals/#{TahiTest.journalId}"
+    ok _.findWhere(server.requests, { method: 'PUT', url })
+
+  visit adminPage
+  .then ->
+    equal(find('.admin-doi-setting-section .doi_publisher_prefix').val(), PPREFIX)
+    equal(find('.admin-doi-setting-section .doi_journal_prefix').val(), JPREFIX)
+    equal(find('.admin-doi-setting-section .doi_start_number').val(), doi_start_number)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/880854/stories/82700892

self review feedback TODOs:
- [x] better names for publisher_prefix, journal_prefix, start_number
- [x] fix HTML labels.
- [x] cannot make two journals that do not have DOI info set (they are not uniquely blank)

— DT RW

![image](https://cloud.githubusercontent.com/assets/5796310/5080898/aa32a7ec-6e7b-11e4-8d38-fc3fc13f9420.png)
