### PR TITLE
sync up rubocop and hound

### DIFF
--- a/.reek
+++ b/.reek
@@ -1,2 +1,4 @@
 IrresponsibleModule:
   enabled: false
+TooManyStatements:
+  enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Style/SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: no_space
 Style/StringLiterals:
   Enabled: false
+Style/DotPosition:
+  Enabled: true
+  EnforcedStyle: trailing


### PR DESCRIPTION
- get rid of strict reek restriction

Both Hound and Rubocop prefer you to put the dot at the end of the line when chaining methods across multiple lines
