### PR TITLE
Add -important- to css class to maintain spacing

### DIFF
--- a/app/assets/stylesheets/screens/manuscript_manager_template.scss
+++ b/app/assets/stylesheets/screens/manuscript_manager_template.scss
@@ -73,7 +73,7 @@ $template-thumbnail-height: 135px;
 
 .manuscript-manager-template-columns {
   // override .columns to allow for larger .control-bar
-  top: 160px;
+  top: 160px !important;
 }
 
 .edit-paper-type-field {


### PR DESCRIPTION
Add '!important' to '.manuscript-manager-template-columns' class to shift mmt columns down to prevent UI overlap.