### PR TITLE
remove phanthom tables

### DIFF
--- a/db/migrate/20141204193328_remove_ghost_table.rb
+++ b/db/migrate/20141204193328_remove_ghost_table.rb
@@ -1,0 +1,15 @@
+class RemoveGhostTable < ActiveRecord::Migration
+  def up
+    if ActiveRecord::Base.connection.table_exists? 'message_participants'
+      drop_table :message_participants
+    end
+
+    if ActiveRecord::Base.connection.table_exists? 'author_groups'
+      drop_table :author_groups
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141203152127) do
+ActiveRecord::Schema.define(version: 20141204193328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,13 +44,6 @@ ActiveRecord::Schema.define(version: 20141203152127) do
     t.string   "caption"
     t.string   "status",          default: "processing"
   end
-
-  create_table "author_groups", force: true do |t|
-    t.string  "name"
-    t.integer "paper_id"
-  end
-
-  add_index "author_groups", ["paper_id"], name: "index_author_groups_on_paper_id", using: :btree
 
   create_table "authors", force: true do |t|
     t.string   "first_name"
@@ -156,16 +149,6 @@ ActiveRecord::Schema.define(version: 20141203152127) do
     t.datetime "updated_at"
     t.string   "status",     default: "processing"
   end
-
-  create_table "message_participants", force: true do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "task_id"
-    t.integer  "participant_id"
-  end
-
-  add_index "message_participants", ["participant_id"], name: "index_message_participants_on_participant_id", using: :btree
-  add_index "message_participants", ["task_id"], name: "index_message_participants_on_task_id", using: :btree
 
   create_table "paper_reviews", force: true do |t|
     t.integer  "task_id"


### PR DESCRIPTION
Addresses the issue that https://www.pivotaltracker.com/story/show/83759162 was attempting to prevent.

Upon further investigation, we've determine that it was not a faulty migration that was causing "ghost" tables from returning. The problem was `author_groups` and `message_participants` table was still on staging despite the fact that `db:migrate:status` indicates the the migration deleting those tables have been executed.

This is a stop gap to prevent this error from propagating to other developer machines.
