### PR TITLE
Always force ssl in staging

### DIFF
--- a/config/environments/performance.rb
+++ b/config/environments/performance.rb
@@ -40,7 +40,7 @@ Tahi::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,7 +1,6 @@
 require_relative 'production'
 
 Tahi::Application.configure do
-  config.force_ssl = false if ENV["DISABLE_SSL"]
   config.basic_auth_required = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.


### PR DESCRIPTION
References:
- https://www.pivotaltracker.com/story/show/97539832
- @mikem, gina just found this older pivotal card which says this work is dependent on another card, but we don't have permission to open it:  https://www.pivotaltracker.com/story/show/96141628

Also Note:
- `staging` environment config already required (and therefore overrides) from `production` environment config

Upon staging deploy:
- remove `DISABLE_SSL` config var

TL;DR:
- going to a non-ssl route in any non-development environment will cause slanger websocket to fail silently.  See above url for more info.
