### PR TITLE
Unassociated User Receives Task Invitiation

### DIFF
--- a/app/policies/invitations_policy.rb
+++ b/app/policies/invitations_policy.rb
@@ -2,11 +2,12 @@ class InvitationsPolicy < ApplicationPolicy
   primary_resource :invitation
 
   def connected_users
-    tasks_policy.connected_users
+    user_ids = (tasks_policy.connected_users.pluck(:id) + [invitation.invitee.id])
+    User.where(id: user_ids)
   end
 
   def show?
-    tasks_policy.show?
+    invitation.invitee == current_user || tasks_policy.show?
   end
 
   private

--- a/spec/policies/invitations_policy_spec.rb
+++ b/spec/policies/invitations_policy_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe InvitationsPolicy do
+  let(:invitation) { FactoryGirl.create(:invitation) }
+  let(:policy) { InvitationsPolicy.new(current_user: user, invitation: invitation) }
+
+  context "invitee" do
+    let(:user) { invitation.invitee }
+
+    include_examples "person who is an invitee"
+  end
+
+  context "non associated user" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    include_examples "person who is not related to task"
+  end
+end

--- a/spec/support/shared_examples/policy_shared_examples.rb
+++ b/spec/support/shared_examples/policy_shared_examples.rb
@@ -315,3 +315,17 @@ shared_examples_for "cannot export paper" do
     expect(policy.status?).to be(false)
   end
 end
+
+
+# invitiations
+shared_examples_for "person who is an invitee" do
+  it "allows them to perform any action" do
+    expect(policy.show?).to be(true)
+  end
+end
+
+shared_examples_for "person who is not related to task" do
+  it "does not allow them to perform any action" do
+    expect(policy.show?).to be(false)
+  end
+end


### PR DESCRIPTION
Ensure that a user not associated to a task is shown an invitation for task.

References: https://www.pivotaltracker.com/story/show/89912282