### PR TITLE
additional args for select-2

### DIFF
--- a/client/app/pods/components/select-2/component.coffee
+++ b/client/app/pods/components/select-2/component.coffee
@@ -56,6 +56,8 @@ Select2Component = Ember.TextField.extend
     options.ajax               = @get('remoteSource') if @get('remoteSource')
     options.dropdownCssClass   = @get('dropdownClass') if @get('dropdownClass')
     options.initSelection      = Ember.run.bind(this, @initSelection)
+    options.minimumResultsForSearch = @get('minimumResultsForSearch') || 10
+    options.width = @get('width') || 'resolve'
 
     @.$().select2(options)
     @setupSelectedListener()


### PR DESCRIPTION
Allows passing in args for width, minimumResultsForSearch.

Also adds some defaults for these.

This will result in smaller drop downs (<10 items) _not_ having search
