### PR TITLE
Use unnamespaced subscription name for supporting info file

### DIFF
--- a/config/initializers/subscriptions.rb
+++ b/config/initializers/subscriptions.rb
@@ -36,7 +36,7 @@ TahiNotifier.subscribe("paper_role:destroyed") do |subscription_name, payload|
   EventStream.new(action, record.paper, subscription_name).destroy_for(record.user)
 end
 
-TahiNotifier.subscribe("supporting_information/file:created", "supporting_information/file:updated") do |subscription_name, payload|
+TahiNotifier.subscribe("supporting_information_file:created", "supporting_information_file:updated") do |subscription_name, payload|
   action = payload[:action]
   record = payload[:record]
 


### PR DESCRIPTION
Looks like the event stream subscription wasn't updated after the engine was moved into tahi standard tasks engine.
