### PR TITLE
[#85817976] Can now open the assign reviewers task

### DIFF
--- a/app/assets/javascripts/components/select2_multiple_component.js.coffee
+++ b/app/assets/javascripts/components/select2_multiple_component.js.coffee
@@ -2,6 +2,6 @@ ETahi.Select2MultipleComponent = ETahi.Select2Component.extend
   multiSelect: true
 
   setSelectedData: (->
-    @.$().select2('val', @get('selectedData').mapProperty('id'))
+    @.$().select2('val', (@get('selectedData') || []).mapProperty('id'))
   ).observes('selectedData')
 

--- a/spec/features/manuscript_manager_spec.rb
+++ b/spec/features/manuscript_manager_spec.rb
@@ -82,6 +82,21 @@ feature "Manuscript Manager", js: true, selenium: true, solr: true do
     expect(task_manager_page.card_count).to eq(before - 1)
   end
 
+  # Preventing a regression
+  scenario 'Opening an AssignReviewers task' do
+    dashboard_page = DashboardPage.new
+    paper_page = dashboard_page.view_submitted_paper paper
+    task_manager_page = paper_page.visit_task_manager
+
+    within 'body' do
+      find('.card-content', text: 'Assign Reviewer').click
+
+      expect(task_manager_page).to have_css('.overlay-content', text: 'Assign Reviewers')
+      expect(task_manager_page).to have_css('.overlay-content', text: 'Discussion')
+      expect(task_manager_page).to have_no_application_error
+    end
+  end
+
   scenario "Admin can assign a paper to themselves" do
     dashboard_page = DashboardPage.new
     paper_page = dashboard_page.view_submitted_paper paper


### PR DESCRIPTION
We are now able to open the popup.

There are other things broken, which we've made another bug card for and are working on.

— AJP DT