### PR TITLE
Autosave changes to paperTitle when navigating to new page/view

### DIFF
--- a/app/assets/javascripts/components/question_component.js.coffee
+++ b/app/assets/javascripts/components/question_component.js.coffee
@@ -5,7 +5,7 @@ ETahi.QuestionComponent = Ember.Component.extend
 
   model: (->
     ident = @get('ident')
-    throw "you must specify an ident" unless ident
+    throw new Error("You must specify an ident, set to name attr") unless ident
 
     question = @get('task.questions').findProperty('ident', ident)
 

--- a/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
+++ b/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
@@ -64,13 +64,13 @@ ETahi.PaperEditController = ETahi.BasePaperController.extend
       @get('visualEditor').startEditing()
 
     toggleEditing: ->
-      if @get('lockedBy') #unlocking
+      if @get('lockedBy') #unlocking -> Allowing others to edit
         @set('body', @get('visualEditor.bodyHtml'))
         @set('lockedBy', null)
         @send('stopEditing')
         @get('model').save().then (paper) =>
           @set('saveState', true)
-      else #locking
+      else #locking -> Editing Paper (locking others out)
         @set('lockedBy', @getCurrentUser())
         @get('model').save().then (paper) =>
           @send('startEditing')

--- a/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
+++ b/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
@@ -77,6 +77,7 @@ ETahi.PaperEditController = ETahi.BasePaperController.extend
           @set('saveState', false)
 
     savePaper: ->
+      return if ETahi.environment == undefined
       return unless @get('model.editable')
       @get('model').save().then (paper) =>
         @set('saveState', true)

--- a/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
+++ b/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
@@ -77,8 +77,7 @@ ETahi.PaperEditController = ETahi.BasePaperController.extend
           @set('saveState', false)
 
     savePaper: ->
-      # TODO return if ETahi.environment == 'test'
-      return if ETahi.environment == undefined
+      return if ETahi.environment == 'test'
       return unless @get('model.editable')
       @get('model').save().then (paper) =>
         @set('saveState', true)

--- a/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
+++ b/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
@@ -77,6 +77,7 @@ ETahi.PaperEditController = ETahi.BasePaperController.extend
           @set('saveState', false)
 
     savePaper: ->
+      # TODO return if ETahi.environment == 'test'
       return if ETahi.environment == undefined
       return unless @get('model.editable')
       @get('model').save().then (paper) =>

--- a/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
+++ b/app/assets/javascripts/controllers/paper_edit_controller.js.coffee
@@ -77,7 +77,6 @@ ETahi.PaperEditController = ETahi.BasePaperController.extend
           @set('saveState', false)
 
     savePaper: ->
-      return if ETahi.environment == 'test'
       return unless @get('model.editable')
       @get('model').save().then (paper) =>
         @set('saveState', true)

--- a/app/assets/javascripts/initializers/error_handler.js.coffee
+++ b/app/assets/javascripts/initializers/error_handler.js.coffee
@@ -14,15 +14,19 @@ ETahi.initializer
 
     # The global error handler
     Ember.onerror = (error) ->
-      # TODO Check how it looks when the error happens in the app.
-      # YES can delete b/c it is not needed in qunit tests.
-      # logError("\n" + error.message + "\n" + error.stack + "\n")
+      # console.log('Ember.onerror', error)
+      if ETahi.environment == 'test'
+        # if we do not print this, you can not click on the stack trace
+        # and jump to the code where the error happened.
+        console.log(error.stack)
+        # in test, this error is caught by QUnit and displayed in the UI
+        throw error
 
-      if ETahi.environment == 'development' || ETahi.environment == 'test'
+      if ETahi.environment == 'development'
+        flash.displayMessage 'error', error
         throw error
       else
         flash.displayMessage 'error', error
-        # TODO run the server in staging mode and see if this works correctly.
         if Bugsnag && Bugsnag.notifyException
           Bugsnag.notifyException(error, "Uncaught Ember Error")
 

--- a/app/assets/javascripts/initializers/error_handler.js.coffee
+++ b/app/assets/javascripts/initializers/error_handler.js.coffee
@@ -15,8 +15,11 @@ ETahi.initializer
     # The global error handler
     Ember.onerror = (error) ->
       logError("\n" + error.message + "\n" + error.stack + "\n")
-      window.ErrorNotifier.notify(error, "Uncaught Ember Error")
+      # TODO FIX THIS
+      # window.ErrorNotifier.notify(error, "Uncaught Ember Error")
       if ETahi.environment == 'development'
+        throw error
+      else if ETahi.environment == undefined # TODO FIX THIS
         throw error
       else
         flash.displayMessage 'error', error

--- a/app/assets/javascripts/initializers/error_handler.js.coffee
+++ b/app/assets/javascripts/initializers/error_handler.js.coffee
@@ -17,10 +17,7 @@ ETahi.initializer
       logError("\n" + error.message + "\n" + error.stack + "\n")
       # TODO FIX THIS
       # window.ErrorNotifier.notify(error, "Uncaught Ember Error")
-      if ETahi.environment == 'development'
-        throw error
-      # TODO FIX THIS. Env is not set in QUnit
-      else if ETahi.environment == undefined
+      if ETahi.environment == 'development' || ETahi.environment == 'test'
         throw error
       else
         flash.displayMessage 'error', error

--- a/app/assets/javascripts/initializers/error_handler.js.coffee
+++ b/app/assets/javascripts/initializers/error_handler.js.coffee
@@ -19,7 +19,8 @@ ETahi.initializer
       # window.ErrorNotifier.notify(error, "Uncaught Ember Error")
       if ETahi.environment == 'development'
         throw error
-      else if ETahi.environment == undefined # TODO FIX THIS
+      # TODO FIX THIS. Env is not set in QUnit
+      else if ETahi.environment == undefined
         throw error
       else
         flash.displayMessage 'error', error

--- a/app/assets/javascripts/initializers/error_handler.js.coffee
+++ b/app/assets/javascripts/initializers/error_handler.js.coffee
@@ -9,12 +9,12 @@ ETahi.initializer
       e = new Error(msg)
       console.log(e.stack || e.message)
 
+    # TODO investigate this more
     container.register('logError:main', logError , instantiate: false)
     application.inject('route', 'logError', 'logError:main')
 
     # The global error handler
     Ember.onerror = (error) ->
-      # console.log('Ember.onerror', error)
       if ETahi.environment == 'test'
         # if we do not print this, you can not click on the stack trace
         # and jump to the code where the error happened.

--- a/app/assets/javascripts/initializers/error_handler.js.coffee
+++ b/app/assets/javascripts/initializers/error_handler.js.coffee
@@ -14,13 +14,17 @@ ETahi.initializer
 
     # The global error handler
     Ember.onerror = (error) ->
-      logError("\n" + error.message + "\n" + error.stack + "\n")
-      # TODO FIX THIS
-      # window.ErrorNotifier.notify(error, "Uncaught Ember Error")
+      # TODO Check how it looks when the error happens in the app.
+      # YES can delete b/c it is not needed in qunit tests.
+      # logError("\n" + error.message + "\n" + error.stack + "\n")
+
       if ETahi.environment == 'development' || ETahi.environment == 'test'
         throw error
       else
         flash.displayMessage 'error', error
+        # TODO run the server in staging mode and see if this works correctly.
+        if Bugsnag && Bugsnag.notifyException
+          Bugsnag.notifyException(error, "Uncaught Ember Error")
 
     $(document).ajaxError (event, jqXHR, ajaxSettings, thrownError) ->
       {type, url} = ajaxSettings

--- a/app/assets/javascripts/mixins/dragndrop.js.coffee
+++ b/app/assets/javascripts/mixins/dragndrop.js.coffee
@@ -15,9 +15,9 @@ DragNDrop.draggingStopped = (dropTargetsSelector)->
 DragNDrop.Dragable = Ember.Mixin.create
   attributeBindings: 'draggable'
   draggable: 'true'
-  dragStart: (e) -> throw "Implement dragStart"
+  dragStart: (e) -> throw new Error("Implement dragStart")
 
 DragNDrop.Droppable = Ember.Mixin.create
   dragEnter: DragNDrop.cancel
   dragOver: DragNDrop.cancel
-  drop: (e) -> throw "Implement drop"
+  drop: (e) -> throw new Error("Implement drop")

--- a/app/assets/javascripts/templates/paper/edit.hbs
+++ b/app/assets/javascripts/templates/paper/edit.hbs
@@ -1,7 +1,10 @@
 {{partial "paper/control-bar"}}
 
+{{flash-messages messages=flash.messages classNames="flash-messages--on-paper-edit-page"}}
+
 <div class="ve-toolbar-underside"></div>
 <div id="tahi-container">
+
   <main {{bind-attr class="hasNoMetaDataTasks:sidebar-empty"}}>
 
     <aside>

--- a/app/assets/javascripts/views/forms/chosen-select.js.coffee
+++ b/app/assets/javascripts/views/forms/chosen-select.js.coffee
@@ -46,7 +46,7 @@ ETahi.ChosenView = Ember.Select.extend
 
   warnValue: ( ->
     if @get('multiple') && !@get('selection')
-      throw "You should use the selection option with a multiple select rather than value"
+      throw new Error("You should use the selection option with a multiple select rather than value")
   ).on('init')
 
   observeSelection: (->

--- a/app/assets/javascripts/views/paper_edit_view.js.coffee
+++ b/app/assets/javascripts/views/paper_edit_view.js.coffee
@@ -71,6 +71,10 @@ ETahi.PaperEditView = Ember.View.extend ETahi.RedirectsIfEditable,
     Ember.$(document).off 'keyup.autoSave'
   ).on('willDestroyElement')
 
+  saveTitleChanges: (->
+    @timeoutSave();
+  ).on('willDestroyElement')
+
   timeoutSave: ->
     @saveVisualEditorChanges()
     @get('controller').send('savePaper')

--- a/app/assets/javascripts/views/paper_edit_view.js.coffee
+++ b/app/assets/javascripts/views/paper_edit_view.js.coffee
@@ -72,7 +72,7 @@ ETahi.PaperEditView = Ember.View.extend ETahi.RedirectsIfEditable,
   ).on('willDestroyElement')
 
   saveTitleChanges: (->
-    @timeoutSave();
+    @timeoutSave()
   ).on('willDestroyElement')
 
   timeoutSave: ->

