### PR TITLE
don't kill redis

### DIFF
--- a/bin/kill-server
+++ b/bin/kill-server
@@ -13,11 +13,6 @@ if [ -n "$(lsof -ti :5000)" ]
     kill -9 `lsof -ti :5000`
 fi
 
-if [ -n "$(lsof -ti :6379)" ]
-  then
-    kill -9 `lsof -ti :6379`
-fi
-
 if [ -n "$(lsof -ti :8982)" ]
   then
     kill -9 `lsof -ti :8982`


### PR DESCRIPTION
RW + AJP

Let's not kill redis with `bin/kill-server` since we're no longer starting it with `bin/foreman-start`.
