### PR TITLE
Activejob refactor

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -48,10 +48,10 @@ class UserMailer < ActionMailer::Base
       subject: "You've been assigned as an editor on Tahi")
   end
 
-  def mention_collaborator(comment_id, commentee_id)
-    @comment = Comment.find(comment_id)
+  def mention_collaborator(comment, commentee)
+    @comment = comment
     @commenter = @comment.commenter
-    @commentee = User.find(commentee_id)
+    @commentee = commentee
 
     mail(
       to: @commentee.try(:email),

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,12 +17,12 @@ class Comment < ActiveRecord::Base
     commenter_id == user.id
   end
 
+  private
+
   # TODO Security? What do you think? Also, should we do this client side too?
   def escape_body
     self.body = ERB::Util.html_escape(body)
   end
-
-  private
 
   def people_mentioned
     @people_mentioned ||= User.where(username: mentions_extracted_from_body)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -32,7 +32,7 @@ class Comment < ActiveRecord::Base
   # uses the same format as
   # https://dev.twitter.com/overview/api/entities-in-twitter-objects#user_mentions
   def set_mentions
-    self.entities = {user_mentions: Twitter::Extractor.extract_mentioned_screen_names_with_indices(body)}
+    self.entities = { user_mentions: Twitter::Extractor.extract_mentioned_screen_names_with_indices(body) }
   end
 
   def people_mentioned

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -29,8 +29,7 @@ class Comment < ActiveRecord::Base
   end
 
   def people_mentioned
-    names = Twitter::Extractor.extract_mentioned_screen_names(body).uniq - [commenter.username]
-    @people_mentioned ||= User.where(username: names)
+    @people_mentioned ||= User.where(username: mentions_extracted_from_body)
   end
 
   # uses the same format as
@@ -50,5 +49,9 @@ class Comment < ActiveRecord::Base
     people_mentioned.each do |mentionee|
       UserMailer.mention_collaborator(self, mentionee).deliver_later
     end
+  end
+
+  def mentions_extracted_from_body
+    Twitter::Extractor.extract_mentioned_screen_names(body).uniq - [commenter.username]
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,10 +11,15 @@ class Comment < ActiveRecord::Base
 
   before_save :escape_body
   before_save :set_mentions
-  after_commit :email_mentioned
 
   def created_by?(user)
     commenter_id == user.id
+  end
+
+  def notify_mentioned_people
+    people_mentioned.each do |mentionee|
+      UserMailer.mention_collaborator(self, mentionee).deliver_later
+    end
   end
 
   private
@@ -24,27 +29,14 @@ class Comment < ActiveRecord::Base
     self.body = ERB::Util.html_escape(body)
   end
 
-  def people_mentioned
-    @people_mentioned ||= User.where(username: mentions_extracted_from_body)
-  end
-
   # uses the same format as
   # https://dev.twitter.com/overview/api/entities-in-twitter-objects#user_mentions
   def set_mentions
-    self.entities = { user_mentions: [] }
-    people_mentioned.each do |user|
-      handle = '@' + user.username
-      first = body.index(handle)
-      last = first + handle.length
-      indices = { indices: [first, last] }
-      self.entities["user_mentions"] << indices
-    end
+    self.entities = {user_mentions: Twitter::Extractor.extract_mentioned_screen_names_with_indices(body)}
   end
 
-  def email_mentioned
-    people_mentioned.each do |mentionee|
-      UserMailer.mention_collaborator(self, mentionee).deliver_later
-    end
+  def people_mentioned
+    @people_mentioned ||= User.where(username: mentions_extracted_from_body)
   end
 
   def mentions_extracted_from_body

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -48,7 +48,7 @@ class Comment < ActiveRecord::Base
 
   def email_mentioned
     people_mentioned.each do |mentionee|
-      UserMailer.delay.mention_collaborator(id, mentionee.id)
+      UserMailer.mention_collaborator(self, mentionee).deliver_later
     end
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -24,10 +24,6 @@ class Comment < ActiveRecord::Base
 
   private
 
-  def notifier_payload
-    { task_id: task.id, paper_id: task.paper.id }
-  end
-
   def people_mentioned
     @people_mentioned ||= User.where(username: mentions_extracted_from_body)
   end

--- a/app/services/comment_look_manager.rb
+++ b/app/services/comment_look_manager.rb
@@ -8,6 +8,7 @@ class CommentLookManager
   def self.sync_comment(comment)
     comment.transaction do
       comment.save!
+      comment.notify_mentioned_people
       comment.task.participants.each do |user|
         create_comment_look(user, comment)
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module Tahi
     # Raise an error within after_rollback & after_commit
     config.active_record.raise_in_transactional_callbacks = true
 
+    config.active_job.queue_adapter = :sidekiq
+
     ActionMailer::Base.smtp_settings = {
       address: 'smtp.sendgrid.net',
       port: '587',

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,6 +30,7 @@ Tahi::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.active_job.queue_adapter = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -76,7 +76,7 @@ describe UserMailer, redis: true do
     let(:invitee) { FactoryGirl.create(:user) }
     let(:paper) { FactoryGirl.create :paper, :with_tasks, creator: admin, submitted: true }
     let(:comment) { FactoryGirl.create(:comment, task: paper.tasks.first) }
-    let(:email) { UserMailer.mention_collaborator(comment.id, invitee.id) }
+    let(:email) { UserMailer.mention_collaborator(comment, invitee) }
 
     it_behaves_like "recipient without email address"
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -14,19 +14,21 @@ describe Comment, redis: true do
   end
 
   context "creating a new Comment" do
-    it "#sanitize_body" do
+    it "sanitize the body" do
       body = "hi @#{author.username}. Trying to break comment with <script>alert('bad script')</script>"
       comment = FactoryGirl.create(:comment, body: body)
       expected = "hi @#{author.username}. Trying to break comment with &lt;script&gt;alert(&#39;bad script&#39;)&lt;/script&gt;"
       expect(comment.body).to eq expected
     end
 
-    it "#set_mentions" do
+    it "set the mentions with indices to entities attribute" do
       body = "hi @#{author.username}, @#{author2.username}, and @nonexistent_user"
       comment = FactoryGirl.create(:comment, body: body)
-      expected = {:indices=>[3, 3+('@'+author.username).length]}
+      first_username_length = ('@'+author.username).length
+
+      expected = {'screen_name' => author.username, 'indices' => [3, 3+first_username_length]}
       expect(comment.entities['user_mentions'][0]).to eq expected
-      expect(comment.entities['user_mentions'].length).to eq 2
+      expect(comment.entities['user_mentions'].length).to eq 3
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -24,11 +24,11 @@ describe Comment, redis: true do
     it "set the mentions with indices to entities attribute" do
       body = "hi @#{author.username}, @#{author2.username}, and @nonexistent_user"
       comment = FactoryGirl.create(:comment, body: body)
-      first_username_length = ('@'+author.username).length
+      first_username_length = "@#{author.username}".length
 
-      expected = {'screen_name' => author.username, 'indices' => [3, 3+first_username_length]}
-      expect(comment.entities['user_mentions'][0]).to eq expected
-      expect(comment.entities['user_mentions'].length).to eq 3
+      expected = { "screen_name" => author.username, "indices" => [3, 3 + first_username_length] }
+      expect(comment.entities["user_mentions"][0]).to eq expected
+      expect(comment.entities["user_mentions"].length).to eq 3
     end
   end
 
@@ -36,7 +36,7 @@ describe Comment, redis: true do
     include ActiveJob::TestHelper
 
     before { ActionMailer::Base.deliveries.clear }
-    after  {clear_enqueued_jobs}
+    after  { clear_enqueued_jobs }
 
     def create_comment_and_notify_mentions(options = {})
       comment = FactoryGirl.create(:comment, options)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ Capybara.register_driver :selenium do |app|
 end
 
 Capybara.javascript_driver = :selenium
-Capybara.default_wait_time = 5
+Capybara.default_wait_time = 10
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.


### PR DESCRIPTION
Hi,

After running the tests I saw a couple of deprecations warning about the use of ActionMailer delay method, this is because Rails 4.2 introduce Active Job

quoting the rails guide

"The main point is to ensure that all Rails apps will have a job infrastructure in place, even if it's in the form of an "immediate runner". We can then have framework features and other gems build on top of that, without having to worry about API differences between various job runners such as Delayed Job and Resque. Picking your queuing backend becomes more of an operational concern, then. And you'll be able to switch between them without having to rewrite your jobs."

So I took the liberty of refactor the comment model which was using the now deprecated delay method, Also I notice some opportunities of improvements in this model, like removing callbacks that send emails, breaking the SRP.

If you like the refactor I will continue updating the calls from the controllers, is this occasion, I only changed the call from the Comment model 

If you have any doubts let me know :smile: 
