### PR TITLE
Change path in postinstall script

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "test": "tests"
   },
   "scripts": {
-    "postinstall": "./../node_modules/bower/bin/bower install"
+    "postinstall": "bower install"
   },
   "repository": "",
   "engines": {


### PR DESCRIPTION
No need to have an absolute path because npm is able to infer where your bower is.

Shout out to @DTrejo 