### PR TITLE
Default to generated serializer in generated model

### DIFF
--- a/lib/generators/tahi/task/templates/model.rb
+++ b/lib/generators/tahi/task/templates/model.rb
@@ -6,7 +6,7 @@ module <%= @plugin.camelize %>
     register_task default_title: "<%= class_name %> Task", default_role: "author"
 
     def active_model_serializer
-      TaskSerializer
+      <%= class_name %>TaskSerializer
     end
   end
 end


### PR DESCRIPTION
I updated the model template to use the new task's serializer.

This should address #951.
