### PR TITLE
Ember cli card generator

### DIFF
--- a/client/blueprints/.jshintrc
+++ b/client/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/client/blueprints/task/files/lib/__name__/app/adapters/__name__.js
+++ b/client/blueprints/task/files/lib/__name__/app/adapters/__name__.js
@@ -1,0 +1,2 @@
+import TaskAdapter from 'tahi/adapters/task';
+export default TaskAdapter.extend();

--- a/client/blueprints/task/files/lib/__name__/app/controllers/overlays/__name__.js
+++ b/client/blueprints/task/files/lib/__name__/app/controllers/overlays/__name__.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import TaskController from 'tahi/pods/task/controller';
+
+export default TaskController.extend();

--- a/client/blueprints/task/files/lib/__name__/app/models/__name__-task.js
+++ b/client/blueprints/task/files/lib/__name__/app/models/__name__-task.js
@@ -1,0 +1,4 @@
+import DS   from 'ember-data';
+import Task from 'tahi/models/task';
+
+export default Task.extend();

--- a/client/blueprints/task/files/lib/__name__/app/serializers/__name__.js
+++ b/client/blueprints/task/files/lib/__name__/app/serializers/__name__.js
@@ -1,0 +1,2 @@
+import TaskSerializer from 'tahi/serializers/task';
+export default TaskSerializer.extend();

--- a/client/blueprints/task/files/lib/__name__/app/templates/overlays/__name__.hbs
+++ b/client/blueprints/task/files/lib/__name__/app/templates/overlays/__name__.hbs
@@ -1,0 +1,3 @@
+<h1>
+  A New Generated Card
+</h1>

--- a/client/blueprints/task/files/lib/__name__/app/views/overlays/__name__.js
+++ b/client/blueprints/task/files/lib/__name__/app/views/overlays/__name__.js
@@ -1,0 +1,6 @@
+import OverlayView from 'tahi/views/overlay';
+
+export default OverlayView.extend({
+  templateName: 'overlays/<%= dasherizedModuleName %>',
+  layoutName:   'layouts/overlay'
+});

--- a/client/blueprints/task/files/lib/__name__/index.js
+++ b/client/blueprints/task/files/lib/__name__/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: '<%= dasherizedModuleName %>',
+
+  isDevelopingAddon: function() {
+    return true;
+  }
+};

--- a/client/blueprints/task/files/lib/__name__/package.json
+++ b/client/blueprints/task/files/lib/__name__/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "<%= dasherizedModuleName %>",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/client/blueprints/task/index.js
+++ b/client/blueprints/task/index.js
@@ -1,0 +1,44 @@
+// copied from the ember-cli string utils (no way to import them)
+// we could pretty easily use an npm package like 'inflection' too.
+
+var path = require('path');
+var fs   = require('fs');
+
+var dasherize =  function(str) {
+    var STRING_DECAMELIZE_REGEXP = (/([a-z\d])([A-Z])/g);
+    var STRING_DASHERIZE_REGEXP = (/[ _]/g);
+
+    var dashed = str.replace(STRING_DECAMELIZE_REGEXP, '$1_$2').toLowerCase();
+    return dashed.replace(STRING_DASHERIZE_REGEXP,'-');
+};
+
+module.exports = {
+  description: 'Creates a new task as an in-repo addon.  Make sure to add the file to addons in package.json',
+
+  // locals: function(options) {
+  //   // Return custom template variables here.
+  //   return {
+  //     foo: options.entity.options.foo
+  //   };
+  // }
+
+  // afterInstall: function(options) {
+  //   // Perform extra work here.
+  // }
+  afterInstall: function(options) {
+    var packagePath = path.join(this.project.root, 'package.json');
+    var contents    = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+    var name        = dasherize(options.entity.name);
+    var newPath     = path.join('lib', name);
+    var paths;
+
+    contents['ember-addon'] = contents['ember-addon'] || {};
+    paths = contents['ember-addon']['paths'] = contents['ember-addon']['paths'] || [];
+
+    if (paths.indexOf(newPath) === -1) {
+      paths.push(newPath);
+    }
+
+    fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
+  }
+};

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test"
+    "test": "ember test",
+    "postinstall": "./../node_modules/bower/bin/bower install"
   },
   "repository": "",
   "engines": {
@@ -38,8 +39,5 @@
     "tahi-standard-cards": "git://github.com/Tahi-project/tahi-standard-cards.git",
     "tahi-supporting-information-card": "git://github.com/Tahi-project/tahi-supporting-information-card.git",
     "tahi-upload-manuscript-card": "git://github.com/Tahi-project/tahi-upload-manuscript-card.git"
-  },
-  "scripts": {
-    "postinstall": "./../node_modules/bower/bin/bower install"
   }
 }

