### PR TITLE
Load env variables before gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby "2.2.0"
 
 # Configuration
 group :development, :test, :performance do
-  gem 'dotenv-rails'
+  gem 'dotenv-rails', :require => 'dotenv/rails-now'
 end
 
 # Task Engines


### PR DESCRIPTION
We use gems that require environment variables so we want these env
variables to be loaded before them

https://github.com/bkeepers/dotenv#note-on-load-order
