### PR TITLE
remove textacular initializer

### DIFF
--- a/config/initializers/textacular.rb
+++ b/config/initializers/textacular.rb
@@ -1,6 +1,0 @@
-# fuzzy searches are subject to a similarity threshold imposed by the 
-# pg_trgm module.  The default is 0.3, meaning that at least 30% of the
-# total string must match your search content.
-
-PG_SIMILARLITY = 0.1
-ActiveRecord::Base.connection.execute("SELECT set_limit(#{PG_SIMILARLITY});")


### PR DESCRIPTION
References:  https://www.pivotaltracker.com/n/projects/880854

Textacular will be removed soon and this initializer is causing issues for some people.  So, removing this for not.  Implications:  fuzzy search will continue to default to a 30% similarity match.

--- AC + CT
