### PR TITLE
Loosen the paper policy

### DIFF
--- a/app/policies/papers_policy.rb
+++ b/app/policies/papers_policy.rb
@@ -14,7 +14,7 @@ class PapersPolicy < ApplicationPolicy
   end
 
   def update?
-    can_manage_paper?
+    can_view_paper?
   end
 
   def upload?
@@ -26,7 +26,7 @@ class PapersPolicy < ApplicationPolicy
   end
 
   def download?
-    can_manage_paper?
+    can_view_paper?
   end
 
   def heartbeat?
@@ -38,14 +38,10 @@ class PapersPolicy < ApplicationPolicy
   end
 
   def submit?
-    can_manage_paper?
+    can_view_paper?
   end
 
   private
-
-  def can_manage_paper?
-    current_user.site_admin? || author? || paper_collaborator? || paper_admin? || paper_editor? || paper_reviewer?
-  end
 
   def can_view_paper?
     current_user.site_admin? || connected_users.exists?(current_user) || can_view_manuscript_manager?

--- a/spec/policies/papers_policy_spec.rb
+++ b/spec/policies/papers_policy_spec.rb
@@ -41,6 +41,14 @@ describe PapersPolicy do
     include_examples "author for paper"
   end
 
+  context "paper participant" do
+    before do
+      create(:paper_role, :participant, user: user, paper: paper)
+    end
+
+    include_examples "author for paper"
+  end
+
   context "paper collaborators" do
     before do
       create(:paper_role, :collaborator, user: user, paper: paper)
@@ -79,7 +87,7 @@ describe PapersPolicy do
     it { expect(policy.show?).to be(true) }
     it { expect(policy.upload?).to be(true) }
     it { expect(policy.toggle_editable?).to be(true) }
-    it { expect(policy.submit?).to be(false) }
+    it { expect(policy.submit?).to be(true) }
   end
 
   context "admin on different journal" do


### PR DESCRIPTION
## References
- https://www.pivotaltracker.com/story/show/82119774
## Notes

The above pivotal card was rejected because when an admin added a non-admin as a task participant, the task did not show up on the non-admin's dashboard.  This was because the paper policy was too restrictive and the non-admin did not pass the `show?` policy logic.

So this pull request is being opened without tests because:  we have no idea what the proper policies should be in this case.  The change we made correctly shows the paper on the non-admin dashboard, but the non-admin would get `403`'d when trying to update the paper, for instance.  They would, however, be able to update the task that they are now a participant on.  Is it acceptable to not allow updates on the paper if they are a task participant?  What should the other policy enforcements look like in this situation?

--- AC + TS