--- a/lib/generators/task/task_generator.rb
+++ b/lib/generators/task/task_generator.rb
@@ -17,14 +17,7 @@ class TaskGenerator < Rails::Generators::Base
     template "subscriptions.rb",    "#{new_path}/app/models/#{engine_file_name}/subscriptions.rb"
     template "serializer.rb",       "#{new_path}/app/serializers/#{engine_file_name}/#{file_name}_task_serializer.rb"
     template "policy.rb",           "#{new_path}/app/policies/#{engine_file_name}/#{file_name}_tasks_policy.rb"
-    template "ember/model.js",      "#{new_path}/app/assets/javascripts/#{engine_file_name}/models/#{file_name}_task.js"
-    template "ember/view.js",       "#{new_path}/app/assets/javascripts/#{engine_file_name}/views/overlays/#{file_name}_overlay_view.js"
-    template "ember/controller.js", "#{new_path}/app/assets/javascripts/#{engine_file_name}/controllers/overlays/#{file_name}_overlay_controller.js"
-    template "ember/serializer.js", "#{new_path}/app/assets/javascripts/#{engine_file_name}/serializers/#{file_name}_task_serializer.js"
-    template "ember/adapter.js",    "#{new_path}/app/assets/javascripts/#{engine_file_name}/adapters/#{file_name}_task_adapter.js"
-    template "ember/overlay.hbs",   "#{new_path}/app/assets/javascripts/#{engine_file_name}/templates/overlays/#{file_name}_overlay.hbs"
   end
-
 
   private
 
@@ -38,6 +31,10 @@ class TaskGenerator < Rails::Generators::Base
 
   def file_name
     @task_name.underscore
+  end
+
+  def ember_task_name
+    @task_name.dasherize
   end
 
   def class_name
@@ -70,6 +67,10 @@ class TaskGenerator < Rails::Generators::Base
 
     cmd = "rails plugin new #{new_path} --full --mountable --skip-test-unit"
     puts cmd
-    system cmd
+    # system cmd
+
+    ember_cmd = "cd client && ember generate task #{ember_task_name}"
+    puts ember_cmd
+    system ember_cmd
   end
 end

--- a/lib/generators/task/templates/ember/adapter.js
+++ b/lib/generators/task/templates/ember/adapter.js
@@ -1,1 +1,0 @@
-ETahi.<%= class_name %>TaskAdapter = ETahi.TaskAdapter.extend();

--- a/lib/generators/task/templates/ember/controller.js
+++ b/lib/generators/task/templates/ember/controller.js
@@ -1,1 +1,0 @@
-ETahi.<%= class_name %>OverlayController = ETahi.TaskController.extend();

--- a/lib/generators/task/templates/ember/model.js
+++ b/lib/generators/task/templates/ember/model.js
@@ -1,3 +1,0 @@
-ETahi.<%= class_name %>Task = ETahi.Task.extend({
-  qualifiedType: "<%= engine_class_name %>::<%= class_name %>Task"
-});

--- a/lib/generators/task/templates/ember/overlay.hbs
+++ b/lib/generators/task/templates/ember/overlay.hbs
@@ -1,3 +1,0 @@
-<h1>Hello World!</h1>
-<p>Find my template at: engines/<%= engine_file_name %>/app/assets/javascripts/<%= engine_file_name %>/templates/overlays/<%= file_name %>_overlay.hbs</p>
-<p>Enter JavaScript in: engines/<%= engine_file_name %>/app/assets/javascripts/<%= engine_file_name %>/views/overlays/<%= file_name %>_overlay_view.js</p>

--- a/lib/generators/task/templates/ember/serializer.js
+++ b/lib/generators/task/templates/ember/serializer.js
@@ -1,1 +1,0 @@
-ETahi.<%= class_name %>TaskSerializer = ETahi.TaskSerializer.extend();

--- a/lib/generators/task/templates/ember/view.js
+++ b/lib/generators/task/templates/ember/view.js
@@ -1,7 +1,0 @@
-ETahi.<%= class_name %>OverlayView = ETahi.OverlayView.extend({
-  templateName: "<%= engine_file_name %>/overlays/<%= file_name %>_overlay",
-  layoutName: "layouts/overlay_layout",
-
-  setup: function() {
-  }.on('didInsertElement')
-});


### PR DESCRIPTION
This replaces the ember side of the current card generator.  It's still a work in progress.  I made an ember blueprint that creates the new task as an 'in-repo addon'.  It's simpler to do development in this fashion - trying to link against an external addon repo is a bit more tedious.  The addon files live in `client/lib/my-addon` and they can be copied out when needed.  We can always revise the approach as necessary.