### PR TITLE
[bug] Force tasks controller to use base sti route

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,12 +10,12 @@ class TasksController < ApplicationController
 
 
   def show
-    respond_with(task)
+    respond_with(task, location: task_url(task))
   end
 
   def create
     task.save
-    respond_with(task)
+    respond_with(task, location: task_url(task))
   end
 
   def update


### PR DESCRIPTION
It was using the sti type route, eg `custom_task_url`.
