### PR TITLE
fix select2 reference

### DIFF
--- a/vendor/assets/bower_components/select2/select2.css.erb
+++ b/vendor/assets/bower_components/select2/select2.css.erb
@@ -105,7 +105,7 @@ html[dir="rtl"] .select2-container .select2-choice > .select2-chosen {
     text-decoration: none;
 
     border: 0;
-    background: url(<%= asset_path 'select2/select2.png' %>) right top no-repeat;
+    background: url(<%= asset_path 'select2.png' %>) right top no-repeat;
     cursor: pointer;
     outline: 0;
 }
@@ -218,7 +218,7 @@ html[dir="rtl"] .select2-container .select2-choice .select2-arrow {
     display: block;
     width: 100%;
     height: 100%;
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat 0 1px;
+    background: url(<%= asset_path 'select2.png' %>) no-repeat 0 1px;
 }
 
 html[dir="rtl"] .select2-container .select2-choice .select2-arrow b {
@@ -256,21 +256,21 @@ html[dir="rtl"] .select2-container .select2-choice .select2-arrow b {
     -webkit-box-shadow: none;
             box-shadow: none;
 
-    background: #fff url(<%= asset_path 'select2/select2.png' %>) no-repeat 100% -22px;
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat 100% -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, #fff), color-stop(0.99, #eee));
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat 100% -22px, -webkit-linear-gradient(center bottom, #fff 85%, #eee 99%);
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat 100% -22px, -moz-linear-gradient(center bottom, #fff 85%, #eee 99%);
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat 100% -22px, linear-gradient(to bottom, #fff 85%, #eee 99%) 0 0;
+    background: #fff url(<%= asset_path 'select2.png' %>) no-repeat 100% -22px;
+    background: url(<%= asset_path 'select2.png' %>) no-repeat 100% -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, #fff), color-stop(0.99, #eee));
+    background: url(<%= asset_path 'select2.png' %>) no-repeat 100% -22px, -webkit-linear-gradient(center bottom, #fff 85%, #eee 99%);
+    background: url(<%= asset_path 'select2.png' %>) no-repeat 100% -22px, -moz-linear-gradient(center bottom, #fff 85%, #eee 99%);
+    background: url(<%= asset_path 'select2.png' %>) no-repeat 100% -22px, linear-gradient(to bottom, #fff 85%, #eee 99%) 0 0;
 }
 
 html[dir="rtl"] .select2-search input {
     padding: 4px 5px 4px 20px;
 
-    background: #fff url(<%= asset_path 'select2/select2.png' %>) no-repeat -37px -22px;
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat -37px -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, #fff), color-stop(0.99, #eee));
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat -37px -22px, -webkit-linear-gradient(center bottom, #fff 85%, #eee 99%);
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat -37px -22px, -moz-linear-gradient(center bottom, #fff 85%, #eee 99%);
-    background: url(<%= asset_path 'select2/select2.png' %>) no-repeat -37px -22px, linear-gradient(to bottom, #fff 85%, #eee 99%) 0 0;
+    background: #fff url(<%= asset_path 'select2.png' %>) no-repeat -37px -22px;
+    background: url(<%= asset_path 'select2.png' %>) no-repeat -37px -22px, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, #fff), color-stop(0.99, #eee));
+    background: url(<%= asset_path 'select2.png' %>) no-repeat -37px -22px, -webkit-linear-gradient(center bottom, #fff 85%, #eee 99%);
+    background: url(<%= asset_path 'select2.png' %>) no-repeat -37px -22px, -moz-linear-gradient(center bottom, #fff 85%, #eee 99%);
+    background: url(<%= asset_path 'select2.png' %>) no-repeat -37px -22px, linear-gradient(to bottom, #fff 85%, #eee 99%) 0 0;
 }
 
 .select2-drop.select2-drop-above .select2-search input {
@@ -278,11 +278,11 @@ html[dir="rtl"] .select2-search input {
 }
 
 .select2-search input.select2-active {
-    background: #fff url(<%= asset_path 'select2/select2-spinner.gif' %>) no-repeat 100%;
-    background: url(<%= asset_path 'select2/select2-spinner.gif' %>) no-repeat 100%, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, #fff), color-stop(0.99, #eee));
-    background: url(<%= asset_path 'select2/select2-spinner.gif' %>) no-repeat 100%, -webkit-linear-gradient(center bottom, #fff 85%, #eee 99%);
-    background: url(<%= asset_path 'select2/select2-spinner.gif' %>) no-repeat 100%, -moz-linear-gradient(center bottom, #fff 85%, #eee 99%);
-    background: url(<%= asset_path 'select2/select2-spinner.gif' %>) no-repeat 100%, linear-gradient(to bottom, #fff 85%, #eee 99%) 0 0;
+    background: #fff url(<%= asset_path 'select2-spinner.gif' %>) no-repeat 100%;
+    background: url(<%= asset_path 'select2-spinner.gif' %>) no-repeat 100%, -webkit-gradient(linear, left bottom, left top, color-stop(0.85, #fff), color-stop(0.99, #eee));
+    background: url(<%= asset_path 'select2-spinner.gif' %>) no-repeat 100%, -webkit-linear-gradient(center bottom, #fff 85%, #eee 99%);
+    background: url(<%= asset_path 'select2-spinner.gif' %>) no-repeat 100%, -moz-linear-gradient(center bottom, #fff 85%, #eee 99%);
+    background: url(<%= asset_path 'select2-spinner.gif' %>) no-repeat 100%, linear-gradient(to bottom, #fff 85%, #eee 99%) 0 0;
 }
 
 .select2-container-active .select2-choice,
@@ -451,7 +451,7 @@ disabled look for disabled choices in the results dropdown
 }
 
 .select2-more-results.select2-active {
-    background: #f4f4f4 url(<%= asset_path 'select2/select2-spinner.gif' %>) no-repeat 100%;
+    background: #f4f4f4 url(<%= asset_path 'select2-spinner.gif' %>) no-repeat 100%;
 }
 
 .select2-results .select2-ajax-error {
@@ -551,7 +551,7 @@ html[dir="rtl"] .select2-container-multi .select2-choices li
 }
 
 .select2-container-multi .select2-choices .select2-search-field input.select2-active {
-    background: #fff url(<%= asset_path 'select2/select2-spinner.gif' %>) no-repeat 100% !important;
+    background: #fff url(<%= asset_path 'select2-spinner.gif' %>) no-repeat 100% !important;
 }
 
 .select2-default {
@@ -610,7 +610,7 @@ html[dir="rtl"] .select2-container-multi .select2-choices .select2-search-choice
 
     font-size: 1px;
     outline: none;
-    background: url(<%= asset_path 'select2/select2.png' %>) right top no-repeat;
+    background: url(<%= asset_path 'select2.png' %>) right top no-repeat;
 }
 html[dir="rtl"] .select2-search-choice-close {
     right: auto;
@@ -693,7 +693,7 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
     .select2-search-choice-close,
     .select2-container .select2-choice abbr,
     .select2-container .select2-choice .select2-arrow b {
-        background-image: url(<%= asset_path 'select2/select2x2.png' %>) !important;
+        background-image: url(<%= asset_path 'select2x2.png' %>) !important;
         background-repeat: no-repeat !important;
         background-size: 60px 40px !important;
     }


### PR DESCRIPTION
`rake bower:resolve` updated this .css to .css.erb and updated the asset_path references.  Not sure why it nested it like `select2/select2`, but it only needed once.

This asset fix has been verified on tahi-staging.

[RW]
