### PR TITLE
Modified the invitation model: added two extra states and a guard on acc...

### DIFF
--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -12,4 +12,8 @@ module Invitable
   def invitation_accepted(_invitation)
     raise NotImplementedError, "the method 'invitation_accepted' must be defined in the subclass"
   end
+
+  def accept_allowed?(_invitation)
+    true
+  end
 end

--- a/spec/controllers/filtered_users_controller_spec.rb
+++ b/spec/controllers/filtered_users_controller_spec.rb
@@ -34,7 +34,7 @@ describe FilteredUsersController do
                            title: "Test",
                            role: "reviewer").extend Invitable
       end
-      let(:invitation) { create :invitation, task: task, invitee: user }
+      let(:invitation) { create :invitation, task: task, email: user.email }
 
       before do
         invitation.invite!

--- a/spec/factories/invitation_factory.rb
+++ b/spec/factories/invitation_factory.rb
@@ -2,17 +2,18 @@ require 'securerandom'
 
 FactoryGirl.define do
   factory :invitation do
-    code { SecureRandom.hex(4) }
-    association(:task, factory: :task)
-    association(:invitee, factory: :user)
-    association(:actor, factory: :user)
 
-    after(:build) do |invitation, evaluator|
-      invitation.email = evaluator.invitee.email
-    end
+    association(:task, factory: :task)
 
     trait :invited do
       state "invited"
+      code { SecureRandom.hex(4) }
+      association(:invitee, factory: :user)
+      association(:actor, factory: :user)
+      after(:build) do |invitation, evaluator|
+        invitation.email = evaluator.invitee.email
+      end
+
     end
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -20,20 +20,81 @@ describe Invitation do
   let(:task) { phase.tasks.create(type: "TestTask", title: "Test", role: "user") }
   let(:invitation) { FactoryGirl.build(:invitation, task: task) }
 
-  describe "#invite!" do
-    it "is invited by default" do
-      expect(task).to receive(:invitation_invited).with(invitation)
-      invitation.invite!
-      # DatabaseCleaner transaction strategy won't commit. Do it manually :(
-      invitation.run_callbacks(:commit)
+  context  "state machine events" do
+
+    describe "#invite!" do
+      it "tarnsitions from pending to invite" do
+        invitation.invite!
+        expect(invitation.invited?).to be_truthy
+      end
+
+      it "triggers an invitation call back in the associated task" do
+        expect(task).to receive(:invitation_invited).with(invitation)
+        invitation.invite!
+      end
+
+      it "generates a code for the invitation" do
+        invitation.invite!
+        expect(invitation.code).not_to be_nil
+      end
+
+      it "associates an existing user to the invitation" do
+        user = FactoryGirl.create(:user, email: "user@example.com")
+        invitation.email = "user@example.com"
+        expect(invitation.invitee).to be_nil
+        invitation.invite!
+        expect(invitation.invitee).to eql(user)
+      end
+    end
+
+    describe "#accept!" do
+      it "sends an role invitation email" do
+        invitation.invite!
+        expect(task).to receive(:invitation_accepted).with(invitation)
+        invitation.accept!
+      end
+
+      it "changes to accepted" do
+        invitation.invite!
+        invitation.accept!
+        expect(invitation.accepted?).to be_truthy
+      end
+
+      it "nakes transition from closed to willing" do
+        invitation2 = FactoryGirl.create(:invitation, task: task)
+        invitation.invite!
+        invitation2.invite!
+        invitation.accept!
+        invitation2.close!
+        allow(invitation2).to receive(:accept_allowed?).and_return(false)
+        invitation2.accept!
+        expect(invitation.accepted?).to be_truthy
+        expect(invitation2.willing?).to be_truthy
+      end
+    end
+
+    describe "#reject!" do
+      it "makes a transition from invited to rejected" do
+        invitation.invite!
+        invitation.reject!
+        expect(invitation.rejected?).to be_truthy
+      end
+
+      it "makes a transition from closed to rejected" do
+        invitation.invite!
+        invitation.close!
+        invitation.reject!
+        expect(invitation.rejected?).to be_truthy
+      end
+    end
+
+    describe "#close!" do
+      it "makes a transition from invited to closed" do
+        invitation.invite!
+        invitation.close!
+        expect(invitation.closed?).to be_truthy
+      end
     end
   end
 
-  describe "#accept!" do
-    it "sends an role invitation email" do
-      invitation.invite!
-      expect(task).to receive(:invitation_accepted).with(invitation)
-      invitation.accept!
-    end
-  end
 end


### PR DESCRIPTION
...ept state

The existing Invitation model lets an invited user accept an invitation that has been already accepted by another user and changes the status of that invitation for that user to "accepted". 
This behavior is not ideal for Academic Editors. 

First, if an AE has accepted to handle a manuscript, we shouldn't let another AE accept the invitation because we send more than one invitation. 

Second, we would like to keep track of those who are interested in handling the paper although it has been picked up; this data is useful in reassigning the manuscript.

In order to prevent the invitation that already has an Editor to be accepted again, we have added a guard on the transition from "invited" to "accepted". If the guard is true the transition happens. In order to preserve the original behavior (no guard) the guard returns true unless it is overrided in the task. We also added an additional state called "willing" to keep track of those who try to accept the manuscript that has an editor. The transition to this state happens only if the guard returns false.

Also, in the existing model when a user accepts an invitation, other invited users can still see the invitation on their dashboard. However, based on our requirements, an AE shouldn't see the invitation that has already been accepted by somebody else. To distinguish between the invitations which are still open (have no editor) with those that are closed (an editor has accepted), we introduced a new state called "closed". We trigger the "close" event as soon as an editor accepts an invitation. The invitation disappears for other editors from their dashboard. Now you might ask, what is the need for the guard or the "willing" state if the AE can't even see the invitation on their dashboard. Well, when inviting an editor, we send an email which has a link to accept or reject a manuscript. Therefore, it is still possible for them to respond to an invitation through their emails. If the invitation is closed, then clicking on accept link will change the state from "closed" to "willing" and clicking on the reject link will change the state from "closed" to "rejected". 

We also added more test for the invitation model and did a small refactoring on the generator to make the tests match the actual behavior: Assigning a code and invitee after inviting a user (in '"invited" state) instead of setting them when creating an invitation.
