### PR TITLE
Cache dashboard papers query until we can rm it

### DIFF
--- a/app/serializers/dashboard_serializer.rb
+++ b/app/serializers/dashboard_serializer.rb
@@ -21,7 +21,7 @@ class DashboardSerializer < ActiveModel::Serializer
   end
 
   def most_recent_paper_roles
-    PaperRole.most_recent_for(user).page(1)
+    @most_recent_paper_roles ||= PaperRole.includes(:paper).most_recent_for(user).page(1)
   end
 
   def user


### PR DESCRIPTION
We call it a couple times, and it always loads up it's associated paper.

Planning on removing the dashboard model on the client and rethinking how data is serialized on the dashboard. Holding off on that work until we discuss improving the dashboard.

For now, cache and eager load.
