### PR TITLE
clear validation errors on transition

### DIFF
--- a/client/app/pods/task/controller.coffee
+++ b/client/app/pods/task/controller.coffee
@@ -66,5 +66,6 @@ TaskController = Ember.Controller.extend SavesDelayed, ControllerParticipants, V
           return
 
       @clearCachedModel(transition)
+      @clearAllValidationErrors()
 
 `export default TaskController`


### PR DESCRIPTION
There may be a better way to do this.

Without this fix, validation errors stick around when a card is closed and reopened, which is strange if the errors are triggered by clicking the "completed" box.
