### PR TITLE
Fix Add Authors feature spec

### DIFF
--- a/engines/plos_authors/spec/features/add_authors_spec.rb
+++ b/engines/plos_authors/spec/features/add_authors_spec.rb
@@ -12,12 +12,10 @@ feature "Add contributing authors", js: true do
 
     sign_in_page = SignInPage.visit
     sign_in_page.sign_in creator
-
-    click_link paper.title
   end
 
   scenario "Author specifies contributing authors" do
-    edit_paper = EditPaperPage.new
+    edit_paper = DashboardPage.new.view_submitted_paper paper
 
     edit_paper.view_card(task.title) do |overlay|
       overlay.add_author(first_name: 'Neils',
@@ -34,13 +32,13 @@ feature "Add contributing authors", js: true do
   context "with an existing author" do
     let!(:author) { FactoryGirl.create :plos_author, paper: paper, plos_authors_task: task }
 
-    skip "editing", selenium: true do
-      edit_paper = EditPaperPage.new
+    scenario "editing", selenium: true do
+      edit_paper = DashboardPage.new.view_submitted_paper paper
       edit_paper.view_card(task.title) do |overlay|
         overlay.edit_author author.first_name,
           last_name: 'rommel',
           email: 'ernie@berlin.de'
-        visit current_url
+        overlay.reload
         within '.authors-overlay-list' do
           expect(page).to have_content "ernie@berlin.de"
           expect(page).to have_content "rommel"
@@ -48,8 +46,8 @@ feature "Add contributing authors", js: true do
       end
     end
 
-    skip "validation on task completion", selenium: true do
-      edit_paper = EditPaperPage.new
+    scenario "validation on task completion", selenium: true do
+      edit_paper = DashboardPage.new.view_submitted_paper paper
       edit_paper.view_card(task.title) do |overlay|
         overlay.edit_author author.first_name,
           email: 'invalid_email_string'
@@ -61,8 +59,8 @@ feature "Add contributing authors", js: true do
       end
     end
 
-    scenario "deleting", selenium: true, flaky: true do
-      edit_paper = EditPaperPage.new
+    scenario "deleting", selenium: true do
+      edit_paper = DashboardPage.new.view_submitted_paper paper
       edit_paper.view_card(task.title) do |overlay|
         overlay.delete_author author.first_name
         within '.authors-overlay-list' do


### PR DESCRIPTION
The specs inside the "with an existing author" context all rely on an
existing author. The author is created with `let!` as soon as we enter
the context. However, in the `before` block outside of the context we
navigate to the edit page.

The browser is now looking at the edit page and _then_ the author is
created. This change in the data on the back end doesn't propagate up to
the browser. When the authors card is opened, the expected author isn't
there, and the specs fail.

In this change we move the act of navigating from the dashboard to the
edit page to inside each scenario. This way we load the edit page after
all its data has been set up on the back end.
