### PR TITLE
Only kill processes if there are any running

### DIFF
--- a/bin/foreman-stop
+++ b/bin/foreman-stop
@@ -1,2 +1,7 @@
 #!/bin/sh
-kill $(ps aux | grep -E 'sidekiq|puma|go|solr' | grep -v grep | awk '{print $2}')
+RUNNING_PROCESSES=$(ps aux | grep -E 'sidekiq|puma|go|solr' | grep -v grep | awk '{print $2}')
+if [[ -n $RUNNING_PROCESSES ]]
+then
+  kill $RUNNING_PROCESSES
+fi
+


### PR DESCRIPTION
This commit adds a guard around sending a blank string to kill in order to suppress warnings when booting with foreman
