### PR TITLE
Fewer hound checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Metrics/ClassLength:
 Documentation:
   Enabled: false
 Metrics/LineLength:
-  Max: 120
+  Enabled: false
 StringLiterals:
   Enabled: false
 Style/SpaceAroundEqualsInParameterDefault:
@@ -27,3 +27,9 @@ Style/StringLiterals:
 Style/DotPosition:
   Enabled: true
   EnforcedStyle: trailing
+Style/EmptyLinesAroundBlockBody:
+  Enabled: false
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+Style/EmptyLinesAroundModuleBody:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,29 @@
+# https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
+
+AllCops:
+  RunRailsCops: true
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'vendor/assets/**/*'
+    - 'db/schema.rb'
+    - 'db/migrate/*'
+Blocks:
+  Enabled: false
+ClassAndModuleChildren:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Documentation:
+  Enabled: false
+Metrics/LineLength:
+  Max: 120
+StringLiterals:
+  Enabled: false
+Style/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+Style/StringLiterals:
+  Enabled: false
+Style/DotPosition:
+  Enabled: true
+  EnforcedStyle: trailing


### PR DESCRIPTION
We restore the `.rubocop.yml` file we used to have because `.hound.yml` refers to it. (It was removed in 03a0392b5009975f75e2893e16dbeef865d304ab.)

We also disable line length checks and blank line around module, class and block bodies.