### PR TITLE
exists?(ar_obj) deprecated in favor of exists?(ar_obj.id)

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -117,7 +117,7 @@ class Paper < ActiveRecord::Base
     # paper.editor?(user1)  # => true
     define_method("#{relation.singularize}?".to_sym) do |user|
       return false unless user.present?
-      send(relation).exists?(user)
+      send(relation).exists?(user.id)
     end
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -129,7 +129,7 @@ class ApplicationPolicy
   end
 
   def can_administer_journal?(journal)
-    super_admin? || administered_journals.exists?(journal)
+    super_admin? || administered_journals.exists?(journal.id)
   end
 
   def author_of_paper?(paper)

--- a/app/policies/task_access_criteria.rb
+++ b/app/policies/task_access_criteria.rb
@@ -25,7 +25,7 @@ module TaskAccessCriteria
 
   # criteria used by this mixin
   def metadata_task_collaborator?
-    task.is_metadata? && paper.collaborators.exists?(current_user)
+    task.is_metadata? && paper.collaborators.exists?(current_user.id)
   end
 
   def can_view_all_manuscript_managers_for_journal?
@@ -39,7 +39,7 @@ module TaskAccessCriteria
   end
 
   def task_participant?
-    task.participants.exists?(current_user)
+    task.participants.exists?(current_user.id)
   end
 
   def allowed_manuscript_information_task?
@@ -51,6 +51,6 @@ module TaskAccessCriteria
   end
 
   def has_paper_role?
-    paper.assigned_users.exists?(current_user)
+    paper.assigned_users.exists?(current_user.id)
   end
 end


### PR DESCRIPTION
See above. I think it's safe to merge if green.
