### PR TITLE
Support recurring Jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'kaminari'
 
 gem 'activemodel-globalid', git: 'https://github.com/rails/activemodel-globalid'
 gem 'sidekiq'
+gem 'sidetiq'
 gem 'sinatra'
 gem 'active_record-acts_as'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,7 @@ GEM
     hitimes (1.2.2)
     humanize (1.1.0)
     i18n (0.7.0)
+    ice_cube (0.11.1)
     inflecto (0.0.2)
     interception (0.5)
     ipaddress (0.8.0)
@@ -461,6 +462,10 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    sidetiq (0.6.3)
+      celluloid (>= 0.14.1)
+      ice_cube (= 0.11.1)
+      sidekiq (>= 3.0.0)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -576,6 +581,7 @@ DEPENDENCIES
   sdoc
   selenium-webdriver
   sidekiq
+  sidetiq
   simplecov
   sinatra
   tahi_epub!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Tahi::Application.routes.draw do
   mount TahiSupportingInformation::Engine => '/', as: 'tahi_supporting_information'
 
   require 'sidekiq/web'
+  require 'sidetiq/web'
   authenticate :user, ->(u) { u.site_admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end


### PR DESCRIPTION
We have a requirement to have a recurring job, so we tried to use the clockwork gem ( to not rely on cron since we use heroku) within the engine, but we had some problem trying to make it work, so we tried to run clockwork from the main app and it worked fine, but still we can't "hardcoded" jobs in the main app since these could be run from any tahi plugin, so, I made a little research on how to handle this directly from the workers classes and I found this sidekiq plugin that will let us define the recurrence within our worker class like this:

``` ruby
class MyWorker
  include Sidekiq::Worker
  include Sidetiq::Schedulable

  recurrence { daily }

  def perform
    # do stuff ...
  end
end
```

And it works fine, but it has some gotchas, like depending on `ice_cube` gem which is slow on start-up time, so they recommend using:

`recurrence { hourly.minute_of_hour(0, 15, 30, 45) }` instead of `recurrence { minutely(15) }`

I also found that discourse stop using sidetiq because some performance issues and they replace it with their own implementation:

https://github.com/discourse/discourse/commit/e1f293ad66d8557cca7054e82b96a4d1381d9e4a

I want to know your thoughts about supporting recurring jobs in tahi

cc @mikem @rizwanreza 

thanks