--- a/app/assets/stylesheets/tahi.scss
+++ b/app/assets/stylesheets/tahi.scss
@@ -147,6 +147,11 @@ html.control-bar-sub-nav-active.matte.paper-submitted #tahi-container {
 .flash-messages--below-control-bar {
   margin-top: $tahi-control-bar-height;
 }
+.flash-messages--on-paper-edit-page {
+  top: $tahi-control-bar-height + $ve-toolbar-height - 2px;
+  position: absolute;
+  width: 100%
+}
 
 // Main Content:
 

--- a/app/assets/stylesheets/tahi.scss
+++ b/app/assets/stylesheets/tahi.scss
@@ -148,9 +148,9 @@ html.control-bar-sub-nav-active.matte.paper-submitted #tahi-container {
   margin-top: $tahi-control-bar-height;
 }
 .flash-messages--on-paper-edit-page {
-  top: $tahi-control-bar-height + $ve-toolbar-height - 2px;
   position: absolute;
-  width: 100%
+  top: $tahi-control-bar-height + $ve-toolbar-height - 2px;
+  width: 100%;
 }
 
 // Main Content:

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -27,3 +27,5 @@ $tahi-control-bar-height: 60px;
 $tahi-navigation-width: 280px;
 
 $message-body-width: 700px;
