### PR TITLE
Add 'hidden' class to 'Add Dataset' button

### DIFF
--- a/app/assets/javascripts/templates/components/additional-datasets.hbs
+++ b/app/assets/javascripts/templates/components/additional-datasets.hbs
@@ -3,6 +3,6 @@
     {{#datum-definition datum=datum}}
       {{yield}}
     {{/datum-definition}}
-    <button class="button-secondary knockout button--green" {{action "additionalDataAction"}}>Add Dataset</button>
+    <button class="button-secondary knockout button--green hidden" {{action "additionalDataAction"}}>Add Dataset</button>
   </div>
 {{/each}}


### PR DESCRIPTION
References: https://www.pivotaltracker.com/story/show/84948610

Hides 'Add Dataset' button because it is/feels broken and the card it is on will soon be heavily reworked.