### PR TITLE
show doi on paper with no metadata tasks

### DIFF
--- a/app/assets/javascripts/templates/paper/edit.hbs
+++ b/app/assets/javascripts/templates/paper/edit.hbs
@@ -16,6 +16,11 @@
 
     <article>
       <div class="edit-paper">
+        {{#if doi}}
+          <div id="no-sidebar-doi" class="task-list-doi">
+            <strong>DOI:</strong> {{doi}}
+          </div>
+        {{/if}}
         <a {{action "submit" target="view"}} {{bind-attr class=":no-sidebar-submit-manuscript :button-primary :button--wide allMetadataTasksCompleted:button--green:button--disabled"}} href="#">Submit Manuscript</a>
         {{edit-paper-button action="toggleEditing" canEdit=canEdit isEditing=isEditing}}
         <span {{bind-attr class=":glyphicon :glyphicon-lock locked::hidden"}}></span>

--- a/app/assets/stylesheets/screens/papers.css.scss
+++ b/app/assets/stylesheets/screens/papers.css.scss
@@ -122,13 +122,24 @@ html.control-bar-sub-nav-active #paper-body .oo-ui-toolbar {
   .no-sidebar-submit-manuscript {
     float: right;
     display: none;
+    clear: right;
+  }
+
+  #no-sidebar-doi {
+    float: right;
+    display: none;
+    margin-bottom: 0;
+    margin-top: -30px;
   }
 
   &.sidebar-empty {
     max-width: 840px;
     min-width: 840px; // override default
 
-    .no-sidebar-submit-manuscript { display: block; }
+    .no-sidebar-submit-manuscript,
+    #no-sidebar-doi {
+      display: block;
+    }
 
     aside { display: none; }
     article {


### PR DESCRIPTION
Show doi above 'Submit Manuscript' button when no metadata tasks exist.