+
+$ve-toolbar-height: 45px;

--- a/app/views/shared/_bugsnag_javascript.html.haml
+++ b/app/views/shared/_bugsnag_javascript.html.haml
@@ -1,3 +1,4 @@
+- # TODO REMOVE JS FROM HERE AND MOVE IT INTO ERROR_HANDLER.JS.COFFE
 - if ENV['BUGSNAG_JAVASCRIPT_API_KEY']
   %script{ src:"//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js",
     "data-apikey" => "#{ENV["BUGSNAG_JAVASCRIPT_API_KEY"]}" }

--- a/app/views/shared/_bugsnag_javascript.html.haml
+++ b/app/views/shared/_bugsnag_javascript.html.haml
@@ -1,17 +1,6 @@
-- # TODO REMOVE JS FROM HERE AND MOVE IT INTO ERROR_HANDLER.JS.COFFE
 - if ENV['BUGSNAG_JAVASCRIPT_API_KEY']
   %script{ src:"//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js",
     "data-apikey" => "#{ENV["BUGSNAG_JAVASCRIPT_API_KEY"]}" }
   :javascript
     Bugsnag.releaseStage = "#{Rails.env}";
     Bugsnag.notifyReleaseStages = ["staging", "production"];
-    window.ErrorNotifier = {};
-    window.ErrorNotifier['notify'] = function(error, label) {
-      Bugsnag.notifyException(error, label);
-    }
-- else
-  :javascript
-    window.ErrorNotifier = {}
-    window.ErrorNotifier['notify'] = function(error, label) {
-      throw error;
-    }

