### PR TITLE
wrap always visible spinner in cover

### DIFF
--- a/engines/tahi_standard_tasks/client/app/templates/overlays/register-decision.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/overlays/register-decision.hbs
@@ -1,5 +1,6 @@
-<div {{bind-attr class=":register-decision-saving-cover isSavingData"}}></div>
-{{progress-spinner visible=isSavingData}}
+<div {{bind-attr class=":register-decision-saving-cover isSavingData"}}>
+  {{progress-spinner visible=true}}
+</div>
 
 <h1>Register Decision</h1>
 


### PR DESCRIPTION
this fixes https://www.pivotaltracker.com/story/show/91463104

In checking this out, I discovered that a `visible` option can be passed to `{{spinner-component}}`, but because the component initializes on `didInsertElement`, the component is not updated when `visible` is toggled.

In the 1 other place where `spinner-component` is used, it is passed a `visible=true`, and we don't appear to have test coverage for this.

To get this turned around quickly, I just tucked the component in the working div overlay. It looks good enough - like the intended behavior.  The spinner is no longer always present.
