### PR TITLE
Doi with id fallback

### DIFF
--- a/app/assets/javascripts/controllers/overlays/paper_new_overlay_controller.js.coffee
+++ b/app/assets/javascripts/controllers/overlays/paper_new_overlay_controller.js.coffee
@@ -11,9 +11,6 @@ ETahi.PaperNewOverlayController = Ember.ObjectController.extend
     createNewPaper: ->
       @get('model').save().then (paper) =>
         @send('addPaperToEventStream', paper)
-        # TODO: this is an ember data bug that will likely be solved after upgrading
-        # to beta 11 or later.  check back then.
-        paper.reload().then (newPaper) =>
-          @transitionToRoute 'paper.edit', newPaper
+        @transitionToRoute 'paper.edit', paper
       , (response) =>
         @flash.displayErrorMessagesFromRailsResponse response

--- a/app/assets/javascripts/models/lite_paper.js.coffee
+++ b/app/assets/javascripts/models/lite_paper.js.coffee
@@ -2,6 +2,7 @@ a = DS.attr
 ETahi.LitePaper = DS.Model.extend
   title: a('string')
   shortTitle: a('string')
+  doi: a('string')
   submitted: a('boolean')
   relatedAtDate: a('date')
   roles: a()

--- a/app/assets/javascripts/router.js.coffee
+++ b/app/assets/javascripts/router.js.coffee
@@ -2,11 +2,7 @@
 ETahi.Router.map ()->
   @route('flow_manager')
 
-  @resource 'paper', { path: '/papers/:publisher_prefix/:suffix' }, ->
-    @route('edit')
-    @route('manage')
-
-  @resource 'paper', { path: '/papers/:paper_id' }, ->
+  @resource 'paper', { path: '/papers/*paper_id' }, ->
     @route('edit')
     @route('manage')
 

--- a/app/assets/javascripts/routes/paper_route.js.coffee
+++ b/app/assets/javascripts/routes/paper_route.js.coffee
@@ -25,3 +25,9 @@ ETahi.PaperRoute = Ember.Route.extend
       return setFormats(window.ETahi.supportedDownloadFormats)
 
     Em.$.getJSON('/formats', setFormats)
+
+  serialize: (model, params) ->
+    if doi = model.get('doi')
+      paper_id: doi
+    else
+      @_super(model, params)

--- a/app/assets/javascripts/routes/paper_route.js.coffee
+++ b/app/assets/javascripts/routes/paper_route.js.coffee
@@ -1,16 +1,13 @@
 ETahi.PaperRoute = Ember.Route.extend
   model: (params) ->
-    if params.paper_id
+    [publisher_prefix, suffix] = params.paper_id.split('/')
+    if publisher_prefix && suffix
+      doi = "#{publisher_prefix}/#{suffix}"
+      ETahi.RESTless.get("/papers/#{doi}").then (data) =>
+        @store.pushPayload('paper', data)
+        @store.all('paper').find (paper) => paper.get('doi') == doi
+    else
       @store.find('paper', params.paper_id)
-    else if params.publisher_prefix && params.suffix
-      doi = params.publisher_prefix + '/' + params.suffix
-      @store.find('paper', doi)
-
-  afterModel: (paper, transition) ->
-    if paper.id
-      doi = paper.get("doi")
-      if doi
-        @transitionTo transition.targetName, doi
 
   setupController: (controller, model) ->
     controller.set('model', model)

--- a/app/assets/javascripts/routes/paper_route.js.coffee
+++ b/app/assets/javascripts/routes/paper_route.js.coffee
@@ -1,6 +1,6 @@
 ETahi.PaperRoute = Ember.Route.extend
   model: (params) ->
-    [publisher_prefix, suffix] = params.paper_id.split('/')
+    [publisher_prefix, suffix] = params.paper_id.toString().split('/')
     if publisher_prefix && suffix
       doi = "#{publisher_prefix}/#{suffix}"
       ETahi.RESTless.get("/papers/#{doi}").then (data) =>

--- a/app/assets/javascripts/services/rest_less.js.coffee
+++ b/app/assets/javascripts/services/rest_less.js.coffee
@@ -7,6 +7,7 @@ ETahi.RESTless = Ember.Namespace.create
         data: data
         success: resolve
         error: reject
+        dataType: 'json'
 
   delete: (path, data) ->
     @ajaxPromise('DELETE', path, data)

--- a/app/assets/javascripts/templates/dashboard_link.hbs
+++ b/app/assets/javascripts/templates/dashboard_link.hbs
@@ -1,6 +1,6 @@
 <li class="dashboard-paper-title">
   {{#link-to "paper.edit"
-             view.content.id
+             view.linkIdentifier
              class="link-tooltip"
              data-toggle="tooltip"
              title=view.content.roleList}}

--- a/app/assets/javascripts/views/dashboard_link_view.js.coffee
+++ b/app/assets/javascripts/views/dashboard_link_view.js.coffee
@@ -3,6 +3,10 @@ ETahi.DashboardLinkView = Em.View.extend
 
   paperId: Ember.computed.alias('content.id')
 
