### PR TITLE
Fix problem with specs checking auth API failing

### DIFF
--- a/app/controllers/concerns/authorizations.rb
+++ b/app/controllers/concerns/authorizations.rb
@@ -19,7 +19,7 @@ module Authorizations
   end
 
   def render_forbidden
-    if request.xhr?
+    if request.xhr? || (request.format != :html)
       head :forbidden
     else
       redirect_to root_path

--- a/spec/controllers/paper_conversions_controller_spec.rb
+++ b/spec/controllers/paper_conversions_controller_spec.rb
@@ -23,12 +23,11 @@ describe PaperConversionsController, type: :controller do
 
     context "as a user with no access" do
       let(:user) { create :user }
-      it "returns a 401" do
+      it "returns a 403" do
         VCR.use_cassette('not_authorized_convert_to_docx') do
           get :export, id: paper.id, format: 'docx'
         end
-        expect(response.status).to eq(302)
-        expect(response).to redirect_to :root
+        expect(response.status).to eq(403)
       end
     end
   end


### PR DESCRIPTION
When rspec tests were checking the API (format: json), the Authorization
concern would redirect them to the root controller rather than rendering
a 403, unless xhr were used.

Change this so that failed authorization only redirects to root if the
requested format is HTML.
