### PR TITLE
Cleanup ancillary views on route transition

### DIFF
--- a/client/app/controllers/overlays/paper-new.js
+++ b/client/app/controllers/overlays/paper-new.js
@@ -51,9 +51,7 @@ export default Ember.Controller.extend(AnimateOverlay, {
   actions: {
     createNewPaper() {
       this.get('model').save().then((paper)=> {
-        this.animateOverlayOut().then(()=> {
-          this.transitionToRoute('paper.edit', paper);
-        });
+        this.transitionToRoute('paper.edit', paper);
       }, (response)=> {
         this.flash.displayErrorMessagesFromResponse(response);
       });

--- a/client/app/pods/application/route.js
+++ b/client/app/pods/application/route.js
@@ -22,6 +22,17 @@ export default Ember.Route.extend(AnimateOverlay, {
     return this.get('container').lookup("serializer:application");
   }),
 
+  cleanupAncillaryViews: function() {
+    this.controllerFor('application').send('hideNavigation');
+
+    this.animateOverlayOut().then(()=> {
+      this.disconnectOutlet({
+        outlet: 'overlay',
+        parentView: 'application'
+      });
+    });
+  },
+
   actions: {
     willTransition(transition) {
       let appController = this.controllerFor('application');
@@ -34,7 +45,8 @@ export default Ember.Route.extend(AnimateOverlay, {
           return;
         }
       }
-      return appController.send('hideNavigation');
+
+      this.cleanupAncillaryViews();
     },
 
     error(response, transition) {
@@ -55,12 +67,7 @@ export default Ember.Route.extend(AnimateOverlay, {
 
     closeOverlay() {
       this.flash.clearAllMessages();
-      this.animateOverlayOut().then(()=> {
-        this.disconnectOutlet({
-          outlet: 'overlay',
-          parentView: 'application'
-        });
-      });
+      this.cleanupAncillaryViews();
     },
 
     closeFeedbackOverlay() {

--- a/client/app/pods/paper/task/controller.coffee
+++ b/client/app/pods/paper/task/controller.coffee
@@ -40,8 +40,7 @@ TaskController = Ember.Controller.extend AnimateOverlay, SavesDelayed, Controlle
   actions:
 
     closeAction: ->
-      @animateOverlayOut().then =>
-        @send(@get('onClose'))
+      @send(@get('onClose'))
 
     redirect: ->
       @transitionToRoute.apply(this, @get('controllers.application.overlayRedirect.lastObject'))


### PR DESCRIPTION
– Manually animating out an overlay no longer required