+  linkIdentifier: (->
+    @get('content.doi') || @get('content.id')
+  ).property('content.id', 'content.doi')
+
   unreadCommentsList: Ember.computed 'unreadComments.@each.readAt', 'unreadComments.@each.paperId', ->
     paperId = @get('paperId')
     @get('unreadComments').filter (c) -> c.get('paperId') == paperId && !c.get('readAt')

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -126,8 +126,14 @@ class PapersController < ApplicationController
   end
 
   def paper
-    doi_or_id = params[:id] || params[:doi]
-    @paper ||= Paper.find(doi_or_id) if doi_or_id
+    @paper ||= begin
+      if params[:id].present?
+        Paper.find(params[:id])
+      elsif params[:publisher_prefix].present? && params[:suffix].present?
+        doi = "#{params[:publisher_prefix]}/#{params[:suffix]}"
+        Paper.find_by!(doi: doi)
+      end
+    end
   end
 
   def enforce_policy

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -42,10 +42,6 @@ class Paper < ActiveRecord::Base
     def unpublished
       where(published_at: nil)
     end
-
-    def find(param)
-      Doi.valid?(param) ? find_by_doi!(param) : super
-    end
   end
 
   def role_for(role:, user:)

--- a/app/serializers/lite_paper_serializer.rb
+++ b/app/serializers/lite_paper_serializer.rb
@@ -1,5 +1,5 @@
 class LitePaperSerializer < ActiveModel::Serializer
-  attributes :id, :title, :short_title, :submitted, :roles, :related_at_date
+  attributes :id, :title, :short_title, :submitted, :roles, :related_at_date, :doi
 
   def related_at_date
     scoped_user.paper_roles.where(paper: object).order(created_at: :desc).pluck(:created_at).first

--- a/app/services/doi.rb
+++ b/app/services/doi.rb
@@ -1,5 +1,9 @@
 class Doi
-  FORMAT = %r{([\w\d\-\.]+/[^/]+)}
+  PUBLISHER_PREFIX_FORMAT = /[\w\d\-\.]+/
+  SUFFIX_FORMAT = /[^\/]+/
+
+  FORMAT = %r{(#{PUBLISHER_PREFIX_FORMAT}\/#{SUFFIX_FORMAT})}
+
   attr_reader :journal
 
   delegate :last_doi_issued,

--- a/app/services/doi.rb
+++ b/app/services/doi.rb
@@ -1,8 +1,7 @@
 class Doi
   PUBLISHER_PREFIX_FORMAT = /[\w\d\-\.]+/
   SUFFIX_FORMAT = /[^\/]+/
-
-  FORMAT = %r{(#{PUBLISHER_PREFIX_FORMAT}\/#{SUFFIX_FORMAT})}
+  FORMAT = %r{(#{PUBLISHER_PREFIX_FORMAT}/#{SUFFIX_FORMAT})}
 
   attr_reader :journal
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,9 +107,9 @@ Tahi::Application.routes.draw do
     end
   end
 
-  get '/papers/:id' => 'papers#show',
-      constraints: { id: Doi::FORMAT },
-      as: :paper_with_doi
+  get '/papers/:publisher_prefix/:suffix' => 'papers#show',
+    constraints: { publisher_prefix: Doi::PUBLISHER_PREFIX_FORMAT, suffix: Doi::SUFFIX_FORMAT },
+    as: :paper_with_doi
 
   resources :comments, only: [:create, :show]
   resources :participations, only: [:create, :show, :destroy]

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -102,39 +102,6 @@ describe Paper do
         expect(Paper.unpublished).to_not include published_paper
       end
     end
-
-    describe ".find" do
-      let!(:paper_with_doi) { create :paper, doi: doi }
-
-      context "when given a doi" do
-        it "returns a paper" do
-          expect(Paper.find(doi)).to eq paper_with_doi
-        end
-      end
-
-      context "when given an id" do
-        it "returns a paper" do
-          expect(Paper.find(paper_with_doi.id)).to eq paper_with_doi
-        end
-      end
-
-      context "when given a non-existent doi" do
-        it "returns raises an exception" do
-          expect {
-            Paper.find("bogus/doi.100")
-          }.to raise_error ActiveRecord::RecordNotFound
-        end
-      end
-
-      context "when given a non-existent ID" do
-        it "returns raises an exception" do
-          expect {
-            Paper.find(0)
-          }.to raise_error ActiveRecord::RecordNotFound
-        end
-      end
-
-    end
   end
 
   describe "#editor" do


### PR DESCRIPTION
We're currently loading the paper too many times in order to get the DOI in the url.

For example, always transitioning to the This is a result of not being able to reliably know if the paper has been issued one or not.

This "works" in master, but relies on a bug in ember to prevent the `/` in the DOI from being properly encoded. Once upgraded (1.8.1), this unsurprisingly breaks. With this in mind, it seemed like a good opportunity to get rid of some of the unnecessary requests.

To accomplish this, we make our ember route's dynamic segment a bit smarter so we can find the paper by either the `id` or the pieces of it's `doi` - purposefully avoiding the `/` to play nicer with rails/ember URI encoding conventions.