### PR TITLE
Adjust font size & spacing on card thumbnails

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -34,10 +34,11 @@
   border-radius: 5px;
   padding: 10px 15px;
   color: $tahi-green-dark;
-  font-size: 18px;
-  word-wrap: break-word;
+  font-size: 20px;
   background-color: $tahi-green-light;
   cursor: pointer;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
   .badge {
     position: absolute;
     top: -5px;
@@ -67,7 +68,7 @@
 // .card modifier:
 .card--completed {
   .card-content {
-    padding-left: 37px;
+    padding-left: 45px;
     color: $tahi-grey-light - #666;
     background: $tahi-grey-light;
   }


### PR DESCRIPTION
This will prevent the text in a completed "Reviewer Recommendations" card thumbnail from wrapping.

Before:

![screen shot 2015-06-25 at 4 15 55 pm](https://cloud.githubusercontent.com/assets/62569/8367669/93d708e4-1b55-11e5-9387-673a739c98f4.png)

After:

![screen shot 2015-06-25 at 4 16 05 pm](https://cloud.githubusercontent.com/assets/62569/8367683/a59b3578-1b55-11e5-8e4a-07c5ef48a7ad.png)
