### PR TITLE
Fix custom card install scss @import

### DIFF
--- a/lib/tasks/custom_cards.rake
+++ b/lib/tasks/custom_cards.rake
@@ -40,8 +40,7 @@ namespace :tahi do
 
     # modify application.scss
     needle = "// DO NOT DELETE OR EDIT. AUTOMATICALLY MOUNTED CUSTOM TASK CARDS GO HERE"
-
-    insert_after("client/app/styles/tahi.scss", needle, "@import '#{engine_path}/application';")
+    insert_after("app/assets/stylesheets/application.scss", needle, "@import '#{engine_path}/application';")
 
     # offer help
     help_url = "https://github.com/Tahi-project/tahi/wiki/HOWTO:-Customizing-Custom-Cards#custom-card-styles"


### PR DESCRIPTION
With rollback of using ember to manage assets, the custom card installer
got left behind. Fix the location of the @import.
