### PR TITLE
[bug] Temporarily remove /papers/:prefix/:suffix from papers url

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -13,12 +13,7 @@ class PapersController < ApplicationController
       :figures, :authors, :supporting_information_files, :paper_roles, :journal, :locked_by, :striking_image,
       phases: { tasks: [:questions, :attachments, :participations, :comments] }
     ])
-    paper = if params[:publisher_prefix].present? && params[:suffix].present?
-      doi = "#{params[:publisher_prefix]}/#{params[:suffix]}"
-      rel.find_by!(doi: doi)
-    else
-      rel.find(params[:id])
-    end
+    paper = rel.find(params[:id])
     authorize_action!(paper: paper)
     respond_with(paper)
   end

--- a/client/app/pods/paper/route.coffee
+++ b/client/app/pods/paper/route.coffee
@@ -4,14 +4,7 @@
 
 PaperRoute = Ember.Route.extend
   model: (params) ->
-    [publisher_prefix, suffix] = params.paper_id.toString().split('/')
-    if publisher_prefix && suffix
-      doi = "#{publisher_prefix}/#{suffix}"
-      RESTless.get("/papers/#{doi}").then (data) =>
-        @store.pushPayload('paper', data)
-        @store.all('paper').find (paper) -> paper.get('doi') == doi
-    else
-      @store.find('paper', params.paper_id)
+    @store.find('paper', params.paper_id)
 
   setupController: (controller, model) ->
     controller.set('model', model)
@@ -25,12 +18,6 @@ PaperRoute = Ember.Route.extend
         controller.set('supportedDownloadFormats', supportedExportFormats)
 
     Ember.$.getJSON('/formats', setFormats)
-
-  serialize: (model, params) ->
-    if doi = model.get('doi')
-      paper_id: doi
-    else
-      @_super(model, params)
 
   actions:
     addContributors: ->

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -8,7 +8,7 @@ Router.map ->
   @route('dashboard', path: '/')
   @route('flow_manager')
 
-  @resource 'paper', { path: '/papers/*paper_id' }, ->
+  @resource 'paper', { path: '/papers/:paper_id' }, ->
     @route('edit')
     @route('manage')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,7 @@ Tahi::Application.routes.draw do
       resource :editor, only: :destroy
       resource :manuscript_manager, only: :show
       resources :figures, only: :create
-      resources :tasks, only: [:update, :create, :show, :destroy] do
+      resources :tasks, only: [:update, :create, :destroy] do
         resources :comments, only: :create
       end
       member do
@@ -91,9 +91,6 @@ Tahi::Application.routes.draw do
         put :toggle_editable
         put :upload
       end
-      get "/:publisher_prefix/:suffix" => "papers#show",
-          constraints: { publisher_prefix: Doi::PUBLISHER_PREFIX_FORMAT, suffix: Doi::SUFFIX_FORMAT },
-          on: :collection
     end
     resources :participations, only: [:create, :show, :destroy]
     resources :phase_templates

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -40,7 +40,7 @@ describe PapersController do
         paper.update_column(:doi, "foobar/baz")
       end
 
-      it "returns the paper" do
+      skip "returns the paper" do
         get :show, publisher_prefix: "foobar", suffix: "baz", format: :json
         expect(response.status).to eq(200)
       end

--- a/spec/features/doi_paper_spec.rb
+++ b/spec/features/doi_paper_spec.rb
@@ -53,7 +53,7 @@ feature "Editing paper", selenium: true, js: true do
         within ".task-list-doi" do
           expect(page).to have_content "DOI: vicious/robots.8888"
         end
-        expect(page.current_path).to eq "/papers/vicious/robots.8888/edit"
+        expect(page.current_path).to eq("#{paper_path(Paper.last.id)}/edit")
       end
 
       scenario "shows the doi on the page when paper is submitted or uneditable" do
@@ -72,7 +72,7 @@ feature "Editing paper", selenium: true, js: true do
         within ".task-list-doi" do
           expect(page).to have_content "DOI: vicious/robots.8888"
         end
-        expect(page.current_path).to eq "/papers/vicious/robots.8888"
+        expect(page.current_path).to eq("#{paper_path(Paper.last.id)}")
       end
     end
 


### PR DESCRIPTION
This is breaking staging in a bunch of ways, accidentally swallowing other requests.

E.g `/papers/:id/edit` an ember url, is hitting `/papers/:prefix/:suffix`, an api route and throwing a 406 - as it should. This problem goes away when we have an api namespace.

Disabling for now to prevent distraction in staging.
