### PR TITLE
modify permission on can_view_manuscript_manager policy

### DIFF
--- a/app/policies/papers_policy.rb
+++ b/app/policies/papers_policy.rb
@@ -58,7 +58,9 @@ class PapersPolicy < ApplicationPolicy
   end
 
   def can_view_manuscript_manager?
-    current_user.roles.where(journal_id: paper.journal).where(can_view_all_manuscript_managers: true).exists?
+    current_user.roles.where(journal_id: paper.journal).
+      where("can_view_assigned_manuscript_managers = ? OR can_view_all_manuscript_managers = ?", true, true).
+      exists?
   end
 
   def author?

--- a/spec/policies/papers_policy_spec.rb
+++ b/spec/policies/papers_policy_spec.rb
@@ -91,6 +91,18 @@ describe PapersPolicy do
     it { expect(policy.submit?).to be(true) }
   end
 
+  context "user with can_view_assigned_manuscript_managers can toggle editable" do
+    let(:user) do
+      FactoryGirl.create(
+        :user,
+        roles: [ FactoryGirl.create(:role, :editor, journal: journal, can_view_assigned_manuscript_managers: true) ],
+      )
+    end
+    let(:journal) { FactoryGirl.create(:journal, papers: [paper]) }
+
+    it { expect(policy.toggle_editable?).to be(true) }
+  end
+
   context "admin on different journal" do
     let(:journal) { FactoryGirl.create(:journal) }
     let(:user) do


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/84435936

Now anyone who can view assigned or all manuscript managers can toggle editable or do other manuscript manager permission things