### PR TITLE
Format date helper

### DIFF
--- a/client/app/helpers/format-date.coffee
+++ b/client/app/helpers/format-date.coffee
@@ -1,6 +1,7 @@
 `import Ember from 'ember'`
 
 formatDate = (date, options) ->
+  return date unless moment(date).isValid()
   moment(date).format(options.hash.format || "LL")
 
 FormatDateHelper = Ember.Handlebars.makeBoundHelper formatDate

--- a/client/app/helpers/format-date.coffee
+++ b/client/app/helpers/format-date.coffee
@@ -1,7 +1,10 @@
 `import Ember from 'ember'`
 
-FormatDate = Ember.Handlebars.makeBoundHelper (date, options) ->
-
+formatDate = (date, options) ->
   moment(date).format(options.hash.format || "LL")
 
-`export default FormatDate`
+FormatDateHelper = Ember.Handlebars.makeBoundHelper formatDate
+
+`export { formatDate }`
+
+`export default FormatDateHelper`

--- a/client/app/helpers/format-date.coffee
+++ b/client/app/helpers/format-date.coffee
@@ -1,0 +1,7 @@
+`import Ember from 'ember'`
+
+FormatDate = Ember.Handlebars.makeBoundHelper (date, options) ->
+
+  moment(date).format(options.hash.format || "LL")
+
+`export default FormatDate`

--- a/client/app/pods/profile/affiliation-form/template.hbs
+++ b/client/app/pods/profile/affiliation-form/template.hbs
@@ -6,7 +6,7 @@
     <div class="profile-affiliation">
       <div class="profile-affiliation-name">{{a.name}}</div>
       <div class="glyphicon glyphicon-remove-circle profile-remove-affiliation" {{action "removeAffiliation" a}}></div>
-      <div>{{a.startDate}} - {{a.displayEndDate}}</div>
+      <div>{{format-date a.startDate}} - {{format-date a.displayEndDate}}</div>
       <div>{{a.email}}</div>
     </div>
   {{/each}}

--- a/client/tests/unit/helpers/format-date-test.coffee
+++ b/client/tests/unit/helpers/format-date-test.coffee
@@ -4,10 +4,10 @@ module 'FormatDateHelper'
 
 test 'default formatting', ->
   helper_options = {hash: {}}
-  result = formatDate(new Date('2015-02-06 08:00'), helper_options)
-  equal(result, 'February 6, 2015', 'returns a human readable date')
+  result = formatDate(new Date('February 06, 1990'), helper_options)
+  equal(result, 'February 6, 1990', 'returns a human readable date')
 
 test 'specify formatting', ->
   helper_options = {hash: {format: 'l'}}
-  result = formatDate(new Date('2015-02-06 08:00'), helper_options)
-  equal(result, '2/6/2015', 'returns date in a custom format')
+  result = formatDate(new Date('February 06, 1990'), helper_options)
+  equal(result, '2/6/1990', 'returns date in a custom format')

--- a/client/tests/unit/helpers/format-date-test.coffee
+++ b/client/tests/unit/helpers/format-date-test.coffee
@@ -4,10 +4,16 @@ module 'FormatDateHelper'
 
 test 'default formatting', ->
   helper_options = {hash: {}}
-  result = formatDate(new Date('February 06, 1990'), helper_options)
+  date = new Date('February 06, 1990')
+  result = formatDate(date, helper_options)
   equal(result, 'February 6, 1990', 'returns a human readable date')
 
 test 'specify formatting', ->
   helper_options = {hash: {format: 'l'}}
   result = formatDate(new Date('February 06, 1990'), helper_options)
   equal(result, '2/6/1990', 'returns date in a custom format')
+
+test 'format only valid dates', ->
+  helper_options = {hash: {}}
+  result = formatDate('hello world', helper_options)
+  equal(result, 'hello world', 'returns original value sent')

--- a/client/tests/unit/helpers/format-date-test.coffee
+++ b/client/tests/unit/helpers/format-date-test.coffee
@@ -1,0 +1,13 @@
+`import { formatDate } from 'tahi/helpers/format-date'`
+
+module 'FormatDateHelper'
+
+test 'default formatting', ->
+  helper_options = {hash: {}}
+  result = formatDate(new Date('2015-02-06 08:00'), helper_options)
+  equal(result, 'February 6, 2015', 'returns a human readable date')
+
+test 'specify formatting', ->
+  helper_options = {hash: {format: 'l'}}
+  result = formatDate(new Date('2015-02-06 08:00'), helper_options)
+  equal(result, '2/6/2015', 'returns date in a custom format')


### PR DESCRIPTION
Use moment js to easily format dates, by default will use the "LL" format if is not specified

```{{format-date invitation.createdAt}}```
March 9, 2015

```{{format-date invitation.createdAt format="L"}}```
03/09/2015