### PR TITLE
Force a reload on the task for every task.

### DIFF
--- a/client/app/store.coffee
+++ b/client/app/store.coffee
@@ -16,7 +16,9 @@ ApplicationStore = DS.Store.extend
   findTask: (id) ->
     matchingTask = @allTaskClasses().find (tm) -> tm.idToRecord[id]
     if matchingTask
-      matchingTask.idToRecord[id]
+      matchingTask.idToRecord[id].reload()
+    else
+      null
 
   # resume the event stream after saving
   didSaveRecord: (record, data) ->

--- a/engines/tahi_standard_tasks/client/app/controllers/overlays/paper-reviewer.coffee
+++ b/engines/tahi_standard_tasks/client/app/controllers/overlays/paper-reviewer.coffee
@@ -9,7 +9,7 @@ PaperReviewerOverlayController = TaskController.extend Select2Assignees,
   resultsTemplate: (user) -> user.email
   selectedTemplate: (user) -> user.email
 
-  latestDecision: Ember.computed 'model.decisions.@each.isLatest', ->
+  latestDecision: Ember.computed 'model.decisions', 'model.decisions.@each.isLatest', ->
     @get('model.decisions').findBy 'isLatest', true
 
   actions:


### PR DESCRIPTION
Currently if Task A relies on data that is modifiable by Task B,
Task A won't necessarily get the freshest data since `store.findTask` is
grabbing the task from the local cache. This seems to be relevant especially for
collections. In this case, completing "Register Decision" creates a decision on the
backend, which "Invite Reviewers" relies on. When the user exists Register Decision
and opens Invite Reviewers, the latest decision is not in the data store.

Story: https://www.pivotaltracker.com/story/show/92459642
