### PR TITLE
set host: localhost in database.yml

### DIFF
--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -17,6 +17,7 @@
 development:
   adapter: postgresql
   encoding: unicode
+  host: localhost
   database: tahi_development
   pool: 5
   username: tahi
@@ -25,6 +26,7 @@ development:
 test:
   adapter: postgresql
   encoding: unicode
+  host: localhost
   database: tahi_test
   pool: 5
   username: tahi
@@ -33,6 +35,7 @@ test:
 performance:
   adapter: postgresql
   encoding: unicode
+  host: localhost
   database: tahi_performance
   pool: 48
   username: tahi
@@ -41,6 +44,7 @@ performance:
 staging:
   adapter: postgresql
   encoding: unicode
+  host: localhost
   database: tahi_staging
   pool: 48
   password:
@@ -48,6 +52,7 @@ staging:
 production:
   adapter: postgresql
   encoding: unicode
+  host: localhost
   database: tahi_production
   pool: 48
   password:


### PR DESCRIPTION
if host is not set, pg connects over domain socket, which by default in
ubuntu uses peer authentication, so the user running tahi must be named
tahi