### PR TITLE
fix affiliation field in plos author overlay

### DIFF
--- a/app/assets/stylesheets/ui/typeahead.css.scss
+++ b/app/assets/stylesheets/ui/typeahead.css.scss
@@ -1,8 +1,6 @@
 .typeahead,
 .tt-query,
 .tt-hint {
-  width: 396px;
-  height: 30px;
   padding: 8px 12px;
   font-size: 24px;
   line-height: 30px;


### PR DESCRIPTION
Rm'ing the CSS width and height does fix the visual issue in `Add Authors` overlay.

I'm not sure where else the Twitter Typeahead is being called and thus, styled.  If you have ideas where others are, please note it in the PR.

And, is this the 3rd type of auto typeahead we are using -- In addition to select2 and chosen?  Is Twitter Typeahead still necessary?

[RW]
