### PR TITLE
User Avatar Upload Route Fixens

### DIFF
--- a/client/app/pods/components/user-avatar/component.coffee
+++ b/client/app/pods/components/user-avatar/component.coffee
@@ -1,18 +1,12 @@
 `import Ember from 'ember'`
 `import FileUploadMixin from 'tahi/mixins/file-upload'`
-`import ValidationErrorsMixin from 'tahi/mixins/validation-errors'`
-`import Utils from 'tahi/services/utils'`
 
-UserAvatarComponent = Ember.Component.extend FileUploadMixin, ValidationErrorsMixin,
-  errorText: ""
-
-  avatarUploadUrl: ( ->
-    "/users/#{@get('model.id')}/update_avatar"
-  ).property('id')
+UserAvatarComponent = Ember.Component.extend FileUploadMixin,
+  avatarUploadUrl: "/users/update_avatar"
 
   actions:
     uploadFinished: (data, filename) ->
       @uploadFinished(data, filename)
-      @set 'model.avatarUrl', data.avatar_url
+      @set 'user.avatarUrl', data.avatar_url
 
 `export default UserAvatarComponent`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,9 +74,8 @@ Tahi::Application.routes.draw do
     end
   end
 
-  resources :users, only: [:show, :index] do
-    put :update_avatar, on: :member
-  end
+  resources :users, only: [:show, :index]
+  put 'users/update_avatar' => 'users#update_avatar'
 
   resources :collaborations, only: [:create, :destroy]
   resources :paper_roles, only: [:show]


### PR DESCRIPTION
The Ember Component was sending a request to `/users/undefined/update_avatar` and the Rails controller was simply using `current_user`. We changed the endpoint to `/users/update_avatar`.