### PR TITLE
Change delivery of mails in dev to use mailcatcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,10 +72,6 @@ group :doc do
   gem 'sdoc', require: false
 end
 
-group :development do
-  gem 'letter_opener'
-end
-
 group :development, :test, :performance do
   gem 'factory_girl_rails'
   gem 'progressbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,8 +245,6 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    letter_opener (1.3.0)
-      launchy (~> 2.2)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -504,7 +502,6 @@ DEPENDENCIES
   heroku-deflater
   kaminari
   launchy
-  letter_opener
   mail_form
   mail_safe (= 0.3.1)
   migration_data

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ ES_URL=http://your-custom-event-server.example.com rails s
 Run `rake db:setup`. This will delete any data you already have in your
 database, and insert test users based on what you see in `db/seeds.rb`.
 
+### Sending Emails
+In development we sent emails through a simple SMTP server which catches any message sent to it to display in a web interface
+
+If you have running mailcatcher already you are ready to go, if not, please follow this instructions:
+ - install the gem `gem install mailcatcher`.
+ - run in the console `mailcatcher` to start the daemon.
+ - Go to http://localhost:1080/
+
+for more information check http://mailcatcher.me/
+
 ### Running specs
 
 We use:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,11 +27,9 @@ Tahi::Application.configure do
   # number of complex assets.
   config.assets.debug = false
 
-  config.action_mailer.delivery_method = :test
-  # use letter_opener if you want to see the emails
-  # config.action_mailer.delivery_method = :letter_opener
-  # consider switching to rails 4.1 mailer preview
-  # http://edgeguides.rubyonrails.org/4_1_release_notes.html#action-mailer-previews
+  # Mailcatcher configuration
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: "localhost", port: 1025 }
 
   # defaults to local storage
   # config.carrierwave_storage = :fog


### PR DESCRIPTION
I was wondering if it was possible to switch to use mailcatcher for development instead of letter_opener, I have a couple reasons why I would like to make the switch:

 - I don't want the app open a browser tab every time an email is sent (its get annoying if I don't want to check the email immediately)
 - Since one of the features that I'm building sends multiple emails, I don't want to popup a new tab for every email sent.
 - I would like the see the HTML, Plain Text and Source versions of the messages
 - I would like to review the emails later all of them group like in an email client

There is an alternative with the letter_opener_web gem https://github.com/fgrehm/letter_opener_web
Which gives letter_opener an interface for browsing sent emails

Is an opinion, it depends if it fits to the tahi core devs needs :+1: 

