### PR TITLE
Scope tasks to journal in site-admin flow manager

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def accessible_journals
+    site_admin? ? Journal.all : journals
+  end
+
   def self.search_users(query: nil, assigned_users_in_journal_id: nil)
     if query
       sanitized_query = connection.quote_string(query.to_s.downcase) + '%'

--- a/app/services/flow_query.rb
+++ b/app/services/flow_query.rb
@@ -9,8 +9,7 @@ class FlowQuery
   def tasks
     return Task.none if flow.query.nil?
 
-    scope = Task.all
-    scope = by_journal(scope) unless user.site_admin?
+    scope = by_journal(Task.all)
 
     flow.query.keys.each do |query_scope|
       scope = send(query_scope, scope)
@@ -45,7 +44,7 @@ class FlowQuery
   end
 
   def by_journal(scope)
-    journals = flow.default? ? user.journals : [flow.journal]
+    journals = flow.default? ? user.accessible_journals : [flow.journal]
     scope.on_journals(journals)
   end
 end

--- a/spec/services/flow_query_spec.rb
+++ b/spec/services/flow_query_spec.rb
@@ -31,9 +31,8 @@ describe FlowQuery do
       context "for a site admin" do
         context "for a default flow" do
           it "does not scope tasks" do
-            flow = FactoryGirl.build(:flow, query: {state: :completed})
+            flow = FactoryGirl.build(:flow, :default, query: {state: :completed})
             tasks = FlowQuery.new(site_admin, flow).tasks
-
             expect(tasks).to include(user_task)
             expect(tasks).to include(other_task)
           end


### PR DESCRIPTION
References: https://www.pivotaltracker.com/story/show/86118656

Journal-specific flows should still scope papers/cards to the journal whether or not a site admin is looking at them.


--------------------
AP + CT