### PR TITLE
Change the way we match headers when finding a phase

### DIFF
--- a/spec/features/manuscript_manager_spec.rb
+++ b/spec/features/manuscript_manager_spec.rb
@@ -97,8 +97,6 @@ feature "Manuscript Manager", js: true, selenium: true, solr: true do
       expect(overlay).to have_admin(admin.full_name)
     end
 
-    expect(task_manager_page).to have_no_application_error
-
     needs_editor_phase = TaskManagerPage.new.phase 'Assign Editor'
     needs_editor_phase.view_card 'Assign Editor' do |overlay|
       expect(overlay).to_not be_completed

--- a/spec/support/pages/task_manager_page.rb
+++ b/spec/support/pages/task_manager_page.rb
@@ -13,7 +13,7 @@ class TaskManagerPage < Page
   def phase phase_name
     expect(page).to have_content(phase_name) # use have_content/css/stuff assertion to avoid sleeps.
     retry_stale_element do
-      PhaseFragment.new(all('.column').detect {|p| p.find('h2').text == phase_name })
+      PhaseFragment.new(all('.column').detect { |p| p.has_css?('h2', text: phase_name) })
     end
   end
 
@@ -34,10 +34,6 @@ class TaskManagerPage < Page
   def message_tasks
     synchronize_content! "Add new card"
     all('.card--message').map { |el| MessageTaskCard.new(el) }
-  end
-
-  def get_first_matching_task name
-    all('.card-content').detect { |card| card.text == name }
   end
 
   def navigate_to_edit_paper


### PR DESCRIPTION
The previous way was causing a stale element reference error because
the column was getting repainted after getting matched.

Also removes an unused method, and unneeded application error check.
