### PR TITLE
don't repost errors to /errors path

### DIFF
--- a/app/assets/javascripts/initializers/error_handler.js.coffee
+++ b/app/assets/javascripts/initializers/error_handler.js.coffee
@@ -8,10 +8,7 @@ ETahi.initializer
     logError = (msg) ->
       if window.teaspoonTesting == true
         console.log("ERROR: " + msg)
-      else
-        ETahi.RESTless.post errorPath,
-          message: msg
-
+        
     container.register('logError:main', logError , instantiate: false)
     application.inject('route', 'logError', 'logError:main')
 


### PR DESCRIPTION
So... um.... we're seeing lots of garbage in the logs.  Backend errors bubbling to the front-end, being re-posted to /errors.  I like the idea of logging the front-end, but only if it's helpful.  It doesn't currently feel helpful.

Just wanted to get this PR out to see if anybody felt strongly about keeping this logging.  The logging is not currently helping us find issues with tahi-staging or plos-currents.

RW + AJP
