### PR TITLE
Remove redis from foreman-stop

### DIFF
--- a/bin/foreman-stop
+++ b/bin/foreman-stop
@@ -1,2 +1,2 @@
 #!/bin/sh
-kill $(ps aux | grep -E 'redis|sidekiq|puma|go|solr' | grep -v grep | awk '{print $2}')
+kill $(ps aux | grep -E 'sidekiq|puma|go|solr' | grep -v grep | awk '{print $2}')


### PR DESCRIPTION
Since redis is a "system-level" concern, don't kill it with an
application script
