### PR TITLE
Refactor filtered users controller

### DIFF
--- a/app/controllers/filtered_users_controller.rb
+++ b/app/controllers/filtered_users_controller.rb
@@ -12,21 +12,25 @@ class FilteredUsersController < ApplicationController
   end
 
   def editors
-    render_selectable_users(:editors)
+    @users = paper.journal.editors
+    filter_and_render
   end
 
   def admins
-    render_selectable_users(:admins)
+    @users = paper.journal.admins
+    filter_and_render
   end
 
   def reviewers
-    render_selectable_users(:reviewers)
+    @users = paper.journal.reviewers
+    filter_and_render
   end
 
   private
 
-  def render_selectable_users(role)
-    respond_with paper.journal.send(role), each_serializer: SelectableUserSerializer
+  def filter_and_render
+    @users = @users.starts_with(params[:query]) if params[:query].present?
+    respond_with @users, each_serializer: SelectableUserSerializer
   end
 
   def paper

--- a/app/controllers/filtered_users_controller.rb
+++ b/app/controllers/filtered_users_controller.rb
@@ -26,9 +26,10 @@ class FilteredUsersController < ApplicationController
   private
 
   def render_selectable_users(role)
-    paper = Paper.find(params[:paper_id])
-    ids = paper.journal.send(role).pluck(:id)
-    users = User.where id: ids
-    respond_with users, each_serializer: SelectableUserSerializer
+    respond_with paper.journal.send(role), each_serializer: SelectableUserSerializer
+  end
+
+  def paper
+    @paper ||= Paper.find(params[:paper_id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,8 @@ class User < ActiveRecord::Base
          authentication_keys: [:login],
          omniauth_providers: [:orcid, :cas]
 
+  scope :starts_with, -> (name){ where("lower(username) LIKE '#{name}%' OR lower(first_name) LIKE '#{name}%' OR lower(last_name) LIKE '#{name}%'")}
+
   def possible_flows
     Flow.where("role_id IN (?) OR role_id IS NULL", role_ids)
   end

--- a/spec/controllers/filtered_users_controller_spec.rb
+++ b/spec/controllers/filtered_users_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe FilteredUsersController do
+  let(:current_user) { create :user }
+  let(:journal) { create(:journal) }
+  let(:paper) {create(:paper, journal: journal)}
+
+  before do
+    sign_in(current_user)
+  end
+
+  describe "#editors" do
+    it "returns an empty list of the editors from a journal" do
+      get :editors, paper_id: paper.id, format: :json
+      json = json(response.body)
+      expect(json[:filtered_users]).to be_empty
+    end
+
+    it "returns a list of the editors from a journal" do
+      possible_editor = create(:user, first_name: "Jhon", last_name: "Doe", email: "tahi@example.com")
+      assign_journal_role(journal, possible_editor, :editor)
+      get :editors, paper_id: paper.id, format: :json
+      json = json(response.body)
+
+      expect(json[:filtered_users].count).to eq 1
+      expect(json[:filtered_users].first[:id]).to eq possible_editor.id
+      expect(json[:filtered_users].first[:full_name]).to eq "Jhon Doe"
+      expect(json[:filtered_users].first[:email]).to eq "tahi@example.com"
+    end
+  end
+
+  describe "#admins" do
+    it "returns an empty list of the admins from a journal" do
+      get :admins, paper_id: paper.id, format: :json
+      json = json(response.body)
+      expect(json[:filtered_users]).to be_empty
+    end
+
+    it "returns a list of the admins from a journal" do
+      possible_admin = create(:user, first_name: "Jhon", last_name: "Doe", email: "tahi@example.com")
+      assign_journal_role(journal, possible_admin, :admin)
+      get :admins, paper_id: paper.id, format: :json
+      json = json(response.body)
+
+      expect(json[:filtered_users].count).to eq 1
+      expect(json[:filtered_users].first[:id]).to eq possible_admin.id
+      expect(json[:filtered_users].first[:full_name]).to eq "Jhon Doe"
+      expect(json[:filtered_users].first[:email]).to eq "tahi@example.com"
+    end
+  end
+
+  describe "#reviewers" do
+    it "returns an empty list of the reviewers from a journal" do
+      get :reviewers, paper_id: paper.id, format: :json
+      json = json(response.body)
+      expect(json[:filtered_users]).to be_empty
+    end
+
+    it "returns a list of the reviewers from a journal" do
+      possible_reviewer = create(:user, first_name: "Jhon", last_name: "Doe", email: "tahi@example.com")
+      assign_journal_role(journal, possible_reviewer, :reviewer)
+      get :reviewers, paper_id: paper.id, format: :json
+      json = json(response.body)
+
+      expect(json[:filtered_users].count).to eq 1
+      expect(json[:filtered_users].first[:id]).to eq possible_reviewer.id
+      expect(json[:filtered_users].first[:full_name]).to eq "Jhon Doe"
+      expect(json[:filtered_users].first[:email]).to eq "tahi@example.com"
+    end
+  end
+end

--- a/spec/controllers/filtered_users_controller_spec.rb
+++ b/spec/controllers/filtered_users_controller_spec.rb
@@ -17,7 +17,7 @@ describe FilteredUsersController do
     end
 
     it "returns a list of the editors from a journal" do
-      possible_editor = create(:user, first_name: "Jhon", last_name: "Doe", email: "tahi@example.com")
+      possible_editor = create(:user, first_name: "Jhon", last_name: "Doe", email: "jhondoe@example.com")
       assign_journal_role(journal, possible_editor, :editor)
       get :editors, paper_id: paper.id, format: :json
       json = json(response.body)
@@ -25,6 +25,18 @@ describe FilteredUsersController do
       expect(json[:filtered_users].count).to eq 1
       expect(json[:filtered_users].first[:id]).to eq possible_editor.id
       expect(json[:filtered_users].first[:full_name]).to eq "Jhon Doe"
+      expect(json[:filtered_users].first[:email]).to eq "jhondoe@example.com"
+    end
+
+    it "returns a filtered list based on the query param sent" do
+      possible_editor1 = create(:user, first_name: "Jhon", last_name: "Doe", email: "jhondoe@example.com")
+      possible_editor2 = create(:user, first_name: "Mr", last_name: "Tahi", email: "tahi@example.com")
+      assign_journal_role(journal, possible_editor1, :editor)
+      assign_journal_role(journal, possible_editor2, :editor)
+      get :editors, paper_id: paper.id, query: "mr", format: :json
+      json = json(response.body)
+      expect(json[:filtered_users].count).to eq 1
+      expect(json[:filtered_users].first[:full_name]).to eq "Mr Tahi"
       expect(json[:filtered_users].first[:email]).to eq "tahi@example.com"
     end
   end
@@ -37,7 +49,7 @@ describe FilteredUsersController do
     end
 
     it "returns a list of the admins from a journal" do
-      possible_admin = create(:user, first_name: "Jhon", last_name: "Doe", email: "tahi@example.com")
+      possible_admin = create(:user, first_name: "Jhon", last_name: "Doe", email: "jhondoe@example.com")
       assign_journal_role(journal, possible_admin, :admin)
       get :admins, paper_id: paper.id, format: :json
       json = json(response.body)
@@ -45,7 +57,7 @@ describe FilteredUsersController do
       expect(json[:filtered_users].count).to eq 1
       expect(json[:filtered_users].first[:id]).to eq possible_admin.id
       expect(json[:filtered_users].first[:full_name]).to eq "Jhon Doe"
-      expect(json[:filtered_users].first[:email]).to eq "tahi@example.com"
+      expect(json[:filtered_users].first[:email]).to eq "jhondoe@example.com"
     end
   end
 
@@ -57,7 +69,7 @@ describe FilteredUsersController do
     end
 
     it "returns a list of the reviewers from a journal" do
-      possible_reviewer = create(:user, first_name: "Jhon", last_name: "Doe", email: "tahi@example.com")
+      possible_reviewer = create(:user, first_name: "Jhon", last_name: "Doe", email: "jhondoe@example.com")
       assign_journal_role(journal, possible_reviewer, :reviewer)
       get :reviewers, paper_id: paper.id, format: :json
       json = json(response.body)
@@ -65,7 +77,7 @@ describe FilteredUsersController do
       expect(json[:filtered_users].count).to eq 1
       expect(json[:filtered_users].first[:id]).to eq possible_reviewer.id
       expect(json[:filtered_users].first[:full_name]).to eq "Jhon Doe"
-      expect(json[:filtered_users].first[:email]).to eq "tahi@example.com"
+      expect(json[:filtered_users].first[:email]).to eq "jhondoe@example.com"
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,10 +6,24 @@ describe User do
   end
 
   describe "scopes" do
-    let(:user1) { FactoryGirl.create(:user) }
-    let(:user2) { FactoryGirl.create(:user) }
+    describe ".starts_with" do
+      it "return users which username, first_name or last_name begins with a value sent" do
+        FactoryGirl.create(:user, username: 'lotus', first_name: 'Bradley', last_name: 'Ally')
+        FactoryGirl.create(:user, username: 'calvin', first_name: 'Belle', last_name: 'Christen')
+        FactoryGirl.create(:user, username: 'maximilian', first_name: 'Brody', last_name: 'Lexis')
+        FactoryGirl.create(:user, username: 'beck', first_name: 'Indigo', last_name: 'James')
+
+        results = User.starts_with('be').order("first_name")
+        expect(results.count).to eq 2
+        expect(results.first.first_name).to eq 'Belle'
+        expect(results.last.first_name).to eq 'Indigo'
+      end
+    end
 
     describe ".admins" do
+      let(:user1) { FactoryGirl.create(:user) }
+      let(:user2) { FactoryGirl.create(:user) }
+
       it "includes admin users only" do
         user1.update! site_admin: true
         admins = User.site_admins

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,4 +1,8 @@
 module TahiHelperMethods
+  def json(body)
+    JSON.parse(body, symbolize_names: true)
+  end
+
   def user_select_hash(user)
     {id: user.id, full_name: user.full_name, avatar: user.image_url}
   end


### PR DESCRIPTION
I'm using the select-2-single component which points to this enpoint, I notice that until now is not filtering the users based on the query param sent by select2, also I took the oportunity to add tests to this endpoint and refactor a little bit the controller.

I've added a scope starts_with to the User model and scopes are cool because returns a ActiveRecord::Relation object which are chainable, the 'search_users' class method which could be refactored or replaced with scopes of this type where we can chain multiple queries.

@mikem 