### PR TITLE
Set attachments to 'done' only after successful save

### DIFF
--- a/app/workers/download_adhoc_task_attachment_worker.rb
+++ b/app/workers/download_adhoc_task_attachment_worker.rb
@@ -6,7 +6,7 @@ class DownloadAdhocTaskAttachmentWorker
     attachment.file.download! url
     attachment.title = attachment.file.filename
     if attachment.save
-      attachment.update_column('status', 'done')
+      attachment.update_attribute('status', 'done')
     end
   end
 end


### PR DESCRIPTION
- This was causing issues with our card since we only apply validations if the attachment is truly 'done'
- Since originally the status was set to done before save, it was not possible to check to see if an attachment was processing or not during validations.
