### PR TITLE
Adds 'kind' as acceptable param for attachments controller

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -26,6 +26,6 @@ class AttachmentsController < ApplicationController
   end
 
   def attachment_params
-    params.require(:attachment).permit(:title, :caption, :attachment_type)
+    params.require(:attachment).permit(:title, :caption, :kind)
   end
 end

--- a/app/serializers/attachment_serializer.rb
+++ b/app/serializers/attachment_serializer.rb
@@ -1,5 +1,5 @@
 class AttachmentSerializer < ActiveModel::Serializer
-  attributes :id, :title, :caption, :src, :status, :preview_src, :attachable
+  attributes :id, :title, :caption, :kind, :src, :status, :preview_src, :attachable
 
   def src
     object.file.url

--- a/client/app/models/attachment.coffee
+++ b/client/app/models/attachment.coffee
@@ -11,7 +11,7 @@ Attachment = DS.Model.extend
   src: a('string')
   status: a('string')
   title: a('string')
-  attachmentType: a('string')
+  kind: a('string')
 
 
 `export default Attachment`

--- a/db/migrate/20150420163630_rename_attachment_type_as_kind.rb
+++ b/db/migrate/20150420163630_rename_attachment_type_as_kind.rb
@@ -1,0 +1,5 @@
+class RenameAttachmentTypeAsKind < ActiveRecord::Migration
+  def change
+    rename_column :attachments, :attachment_type, :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150416184531) do
+ActiveRecord::Schema.define(version: 20150420163630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 20150416184531) do
     t.string   "title",           limit: 255
     t.string   "caption",         limit: 255
     t.string   "status",          limit: 255, default: "processing"
-    t.string   "attachment_type"
+    t.string   "kind"
   end
 
   create_table "authors", force: :cascade do |t|


### PR DESCRIPTION
This is related to [PR 1061](https://github.com/Tahi-project/tahi/pull/1061) which added the attachment_type column.  This PR renames attachment_type to `kind` and accepts `kind` as a permitted parameter for the `attachments_controller` so different actions can set this column.