--- a/spec/features/event_streaming_spec.rb
+++ b/spec/features/event_streaming_spec.rb
@@ -22,20 +22,12 @@ feature "Event streaming", js: true, selenium: true do
 
     scenario "creating a new task" do
       submission_phase.tasks.create title: "Wicked Awesome Card", type: "Task", body: text_body, role: "admin"
-
-      phase = all('.column').detect {|p| p.find('h2').text == "Submission Data" }
-      within phase do
-        expect(page).to have_content "Wicked Awesome Card"
-      end
+      expect(page).to have_content "Wicked Awesome Card"
     end
 
     scenario "deleting a task" do
       deleted_task = submission_phase.tasks.first.destroy!
-
-      phase = all('.column').detect { |p| p.find('h2').text == "Submission Data" }
-      within phase do
-        expect(page).to_not have_content deleted_task.title
-      end
+      expect(page).to_not have_content deleted_task.title
     end
   end
 

--- a/spec/features/manuscript_manager_spec.rb
+++ b/spec/features/manuscript_manager_spec.rb
@@ -59,16 +59,13 @@ feature "Manuscript Manager", js: true, selenium: true, solr: true do
   end
 
   scenario 'Removing a task' do
-    dashboard_page = DashboardPage.new
-    paper_page = dashboard_page.view_submitted_paper paper
-    task_manager_page = paper_page.visit_task_manager
+    task_manager_page = TaskManagerPage.visit paper
 
     phase = task_manager_page.phase 'Submission Data'
     expect(task_manager_page).to have_no_application_error
     before = task_manager_page.card_count
     expect {
       phase.remove_card('Upload Manuscript')
-
       within '.overlay' do
         find('.overlay-action-buttons button', text: 'Yes, Delete this Card'.upcase).click
       end
@@ -76,7 +73,7 @@ feature "Manuscript Manager", js: true, selenium: true, solr: true do
       task_manager_page.card_count
     }.by(-1)
 
-    visit root_path
+    dashboard_page = task_manager_page.navigate_to_dashboard
     paper_page = dashboard_page.view_submitted_paper paper
     task_manager_page = paper_page.visit_task_manager
     expect(task_manager_page.card_count).to eq(before - 1)
@@ -84,9 +81,7 @@ feature "Manuscript Manager", js: true, selenium: true, solr: true do
 
   # Preventing a regression
   scenario 'Opening an AssignReviewers task' do
-    dashboard_page = DashboardPage.new
-    paper_page = dashboard_page.view_submitted_paper paper
-    task_manager_page = paper_page.visit_task_manager
+    task_manager_page = TaskManagerPage.visit paper
 
     within 'body' do
       find('.card-content', text: 'Assign Reviewer').click
@@ -98,9 +93,7 @@ feature "Manuscript Manager", js: true, selenium: true, solr: true do
   end
 
   scenario "Admin can assign a paper to themselves" do
-    dashboard_page = DashboardPage.new
-    paper_page = dashboard_page.view_submitted_paper paper
-    task_manager_page = paper_page.visit_task_manager
+    task_manager_page = TaskManagerPage.visit paper
 
     expect(task_manager_page).to have_content 'Assign Editor'
     needs_editor_phase = task_manager_page.phase 'Assign Editor'

