### PR TITLE
show doi when paper is submitted or not editable.

### DIFF
--- a/app/assets/javascripts/templates/paper/_task-list.hbs
+++ b/app/assets/javascripts/templates/paper/_task-list.hbs
@@ -1,3 +1,7 @@
+{{#if doi}}
+<div class="task-list-doi"><strong>DOI:</strong> {{doi}}</div>
+{{/if}}
+
 {{#if assignedTasks}}
   <div id="paper-assigned-tasks">
     {{#each task in assignedTasks}}

--- a/app/assets/javascripts/templates/paper/edit.hbs
+++ b/app/assets/javascripts/templates/paper/edit.hbs
@@ -6,9 +6,6 @@
 
     <aside>
       <div class="task-list">
-        {{#if doi}}
-          <div class="task-list-doi"><strong>DOI:</strong> {{doi}}</div>
-        {{/if}}
         {{partial "paper/task-list"}}
         <a {{action "submit" target="view"}} {{bind-attr class=":button-primary :button--wide allMetadataTasksCompleted:button--green:button--disabled"}} href="#">Submit</a>
       </div>

--- a/spec/features/doi_paper_spec.rb
+++ b/spec/features/doi_paper_spec.rb
@@ -54,6 +54,25 @@ feature "Editing paper", selenium: true, js: true do
         end
         expect(page.current_path).to eq "/papers/vicious/robots.8888/edit"
       end
+
+      scenario "shows the doi on the page when paper is submitted or uneditable" do
+        visit '/'
+        click_button 'Create New Submission'
+        within('.overlay-container') do |page|
+          fill_in 'paper-short-title', with: "A paper with doi"
+          click_button 'Create'
+        end
+        wait_for_ajax
+
+        click_link 'Workflow'
+        uncheck 'paper-editable'
+        click_link 'Manuscript'
+
+        within ".task-list-doi" do
+          expect(page).to have_content "DOI: vicious/robots.8888"
+        end
+        expect(page.current_path).to eq "/papers/vicious/robots.8888"
+      end
     end
 
   end


### PR DESCRIPTION
Move show-doi logic to task_list partial so it's hit even when paper is not editable.