### PR TITLE
Remove “null” status message

### DIFF
--- a/app/assets/javascripts/helpers/display_or.js.coffee
+++ b/app/assets/javascripts/helpers/display_or.js.coffee
@@ -1,2 +1,2 @@
 Ember.Handlebars.helper 'display', (value, options) ->
-  if Em.isEmpty(value) then options.hash.or else value
+  if Em.isEmpty(value) then options.hash.or else value.htmlSafe()

--- a/app/assets/javascripts/templates/paper/edit.hbs
+++ b/app/assets/javascripts/templates/paper/edit.hbs
@@ -21,7 +21,7 @@
         <a {{action "submit" target="view"}} {{bind-attr class=":no-sidebar-submit-manuscript :button-primary :button--wide allMetadataTasksCompleted:button--green:button--disabled"}} href="#">Submit Manuscript</a>
         {{edit-paper-button action="toggleEditing" canEdit=canEdit isEditing=isEditing}}
         <span {{bind-attr class=":glyphicon :glyphicon-lock locked::hidden"}}></span>
-        <span class="edit-paper-lock-message">{{{statusMessage}}} {{time-ago time=savedAt}}</span>
+        <span class="edit-paper-lock-message">{{display statusMessage or=""}} {{time-ago time=savedAt}}</span>
       </div>
 
       <div class="manuscript-container">


### PR DESCRIPTION
References: https://www.pivotaltracker.com/story/show/85800746

Using {{{}}} with the status message was displaying `null` as an html-
safe string. We use the `display` helper instead to default to empty
and make the `display` helper html-safe.

-------------------
AP + CT