--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -170,10 +170,9 @@ class Page < PageFragment
   end
 
   def navigate_to_dashboard
-    within('.nav-bar') do
-      click_on 'Dashboard'
-      DashboardPage.new
-    end
+    find('.navigation-toggle').click
+    find('a.navigation-item', text: 'DASHBOARD').click
+    DashboardPage.new
   end
 
   def sign_out

--- a/test/javascripts/integration/download_docx_test.js.coffee
+++ b/test/javascripts/integration/download_docx_test.js.coffee
@@ -7,6 +7,7 @@ expectedSupportedDownloadFormats = undefined
 module 'Integration: Paper Docx Download',
   teardown: ->
     ETahi.reset()
+    ETahi.paperEditActionStub.restore()
 
   setup: ->
     setupApp integration: true
@@ -58,6 +59,7 @@ test 'show download links on control bar', ->
   mock = undefined
   visit "/papers/#{ETahi.Test.currentPaper.id}/edit"
   andThen ->
+    ETahi.paperEditActionStub = sinon.stub(ETahi.__container__.lookup('controller:paperEdit')._actions, "savePaper")
     mock = sinon.mock(Tahi.utils)
     mock.expects("windowLocation").withArgs("https://www.google.com")
       .returns(true)
@@ -79,6 +81,7 @@ test 'iHat supported formats are set after page load', ->
     # on /formats when someone visits the paper_edit_route or paper_index_route.
     # The mock_server.js has a route for /formats that is always defined.
     export_formats = window.ETahi.supportedDownloadFormats.export_formats
+    ETahi.paperEditActionStub = sinon.stub(ETahi.__container__.lookup('controller:paperEdit')._actions, "savePaper")
     expected = window.expectedSupportedDownloadFormats
     equal(export_formats[0].format, expected.export_formats[0].format)
     equal(export_formats[1].format, expected.export_formats[1].format)

--- a/test/javascripts/integration/edit_paper_test.js.coffee
+++ b/test/javascripts/integration/edit_paper_test.js.coffee
@@ -37,6 +37,9 @@ module 'Integration: EditPaper',
     server.respondWith 'PUT', /\/tasks\/\d+/, [
       204, {"Content-Type": "application/json"}, JSON.stringify {}
     ]
+    server.respondWith 'PUT', /\/papers\/\d+/, [
+      204, {"Content-Type": "application/json"}, JSON.stringify {}
+    ]
     server.respondWith 'GET', /\/filtered_users\/users\/\d+/, [
       200, {"Content-Type": "application/json"}, JSON.stringify []
     ]

--- a/test/javascripts/integration/reporting_guidelines_test.js.coffee
+++ b/test/javascripts/integration/reporting_guidelines_test.js.coffee
@@ -1,5 +1,7 @@
 module 'Integration: Reporting Guidelines Card',
-  teardown: -> ETahi.reset()
+  teardown: ->
+    ETahi.reset()
+    ETahi.paperEditActionStub.restore()
   setup: ->
     setupApp integration: true
     TahiTest.questionId = 553
@@ -57,7 +59,9 @@ test 'Supporting Guideline is a meta data card, contains the right questions and
     find('.question .item').filter (i, el) -> Em.$(el).find('label').text().trim() is questionText
 
   visit "/papers/#{TahiTest.paperId}/edit"
-  .then -> ok exists find '.card-content:contains("Reporting Guidelines")'
+  .then ->
+    ok exists find '.card-content:contains("Reporting Guidelines")'
+    ETahi.paperEditActionStub = sinon.stub(ETahi.__container__.lookup('controller:paperEdit')._actions, "savePaper")
 
   click '.card-content:contains("Reporting Guidelines")'
   .then ->

--- a/test/javascripts/support/factories.js.coffee
+++ b/test/javascripts/support/factories.js.coffee
@@ -102,28 +102,28 @@ ETahi.Factory =
         payload[(typeName + "s")] = records
     payload
 
-   createPayload: (primaryTypeName) ->
-     _addRecordToManifest = @addRecordToManifest
-     _manifestToPayload = @manifestToPayload
-     manifest: {types: {}}
+  createPayload: (primaryTypeName) ->
+    _addRecordToManifest = @addRecordToManifest
+    _manifestToPayload = @manifestToPayload
+    manifest: {types: {}}
 
-     createRecord: (type, attrs) ->
-       newRecord = ETahi.Factory.createRecord(type, attrs)
-       @addRecord(newRecord)
-       newRecord
+    createRecord: (type, attrs) ->
+      newRecord = ETahi.Factory.createRecord(type, attrs)
+      @addRecord(newRecord)
+      newRecord
 
-     addRecords: (records, options={}) ->
-       _.forEach(records, (r) => @addRecord(r, options))
-       @
+    addRecords: (records, options={}) ->
+      _.forEach(records, (r) => @addRecord(r, options))
+      @
 
-     addRecord: (record, options={}) ->
-       rootKey = options.rootKey || record._rootKey
-       isPrimary = (rootKey == primaryTypeName)
-       @manifest = _addRecordToManifest(@manifest, rootKey, record, isPrimary)
-       @
+    addRecord: (record, options={}) ->
+      rootKey = options.rootKey || record._rootKey
+      isPrimary = (rootKey == primaryTypeName)
+      @manifest = _addRecordToManifest(@manifest, rootKey, record, isPrimary)
+      @
 
-     toJSON: ->
-       _manifestToPayload(@manifest)
+    toJSON: ->
+      _manifestToPayload(@manifest)
 
   createBasicPaper: (defs) ->
     ef = ETahi.Factory

--- a/test/javascripts/support/factories.js.coffee
+++ b/test/javascripts/support/factories.js.coffee
@@ -20,7 +20,7 @@ ETahi.Factory =
       recordAttrs = attrs
 
     baseAttrs = ETahi.FactoryAttributes[type]
-    throw "No factory exists for type: #{type}" unless baseAttrs
+    throw new Error("No factory exists for type: #{type}") unless baseAttrs
     _.defaults(recordAttrs, baseAttrs)
 
   createList: (numberOfRecords, type) ->

--- a/test/javascripts/support/test_initializer.js.coffee
+++ b/test/javascripts/support/test_initializer.js.coffee
@@ -63,6 +63,7 @@ QUnit.testDone(-> ETahi.Factory.resetFactoryIds())
   ETahi.rootElement = '#ember-testing'
   ETahi.setupForTesting()
   ETahi.injectTestHelpers()
+  window.ETahi.environment = 'test'
 
 @setupTestEnvironment()
 


### PR DESCRIPTION
References: https://www.pivotaltracker.com/story/show/85970300

## Pull Request Checklist
- [x] ask yourself: is this PR complicated enough that you should write
      integration tests?
- [x] ask yourself: do you feel that things are well abstracted?
- [x] do a self code review (read through `git diff` or the github UI)
- [x] complete all relevant todos in your code
- [x] self QA (make sure the app still works, along with your change)
- [ ] get review from a team-member with knowledge of this codebase area
- [ ] **team-member said ship it! (:ship: it)**
- [ ] self QA on staging
- [ ] do any changes need to be made to prod before a deploy? List them in
      the `deployer checklist`
- [ ] the tests are passing for this branch on semaphore
- [ ] merge! Celebrate your success!

## Reviewer Checklist
- [ ] is syntax consistent with rest of code-base?
- [ ] are database access patterns relatively efficient?
- [ ] are client-side access patterns
- [ ] ember style

## Deployer Checklist
Changes to Tahi are deployed automatically to staging whenever tests for
the `master` branch are passing. These items really only apply for deploys
to `currents`, and `demo` (we don't have a production yet).
- [ ] **>>list changes here that need to be made to prod before a deploy<<**
- [ ] ideally these changes can be made by running a rake task or script
- [ ] you are deploying in the morning
- [ ] you are deploying on Monday, Tuesday, Wednesday, or Thursday.
- [ ] you are deploying your own code
- [ ] did the deploy
- [ ] you are watching the BugSnag slack channel and/or `heroku logs --tail`
- [ ] you announced the deploy with a few words summary to chatrooms
- [ ] you have opened https://dashboard.heroku.com/apps for rollback