### PR TITLE
Update plos bio tech check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,10 +18,10 @@ GIT
 
 GIT
   remote: https://f11148f2df58b9d5966b2543f6a0d3c035985f88:x-oauth-basic@github.com/tahi-project/plos_bio_tech_check
-  revision: 6b0487ab978ada05dfc07e6647d9c89a90796b7c
+  revision: 059786c8ce89a84af31040696692a5fd08c9d0aa
   specs:
     plos_bio_tech_check (0.0.1)
-      rails (~> 4.2.0)
+      rails (= 4.2.1)
 
 GIT
   remote: https://f11148f2df58b9d5966b2543f6a0d3c035985f88:x-oauth-basic@github.com/tahi-project/tahi_epub
@@ -276,12 +276,11 @@ GEM
     gepub (0.7.0beta1)
       nokogiri (~> 1.6.1)
       rubyzip (>= 1.1.1)
-    globalid (0.3.3)
+    globalid (0.3.5)
       activesupport (>= 4.1.0)
     hashie (2.1.1)
     heroku-deflater (0.5.3)
       rack (>= 1.4.5)
-    hike (1.2.3)
     hitimes (1.2.2)
     humanize (1.1.0)
     i18n (0.7.0)
@@ -309,7 +308,7 @@ GEM
     mime-types (2.4.3)
     mini_magick (4.1.0)
     mini_portile (0.6.2)
-    minitest (5.5.1)
+    minitest (5.6.0)
     multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -470,11 +469,8 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.6.0)
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.0.0)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
     sprockets-rails (2.2.4)
       actionpack (>= 3.0)
       activesupport (>= 3.0)


### PR DESCRIPTION
- Fix tech check to be admin default role

Had to lock plos_bio_tech_check to rails 4.2.1 (our version at time of PR) because `~> 4.2.0` brings in sprockets 3, which currently breaks our asset compilation.

Should be ready for sprockets 3 once https://github.com/Tahi-project/tahi/pull/1017 is merged.
