### PR TITLE
add new internal_address_definition for mail_safe

### DIFF
--- a/config/initializers/mail_safe.rb
+++ b/config/initializers/mail_safe.rb
@@ -1,3 +1,4 @@
 if defined?(MailSafe::Config)
+  MailSafe::Config.internal_address_definition = Proc.new { false }
   MailSafe::Config.replacement_address = ENV.fetch('MAILSAFE_REPLACEMENT_ADDRESS')
 end


### PR DESCRIPTION
Needed to specify additional `mail_safe` settings, per: https://github.com/myronmarston/mail_safe to fix the error below on `tahi-staging`

![screen shot 2015-06-15 at 2 32 07 pm](https://cloud.githubusercontent.com/assets/67984/8171242/5788fae2-136b-11e5-834e-69fb4e6a6697.png)
