### PR TITLE
remove coffee-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem 'pg'
 gem 'ember-cli-rails'
 gem 'sass-rails'
 gem 'uglifier'
-gem 'coffee-rails'
 gem 'acts_as_list', github: 'swanandp/acts_as_list', ref: "84325ede9ad528acbf68a97c5070cff113ee6a17"
 gem 'devise'
 gem 'bourbon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,13 +150,6 @@ GEM
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
-    coffee-rails (4.1.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
-    coffee-script (2.3.0)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.8.0)
     columnize (0.9.0)
     connection_pool (2.1.2)
     crack (0.4.2)
@@ -541,7 +534,6 @@ DEPENDENCIES
   capybara-webkit
   carrierwave
   codeclimate-test-reporter
-  coffee-rails
   database_cleaner
   devise
   dotenv-rails


### PR DESCRIPTION
it looks like `.coffee` only remains in `/client` 

:100: 
:+1: 
:bow: 
