### PR TITLE
Destroying a task destroys its questions, too

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,7 +23,7 @@ class Task < ActiveRecord::Base
   has_one :paper, through: :phase
   has_one :journal, through: :paper
   has_many :attachments, as: :attachable
-  has_many :questions, inverse_of: :task
+  has_many :questions, inverse_of: :task, dependent: :destroy
   has_many :participations, inverse_of: :task, dependent: :destroy
   has_many :participants, through: :participations, source: :user
 


### PR DESCRIPTION
We discovered this to be the root cause for papers not loading on tahi-lean-workflow. The events we believe lead to such a state:
1. A paper receives a revise decision
2. A decision object is created, and all the paper's task's questions have their `decision_id` set
3. Somebody destroys a task, leaving orphaned questions behind
4. When the paper is serialized again, its decisions are serialized, each decision's questions are serialized, and each question has a reference to its task; if the task is missing, `Question#task == nil`, which makes the serialization process explode :boom:
