### PR TITLE
modify ember_addons_installer to query gemspec metadata

### DIFF
--- a/lib/tahi_plugin.rb
+++ b/lib/tahi_plugin.rb
@@ -1,0 +1,13 @@
+class TahiPlugin
+
+  # Return all installed Tahi plugins.
+  def self.plugins
+    Bundler.load.specs.select { |gem| tahi_plugin?(gem) }
+  end
+
+  # Return true if the gem is a tahi plugin.
+  def self.tahi_plugin?(gem)
+    # TODO: In the future, only tahi- is allowed as a prefix
+    gem.name =~ /\A(tahi_|tahi-|plos_|assess)/
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,9 +16,11 @@ require_relative 'support/pages/page'
 require_relative 'support/pages/overlay'
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
-# NOTE: This will stop working after we move the engines into their own repository.
-Dir[Rails.root.join("engines/**/spec/support/**/*.rb")].each { |f| require f }
-Dir[Rails.root.join("engines/**/spec/factories/**/*.rb")].each { |f| require f }
+# Load support & factories for installed Tahi plugins
+TahiPlugin.plugins.each do |gem|
+  Dir[File.join(gem.full_gem_path, 'spec', 'support', '**', '*.rb')].each { |f| require f }
+  Dir[File.join(gem.full_gem_path, 'spec', 'factories', '**', '*.rb')].each { |f| require f }
+end
 
 Capybara.server_port = ENV["CAPYBARA_SERVER_PORT"]
 Capybara.server do |app, port|


### PR DESCRIPTION
allows a gem to have any name and be a tahi plugin as long
as it has a gemspec metadata key 'tahi-plugin'
