### PR TITLE
Move textacular -> pg_search for fuzzy searching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'faraday_middleware'
 gem 'ordinalize'
 gem 'migration_data'
 gem 'bugsnag'
-gem 'textacular'
+gem 'pg_search'
 gem 'aasm'
 gem 'bootstrap-sass'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,10 @@ GEM
     orm_adapter (0.5.0)
     pdfkit (0.6.2)
     pg (0.18.1)
+    pg_search (1.0.0)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
+      arel
     progressbar (0.21.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -480,8 +484,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    textacular (3.2.1)
-      activerecord (>= 3.0, < 5.0)
     thin (1.6.3)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0)
@@ -553,6 +555,7 @@ DEPENDENCIES
   ordinalize
   pdfkit
   pg
+  pg_search
   plos_authors!
   plos_billing!
   plos_bio_tech_check!
@@ -582,7 +585,6 @@ DEPENDENCIES
   tahi_epub!
   tahi_standard_tasks!
   tahi_upload_manuscript!
-  textacular
   thin
   timecop
   timeliness

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,12 @@
-require 'textacular/searchable'
-
 class User < ActiveRecord::Base
 
   include UserDevise
 
-  extend Searchable :first_name, :last_name, :email, :username
+  include PgSearch
+  pg_search_scope :fuzzy_search,
+    against: [:first_name, :last_name, :email, :username],
+    ignoring: :accents,
+    using: { tsearch: { prefix: true }, trigram: { threshold: 0.08 } }
 
   has_many :affiliations, inverse_of: :user
   has_many :submitted_papers, inverse_of: :creator, class_name: 'Paper'

--- a/config/initializers/textacular.rb
+++ b/config/initializers/textacular.rb
@@ -1,6 +1,0 @@
-# fuzzy searches are subject to a similarity threshold imposed by the 
-# pg_trgm module.  The default is 0.3, meaning that at least 30% of the
-# total string must match your search content.
-
-PG_SIMILARLITY = 0.1
-ActiveRecord::Base.connection.execute("SELECT set_limit(#{PG_SIMILARLITY});")


### PR DESCRIPTION
## References

https://www.pivotaltracker.com/story/show/92629028
## tl;dr

`textacular` gem does not support an in-built way to handle similarity matches, but `pg_search` gem does.  So, switcharoo.

--- AC + CT
