### PR TITLE
Update migration task name

### DIFF
--- a/lib/tasks/custom_cards.rake
+++ b/lib/tasks/custom_cards.rake
@@ -27,7 +27,7 @@ namespace :tahi do
       if `bundle exec rake -T #{migration_task}`.size > 0
         sh "bundle exec rake #{migration_task}"
       else
-        puts "No migrations found for this card. You can install card migrations with #{migration_task}."
+        puts "No migration task found for this card. If you add migrations for #{engine_name} in in the future, you can install migrations with #{migration_task}."
       end
       
       # tahi magic installer


### PR DESCRIPTION
If the engine name uses dashes then the migration installation will fail silently.  This pull request:
- Replaces dashes with underscores for the migration task to successfully install migrations.
- No longer fails silently for migrations and now notifies the user how to install migrations in the future if no migrations exist.
- No longer inserts duplicate lines in the Gemfile and routes.rb if the rake task is rerun on failure.
