### PR TITLE
Grep specifically for eventsource server

### DIFF
--- a/bin/foreman-stop
+++ b/bin/foreman-stop
@@ -1,5 +1,5 @@
 #!/bin/sh
-RUNNING_PROCESSES=$(ps aux | grep -E 'sidekiq|puma|go|solr' | grep -v grep | awk '{print $2}')
+RUNNING_PROCESSES=$(ps aux | grep -E 'sidekiq|puma|golang-eventsource|solr' | grep -v grep | awk '{print $2}')
 if [[ -n $RUNNING_PROCESSES ]]
 then
   kill $RUNNING_PROCESSES


### PR DESCRIPTION
The previous implementation matched any process that had the word go(ogle)
in the process name, killing processes that were not meant to be killed
