### PR TITLE
Handle 403 gracefully on `papers#manage`

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -45,6 +45,10 @@ class PapersController < ApplicationController
 
   # non RESTful routes
 
+  def manage
+    render 'ember/index'
+  end
+
   def upload
     manuscript = paper.manuscript || paper.build_manuscript
     manuscript.update_attribute :status, "processing"

--- a/app/policies/papers_policy.rb
+++ b/app/policies/papers_policy.rb
@@ -25,6 +25,10 @@ class PapersPolicy < ApplicationPolicy
     can_view_paper?
   end
 
+  def manage?
+    current_user.site_admin? || can_view_manuscript_manager?
+  end
+
   def download?
     can_manage_paper?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,7 @@ Tahi::Application.routes.draw do
 
     member do
       put :upload
-      get :manage, to: 'ember#index'
+      get :manage
       get :download
       put :heartbeat
       put :toggle_editable

--- a/spec/policies/papers_policy_spec.rb
+++ b/spec/policies/papers_policy_spec.rb
@@ -78,6 +78,7 @@ describe PapersPolicy do
 
     it { expect(policy.show?).to be(true) }
     it { expect(policy.upload?).to be(true) }
+    it { expect(policy.manage?).to be(true) }
     it { expect(policy.toggle_editable?).to be(true) }
     it { expect(policy.submit?).to be(false) }
   end

--- a/spec/support/shared_examples/policy_shared_examples.rb
+++ b/spec/support/shared_examples/policy_shared_examples.rb
@@ -36,6 +36,7 @@ shared_examples_for "administrator for paper" do
     expect(policy.show?).to be(true)
     expect(policy.create?).to be(true)
     expect(policy.update?).to be(true)
+    expect(policy.manage?).to be(true)
     expect(policy.upload?).to be(true)
     expect(policy.download?).to be(true)
     expect(policy.heartbeat?).to be(false)
@@ -45,11 +46,12 @@ shared_examples_for "administrator for paper" do
 end
 
 shared_examples_for "author for paper" do
-  it "lets them do everything except keep the paper open and toggle edit mode" do
+  it "lets them do everything except manage, keep the paper open and toggle edit mode" do
     expect(policy.show?).to be(true)
     expect(policy.create?).to be(true)
     expect(policy.update?).to be(true)
     expect(policy.edit?).to be(true)
+    expect(policy.manage?).to be(false)
     expect(policy.upload?).to be(true)
     expect(policy.download?).to be(true)
     expect(policy.heartbeat?).to be(false)
@@ -64,6 +66,7 @@ shared_examples_for "person who cannot see a paper" do
     expect(policy.show?).to be(false)
     expect(policy.create?).to be(true)
     expect(policy.update?).to be(false)
+    expect(policy.manage?).to be(false)
     expect(policy.upload?).to be(false)
     expect(policy.download?).to be(false)
     expect(policy.heartbeat?).to be(false)


### PR DESCRIPTION
- References: https://www.pivotaltracker.com/story/show/82894378

Makes the `manage` route symmetric with other paper routes, which
redirect from the policy.
