### PR TITLE
fix deep namespaces from task type

### DIFF
--- a/client/app/serializers/dashboard.coffee
+++ b/client/app/serializers/dashboard.coffee
@@ -3,7 +3,6 @@
 DashboardSerializer = ApplicationSerializer.extend
   normalizeHash:
     tasks: (hash)->
-      hash.qualified_type = hash.type
-      hash.type = hash.type.replace(/.+::/, '')
+      hash = @normalizeType(hash)
 
 `export default DashboardSerializer`


### PR DESCRIPTION
was only stripping Foo:: from Foo::Bar::Baz; it should strip Foo::Bar::
