### PR TITLE
temporarily hide DOI UI

### DIFF
--- a/app/assets/javascripts/templates/journal/index.hbs
+++ b/app/assets/javascripts/templates/journal/index.hbs
@@ -32,7 +32,7 @@
 
   {{render "manuscript_manager_template/index" manuscriptManagerTemplates}}
 
-  <div class="admin-section admin-doi-setting-section">
+  <div class="admin-section admin-doi-setting-section hide">
     <h2 class="admin-section-title">Document Object Identifier</h2>
 
     <p>This is the document identifier for this journal's articles, which appears alongside each article.</p>


### PR DESCRIPTION
For everyone to see:

We're hiding the DOI UI for a release. 
We should re-enable this after the DOI is solidified.
