### PR TITLE
Cleanup invitable mixin

### DIFF
--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -5,11 +5,42 @@ module Invitable
     has_many :invitations, inverse_of: :task, foreign_key: :task_id
   end
 
+  # Public: after transition hook for custom task behavior upon transitioning to "invited" state
+  #
+  # _invitation - the invitation
+  #
+  # Examples
+  #
+  #   Use this method to send an invitation email a user can accept/reject
+  #
+  # Returns true, is a noop if unimplemented
   def invitation_invited(_invitation)
-    raise NotImplementedError, "the method 'invitation_invited' must be defined in the subclass"
+    true
   end
 
+  # Public: after transition hook for custom task behavior upon transitioning to "accepted" state
+  #
+  # _invitation - the invitation
+  #
+  # Examples
+  #
+  #   Implement this hook to create the association between the accepting user and the paper
+  #
+  # Returns true, is a noop if unimplemented
   def invitation_accepted(_invitation)
-    raise NotImplementedError, "the method 'invitation_accepted' must be defined in the subclass"
+    true
+  end
+
+  # Public: after transition hook for custom task behavior upon transitioning to "rejected" state
+  #
+  # _invitation - the invitation
+  #
+  # Examples
+  #
+  #   Implement this hook to notify the next person in the queue of people to invite
+  #
+  # Returns true, is a noop if unimplemented
+  def invitation_rejected(_invitation)
+    true
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,7 +2,7 @@ class Invitation < ActiveRecord::Base
   include EventStreamNotifier
   include AASM
 
-  belongs_to :task, inverse_of: :invitations
+  belongs_to :task
   has_one :paper, through: :task
   belongs_to :invitee, class_name: "User", inverse_of: :invitations
   belongs_to :actor, class_name: "User", inverse_of: :invitations
@@ -36,15 +36,15 @@ class Invitation < ActiveRecord::Base
   private
 
   def notify_invitation_invited
-    task.invitation_invited(self) if task.respond_to?(:invitation_invited)
+    task.invitation_invited(self)
   end
 
   def notify_invitation_accepted
-    task.invitation_accepted(self) if task.respond_to?(:invitation_accepted)
+    task.invitation_accepted(self)
   end
 
   def notify_invitation_rejected
-    task.invitation_rejected(self) if task.respond_to?(:invitation_rejected)
+    task.invitation_rejected(self)
   end
 
   def associate_existing_user

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,7 +25,6 @@ class Task < ActiveRecord::Base
   has_many :questions, inverse_of: :task
   has_many :participations, inverse_of: :task, dependent: :destroy
   has_many :participants, through: :participations, source: :user
-  has_many :invitations, inverse_of: :task
 
   belongs_to :phase, inverse_of: :tasks
 

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -1,9 +1,15 @@
 require "rails_helper"
 
+class TestTask < Task
+  include TaskTypeRegistration
+  include Invitable
+  register_task default_title: "Test Task", default_role: "user"
+end
+
 describe InvitationsController do
 
   let(:invitee) { FactoryGirl.create(:user) }
-  let(:task) { FactoryGirl.create(:task) }
+  let(:task) { FactoryGirl.create(:task, type: "TestTask") }
 
   before { sign_in(invitee) }
 


### PR DESCRIPTION
- Remove unnecessary `has_many :invitations` from task base class
- Add some documentation for task hooks
- Change hooks to noop instead of raise exception - they should be optional (especially in case of rejection)
- Remove respond_to guards as they shouldn't be necessary.

cc @mikem 
