### PR TITLE
fix task generator for tahi namespace

### DIFF
--- a/client/blueprints/tahi-task/files/__tahipluginpath__/client/app/views/overlays/__name__.js
+++ b/client/blueprints/tahi-task/files/__tahipluginpath__/client/app/views/overlays/__name__.js
@@ -2,6 +2,6 @@ import OverlayView from 'tahi/views/overlay';
 
 export default OverlayView.extend({
   templateName: 'overlays/<%= dasherizedModuleName %>',
-  layoutName:   'layouts/overlay',
+  layoutName: 'layouts/overlay',
   cardName: '<%= dasherizedModuleName %>'
 });

--- a/lib/generators/tahi/task/USAGE
+++ b/lib/generators/tahi/task/USAGE
@@ -1,16 +1,25 @@
 Description:
     Generate a Tahi task in an existing Tahi plugin.
 
+    Tahi plugins must begin with the string `tahi-` and will be part
+    of the `Tahi` module.
+
+    Tasks should named foo_bar and will have the string `task`
+    appended appropriately.
+    
 Example:
-    rails generate tahi:task TASK_NAME PLUGIN_NAME
+    rails generate tahi:task FOO_BAR tahi-BAZ
 
     This will create:
-        engines/PLUGIN_NAME/app/models/PLUGIN_NAME/TASK_NAME_task.rb
-        engines/PLUGIN_NAME/app/serializers/PLUGIN_NAME/TASK_NAME_task_serializer.rb
-        engines/PLUGIN_NAME/app/policies/PLUGIN_NAME/TASK_NAME_tasks_policy.rb
-        engines/PLUGIN_NAME/client/app/adapters/TASK-NAME-task.js
-        engines/PLUGIN_NAME/client/app/controllers/overlays/TASK-NAME.js
-        engines/PLUGIN_NAME/client/app/models/TASK-NAME-task.js
-        engines/PLUGIN_NAME/client/app/serializers/TASK-NAME-task.js
-        engines/PLUGIN_NAME/client/app/templates/overlays/TASK-NAME.hbs
-        engines/PLUGIN_NAME/client/app/views/overlays/TASK-NAME.js
+        engines/tahi-BAZ/app/models/tahi/BAZ/FOO_BAR_task.rb
+        engines/tahi-BAZ/app/policies/tahi/BAZ/FOO_BAR_tasks_policy.rb
+        engines/tahi-BAZ/app/serializers/tahi/BAZ/FOO_BAR_task_serializer.rb
+
+        engines/tahi-BAZ/client/app/adapters/FOO-BAR-task.js
+        engines/tahi-BAZ/client/app/controllers/overlays/FOO-BAR.js
+        engines/tahi-BAZ/client/app/models/FOO-BAR-task.js
+        engines/tahi-BAZ/client/app/serializers/FOO-BAR-task.js
+        engines/tahi-BAZ/client/app/templates/overlays/FOO-BAR.hbs
+        engines/tahi-BAZ/client/app/views/overlays/FOO-BAR.js
+
+(Do not use UPPERCASE, this is simply for emphasis.)

--- a/lib/generators/tahi/task/task_generator.rb
+++ b/lib/generators/tahi/task/task_generator.rb
@@ -5,9 +5,12 @@ module Tahi
     argument :plugin, type: :string, required: true
 
     def generate
-      template 'model.rb', File.join(app_dir, 'models', plugin, "#{name}_task.rb")
-      template 'serializer.rb', File.join(app_dir, 'serializers', plugin, "#{name}_task_serializer.rb")
-      template 'policy.rb', File.join(app_dir, 'policies', plugin, "#{name}_tasks_policy.rb")
+      fail Exception, "Plugins must be prefixed with 'tahi'." unless plugin.match(/^tahi-/)
+      @plugin_short = plugin.gsub(/^tahi-/, '')
+      @task_name = (class_name.split(/(?=[A-Z])/) + ['Task']).join(' ')
+      template 'model.rb', File.join(app_dir, 'models', 'tahi', @plugin_short, "#{name}_task.rb")
+      template 'serializer.rb', File.join(app_dir, 'serializers', 'tahi', @plugin_short, "#{name}_task_serializer.rb")
+      template 'policy.rb', File.join(app_dir, 'policies', 'tahi', @plugin_short, "#{name}_tasks_policy.rb")
       system("cd client && ember generate tahi-task #{name} #{engine_path}")
       print_wrapped "New task #{name} generated in #{engine_path}."
       print_wrapped "Now run `rake data:create_task_types`"
@@ -22,7 +25,7 @@ module Tahi
     def engine_path
       @engine_path ||= begin
                          spec = Bundler.load.specs.detect { |s| s.name == plugin }
-                         raise Exception, "Could not find gem '#{plugin}' in the current bundle." unless spec
+                         fail Exception, "Could not find gem '#{plugin}' in the current bundle." unless spec
                          spec.full_gem_path
                        end
     end

--- a/lib/generators/tahi/task/templates/model.rb
+++ b/lib/generators/tahi/task/templates/model.rb
@@ -1,12 +1,16 @@
-module <%= @plugin.camelize %>
-  class <%= class_name %>Task < Task
-    # uncomment the following line if you want to enable event streaming for this model
-    # include EventStreamNotifier
+module Tahi
+  module <%= @plugin_short.camelize %>
+    class <%= class_name %>Task < Task
 
-    register_task default_title: "<%= class_name %> Task", default_role: "author"
+      # uncomment the following line if you want to enable event
+      # streaming for this model
+      # include EventStreamNotifier
 
-    def active_model_serializer
-      <%= class_name %>TaskSerializer
+      register_task default_title: '<%= @task_name %>', default_role: 'author'
+
+      def active_model_serializer
+        <%= class_name %>TaskSerializer
+      end
     end
   end
 end

--- a/lib/generators/tahi/task/templates/policy.rb
+++ b/lib/generators/tahi/task/templates/policy.rb
@@ -1,4 +1,6 @@
-module <%= @plugin.camelize %>
-  class <%= class_name %>TasksPolicy < ::TasksPolicy
+module Tahi
+  module <%= @plugin_short.camelize %>
+    class <%= class_name %>TasksPolicy < ::TasksPolicy
+    end
   end
 end

--- a/lib/generators/tahi/task/templates/serializer.rb
+++ b/lib/generators/tahi/task/templates/serializer.rb
@@ -1,4 +1,6 @@
-module <%= @plugin.camelize %>
-  class <%= class_name %>TaskSerializer < ::TaskSerializer
+module Tahi
+  module <%= @plugin_short.camelize %>
+    class <%= class_name %>TaskSerializer < ::TaskSerializer
+    end
   end
 end


### PR DESCRIPTION
rails generate tahi:task foo engines/bar was not working for the new
Tahi:: module convention.
