### PR TITLE
[WIP] Define API endpoints

### DIFF
--- a/app/controllers/admin/journals_controller.rb
+++ b/app/controllers/admin/journals_controller.rb
@@ -12,10 +12,7 @@ class Admin::JournalsController < ApplicationController
   end
 
   def show
-    respond_to do |f|
-      f.json { render json: journal, serializer: AdminJournalSerializer, root: 'admin_journal' }
-      f.html { render 'ember/index', layout: 'ember' }
-    end
+    respond_with(journal, serializer:AdminJournalSerializer, root: 'admin_journal')
   end
 
   def authorization
@@ -24,25 +21,22 @@ class Admin::JournalsController < ApplicationController
 
   def create
     journal.save!
-    respond_with journal, serializer: AdminJournalSerializer, root: 'admin_journal'
+    respond_with(journal, serializer: AdminJournalSerializer, root: 'admin_journal')
   end
 
   def update
-    if journal.update(journal_params)
-      render json: journal, serializer: AdminJournalSerializer
-    else
-      respond_with journal
-    end
+    journal.update(journal_params)
+    respond_with(journal, serializer: AdminJournalSerializer, root: 'admin_journal')
   end
 
   def upload_logo
     journal_with_logo = DownloadLogo.call(journal, params[:url])
-    render json: journal_with_logo, serializer: AdminJournalSerializer
+    respond_with(journal_with_logo, serializer: AdminJournalSerializer)
   end
 
   def upload_epub_cover
     journal_with_cover = DownloadEpubCover.call(journal, params[:url])
-    render json: journal_with_cover, serializer: AdminJournalSerializer
+    respond_with(journal_with_cover, serializer: AdminJournalSerializer)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_with_basic_http
   before_filter :configure_permitted_parameters, if: :devise_controller?
   rescue_from ActiveRecord::RecordInvalid, with: :render_errors
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
   protected
   def configure_permitted_parameters
@@ -28,6 +29,10 @@ class ApplicationController < ActionController::Base
 
   def render_errors(e)
     render status: 422, json: {errors: e.record.errors}
+  end
+
+  def render_404
+    head 404
   end
 
   # customize devise signout path

--- a/app/controllers/ember_controller.rb
+++ b/app/controllers/ember_controller.rb
@@ -1,11 +1,7 @@
 class EmberController < ApplicationController
   respond_to :html
   layout 'ember'
-  def index
-    #do nothing
-  end
 
-  def styleguide
-    render layout: 'layouts/styleguide'
+  def index
   end
 end

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -6,30 +6,16 @@ class PapersController < ApplicationController
   before_action :sanitize_title, only: [:create, :update]
   before_action :prevent_update_on_locked!, only: [:update, :toggle_editable, :submit, :upload]
 
-  layout 'ember'
-
   respond_to :json
 
   def show
-    respond_to do |format|
-      format.html do
-        render 'ember/index'
-      end
-
-      format.json do
-        render json: paper
-      end
-    end
+    respond_with(paper)
   end
 
   def create
     @paper = PaperFactory.create(paper_params, current_user)
     notify_paper_created! if @paper.valid?
-    respond_with @paper
-  end
-
-  def edit
-    render 'ember/index'
+    respond_with(@paper)
   end
 
   def update
@@ -53,10 +39,6 @@ class PapersController < ApplicationController
     # TODO: params[:name] probably needs some securitifications
     activity_feeds = ActivityFeed.where(feed_name: params[:name], subject_id: paper.id).order('created_at DESC')
     respond_with activity_feeds, each_serializer: ActivityFeedSerializer, root: 'feeds'
-  end
-
-  def manage
-    render 'ember/index'
   end
 
   def upload

--- a/app/controllers/styleguide_controller.rb
+++ b/app/controllers/styleguide_controller.rb
@@ -1,0 +1,7 @@
+class StyleguideController < ApplicationController
+  respond_to :html
+  layout 'styleguide'
+
+  def index
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -8,21 +8,14 @@ class TasksController < ApplicationController
 
   respond_to :json
 
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
   def show
-    respond_to do |f|
-      f.json { render json: task }
-      f.html { render 'ember/index', layout: 'ember' }
-    end
+    respond_with(task)
   end
 
   def create
-    if task.save
-      respond_with task, location: task_url(task)
-    else
-      render json: { errors: task.errors }, status: :unprocessable_entity
-    end
+    task.save
+    respond_with(task)
   end
 
   def update
@@ -36,7 +29,7 @@ class TasksController < ApplicationController
 
   def destroy
     task.destroy
-    respond_with task
+    respond_with(task)
   end
 
   def send_message
@@ -82,10 +75,6 @@ class TasksController < ApplicationController
       whitelisted[:body] ||= "Nothing to see here."
       whitelisted[:recipients] ||= []
     end
-  end
-
-  def render_404
-    head 404
   end
 
   def enforce_policy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,9 +24,6 @@ Tahi::Application.routes.draw do
 
   resources :journals, only: [:index, :show]
 
-  get '/flow_manager' => 'ember#index'
-  get '/profile' => 'ember#index'
-
   get '/request_policy' => 'direct_uploads#request_policy'
 
   get 'filtered_users/users/:paper_id' => 'filtered_users#users'
@@ -82,7 +79,7 @@ Tahi::Application.routes.draw do
 
   post :ihat_jobs, to: "ihat_jobs#update", as: :ihat_callback
 
-  resources :papers, only: [:create, :show, :edit, :update] do
+  resources :papers, only: [:create, :show, :update] do
     resources :figures, only: :create
     resource :manuscript_manager, only: :show
     resource :editor, only: :destroy
@@ -92,7 +89,6 @@ Tahi::Application.routes.draw do
 
     member do
       put :upload
-      get :manage
       get :download
       put :heartbeat
       get :export, to: 'paper_conversions#export'
@@ -147,7 +143,7 @@ Tahi::Application.routes.draw do
 
   get "/formats", to: "formats#index"
 
-  get "/styleguide", to: "ember#styleguide"
+  get "/styleguide", to: "styleguide#index"
 
   mount EmberCLI::Engine => "ember-tests" if Rails.env.development?
   get '*route' => 'ember#index'


### PR DESCRIPTION
## Very Much Not Ready

We need to start treating our JSON endpoints like an API. _Because it is._

There's a lot of `ember/layout` cruft on the rails side. We shouldn't have to handle html requests to our JSON endpoints. This will remove them and ensure that our JSON endpoints only respond to JSON, not handling unnecessary cases.

There's also some endpoints that exist only in ember that are defined in rails. These will be removed as they almost certainly never get called, or when do, produce the `500` errors you're seeing in the rails log.

I'd also like to clean up the `routes.rb` file to have more sane organization, and likely an API namespace.
