### PR TITLE
Reset feedback overlay after close

### DIFF
--- a/client/app/controllers/overlays/feedback.js
+++ b/client/app/controllers/overlays/feedback.js
@@ -25,7 +25,6 @@ export default Ember.Controller.extend({
 
     closeAction() {
       this.send('closeFeedbackOverlay');
-      this.set('feedbackSubmitted', false);
     },
 
     uploadFinished(data, filename) {

--- a/client/app/views/overlays/feedback.js
+++ b/client/app/views/overlays/feedback.js
@@ -13,6 +13,9 @@ export default OverlayView.extend({
       extraClasses: this.get('controller.overlayClass')
     };
 
+    // TEMP HACK: Remove when on Ember 1.13
+    this.get('controller').set('feedbackSubmitted', false);
+
     Ember.run.scheduleOnce('afterRender', this, this.animateOverlayIn, options);
   }.on('didInsertElement'),
 });


### PR DESCRIPTION
Hack for now that can be removed when the Ember 1.13 branch is merged.
