### PR TITLE
Stop running rails assets through ember-cli-rails middleware

### DIFF
--- a/config/initializers/ember.rb
+++ b/config/initializers/ember.rb
@@ -2,6 +2,6 @@ EmberCLI.configure do |c|
   c.app(:tahi, {
     path: Rails.root.join('client'),
     build_timeout: 15,
-    enable: -> path { !path.starts_with?("/api/") }
+    enable: -> path { !%r{/(?:api|assets)/}.match(path) }
   })
 end


### PR DESCRIPTION
Seems to speed up development to be closer to how staging feels on reloads.

However, I'm not sure yet if I'm stepping on ember-cli-rails by doing this. Checking tests.
