### PR TITLE
Force foreman to use config overrides

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,2 +1,3 @@
 port: 5000
 procfile: Procfile.local
+env: .env,.env.local

--- a/bin/slanger-start
+++ b/bin/slanger-start
@@ -23,7 +23,7 @@ def rails_env
 end
 
 Bundler.with_clean_env do
-  Dotenv.load(".env.#{rails_env}")
+  Dotenv.load
   validate_slanger!
   validate_event_stream_config!
   verbose = "-v" if rails_env == "development"


### PR DESCRIPTION
The dotenv gem allows overriding environment vars in the following 
order:
1. `.env`
2. `.env.<current environment>`
3. `.env.local` 

However, foreman has its own mechanism for loading environment configs and only loads `.env`, so no overrides will work.

This change forces foreman to adhere to the convention established by tahi which is to put general configurations in `.env` and override them in the `.env.local` file.
