### PR TITLE
Avoid race condition delaying the pushPayload call

### DIFF
--- a/client/app/pods/application/route.js
+++ b/client/app/pods/application/route.js
@@ -102,7 +102,10 @@ export default Ember.Route.extend(AnimateOverlay, {
     updated(payload) {
       let description = "Pusher: updated";
       Utils.debug(description, payload);
-      this.store.pushPayload(payload);
+
+      Ember.run.later(() => {
+        this.store.pushPayload(payload);
+      }, 100);
     },
 
     destroyed(payload) {


### PR DESCRIPTION
I've found issue with the ember data store when we receive a response from an endpoint and immediately after that we receive event stream from the server with the same content receive a moment earlier in the payload, that produce a duplication of records in the `store`, same ID.. same model

Ex: http://monosnap.com/file/BkORJ3Mm3q7lFOAIlkXfwXfoFzAADL

I thought that this could be a race condition.. so I looked into place where we update the ember store with the payload that comes from slanger and handle this instruction manually in the event run loop.

so I tried with `Ember.run.next` but sometimes worked, sometimes not, so  after reading the docs:

"Schedules an item to run from within a separate run loop, after control has been returned to the system. This is equivalent to calling run.later with a wait time of 1ms.”

I tried with `Ember.run.later` and it always worked.

so if this line:

`this.store.pushPayload(payload);`

becomes:

``` javascript
Ember.run.later(() => {
  this.store.pushPayload(payload);
}, 100);
```

I don’t know which number of milliseconds is best to avoid the race condition, but 100 ms have worked well.

Let me know your thoughts about this solution :+1: 

PS: I've only updated the code in the `updated` action since is the only event that I had the problem
