### PR TITLE
allow configuration of CAS via envvar

### DIFF
--- a/config/initializers/cas_middleware.rb
+++ b/config/initializers/cas_middleware.rb
@@ -1,4 +1,19 @@
-CAS_CONFIG = YAML.load_file("#{Rails.root}/config/cas.yml")[Rails.env]
+CAS_CONFIG = if ENV['CAS_HOST']
+               retval = {
+                 # booleans
+                 'ssl'                      => ENV['CAS_SSL'].present?,
+                 'disable_ssl_verification' => ENV['CAS_DISABLE_SSL_VERIFICATION'].present?
+               }
+               %w(host port service_validate_url callback_url logout_url
+                  login_url uid_field ca_path).each do |key|
+                 val = ENV["CAS_#{key.upcase}"]
+                 retval[key] = val if val
+               end
+               retval
+             else
+               YAML.load_file(File.join(Rails.root, 'config', 'cas.yml'))[Rails.env]
+             end
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :cas, CAS_CONFIG
 end


### PR DESCRIPTION
configure CAS via env vars, useful for heroku and other 12-factor app servers

e.g. set:

```
CAS_HOST=...
CAS_LOGIN_URL=/cas/login
CAS_PORT=443
CAS_SERVICE_VALIDATE_URL=/cas/serviceValidate
CAS_SSL=true
```
