### PR TITLE
allow configuration of callback URL to ihat

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -50,7 +50,8 @@ class PapersController < ApplicationController
   end
 
   def upload
-    IHatJobRequest.new(paper: paper).queue(file_url: params[:url], callback_url: ihat_callback_url)
+    IHatJobRequest.new(paper: paper).queue(file_url: params[:url],
+                                           callback_url: ENV.fetch('IHAT_CALLBACK_URL', ihat_callback_url))
     render json: paper
   end
 


### PR DESCRIPTION
When trying to set up Tahi via fig, I was finding that the automatically generated callback URL `http://localhost:8080/ihat_jobs` did not work, because localhost would resolve different in the container used for ihat. This is a workaround for this issue. It's not the best solution, but I can't think of a better one.