### PR TITLE
add the queue 'mailers' to the list

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,3 +2,4 @@
 :queues:
   - default
   - paper_unlocker
+  - mailers


### PR DESCRIPTION
By default ActiveJob have the queue ‘mailers’ for ActionMailer jobs
https://github.com/mperham/sidekiq/wiki/Active-Job#action-mailer