### PR TITLE
[WIP] typeahead component (autocomplete)

### DIFF
--- a/client/Brocfile.js
+++ b/client/Brocfile.js
@@ -31,6 +31,9 @@ app.import('vendor/bootstrap-tooltip/index.js');
 app.import('bower_components/bootstrap-datepicker/css/datepicker3.css');
 app.import('bower_components/bootstrap-datepicker/js/bootstrap-datepicker.js');
 
+// Typeahead
+app.import('bower_components/typeahead.js/dist/typeahead.bundle.min.js');
+
 // FileUpload
 app.import('vendor/jquery.ui.widget.js');
 app.import('vendor/jquery.iframe-transport.js');

--- a/client/app/pods/components/type-ahead/component.coffee
+++ b/client/app/pods/components/type-ahead/component.coffee
@@ -1,0 +1,53 @@
+`import Ember from 'ember'`
+
+TypeAheadComponent = Ember.TextField.extend
+
+  suggestionEngine: null
+  displayKey: null
+  selection: null
+  url: null
+
+  setupSuggestionEngine:(->
+    self = @
+    @_super()
+    @suggestionEngine = new Bloodhound(
+      datumTokenizer: Bloodhound.tokenizers.obj.whitespace(self.get('displayKey'))
+      queryTokenizer: Bloodhound.tokenizers.whitespace
+      remote:
+        url: self.get('url')
+        filter: (response) ->
+          $.map response.filtered_users, (user) ->
+            { name: user.full_name, email: user.email }
+    )
+
+    @suggestionEngine.initialize()
+  ).on('init'),
+
+  setup:(->
+    @.$().typeahead {
+      hint: true
+      highlight: true
+      minLength: 2
+    },
+      name: 'auto-complete'
+      displayKey: @get('displayKey')
+      source: @get('suggestionEngine').ttAdapter()
+      templates:
+        empty: ->
+          "no results"
+        suggestion: (context) ->
+          "#{context.name} #{context.email}"
+
+
+    @.$().on('typeahead:selected', (obj, data, name) ->
+      console.log obj
+      console.log data
+      console.log name
+    )
+
+  ).on('didInsertElement'),
+
+  willDestroyElement: ->
+    @.$().typeahead('destroy')
+
+`export default TypeAheadComponent`

--- a/client/bower.json
+++ b/client/bower.json
@@ -23,6 +23,7 @@
     "bootstrap-datepicker": "1.3.1",
     "ember-data-factory-guy": "0.9.10",
     "font-awesome": "~4.3.0",
-    "jquery-ui": "~1.11.3"
+    "jquery-ui": "~1.11.3",
+    "typeahead.js": "~0.10.5"
   }
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Tahi::Application.routes.draw do
   get '/request_policy' => 'direct_uploads#request_policy'
 
   get 'filtered_users/users/:paper_id' => 'filtered_users#users'
-  get 'filtered_users/editors/:paper_id' => 'filtered_users#editors'
+  get 'filtered_users/editors/:paper_id' => 'filtered_users#editors', defaults: {format: "json"}
   get 'filtered_users/admins/:paper_id' => 'filtered_users#admins'
   get 'filtered_users/reviewers/:paper_id' => 'filtered_users#reviewers'
 


### PR DESCRIPTION
This is my first draft of wrapping a jquery plugin [Typeahead](https://twitter.github.io/typeahead.js/examples/)

I sent this as a pull request so I could receive some feedback for improvements in the pattern of handling jquery plugins components inside Tahi

The way I sent the parameters in my engine is like:

```{{type-ahead displayKey='name' url='/filtered_rails_path/?query=%QUERY'}}```



I'm open for suggestions on how to improve the design structure of the component

Thanks!

PS: as you may see this is under development and I don't want this PR to be merge