### PR TITLE
Set engines to be watched by ember-cli.

### DIFF
--- a/engines/plos_authors/client/index.js
+++ b/engines/plos_authors/client/index.js
@@ -2,5 +2,8 @@
 'use strict';
 
 module.exports = {
-  name: 'tahi-plos-authors-card'
+  name: 'tahi-plos-authors-card',
+  isDevelopingAddon: function() {
+    return true;
+  }
 };

--- a/engines/plos_billing/client/index.js
+++ b/engines/plos_billing/client/index.js
@@ -1,6 +1,5 @@
 module.exports = {
   name: 'plos_billing',
-
   isDevelopingAddon: function() {
     return true;
   }

--- a/engines/tahi_standard_tasks/client/index.js
+++ b/engines/tahi_standard_tasks/client/index.js
@@ -2,5 +2,9 @@
 'use strict';
 
 module.exports = {
-  name: 'tahi-standard-cards'
+  name: 'tahi-standard-cards',
+  isDevelopingAddon: function() {
+    return true;
+  }
 };
+

--- a/engines/tahi_upload_manuscript/client/index.js
+++ b/engines/tahi_upload_manuscript/client/index.js
@@ -2,5 +2,8 @@
 'use strict';
 
 module.exports = {
-  name: 'tahi-upload-manuscript-card'
+  name: 'tahi-upload-manuscript-card',
+  isDevelopingAddon: function() {
+    return true;
+  }
 };


### PR DESCRIPTION
This is so one does not have to manually touch something in the root `client` folder every time a change is made to an embedded plugin.

History:

http://discuss.emberjs.com/t/solved-watch-addon-directory-for-changes/6410/6

https://github.com/emberjs/ember.js/issues/11185

https://github.com/ember-cli/ember-cli/blob/master/ADDON_HOOKS.md#isdevelopingaddon
