### PR TITLE
move some components to an Admin section

### DIFF
--- a/client/app/pods/styleguide/admin/nav/template.hbs
+++ b/client/app/pods/styleguide/admin/nav/template.hbs
@@ -1,0 +1,40 @@
+<nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm">
+  <ul class="nav bs-docs-sidenav">
+    <li>
+      <ul class="nav">
+        <li>
+          <a href="#format">Format</a>
+        </li>
+        <li>
+          <a href="#header-footer">Header/Footer</a>
+        </li>
+        <li>
+          <a href="#body">Body</a>
+          <ul>
+            <li>
+              <a href="#ordered-instructions">Ordered Instructions</a>
+            </li>
+            <li>
+              <a href="#radio-buttons">Radio Buttons</a>
+            </li>
+            <li>
+              <a href="#checkboxes">Checkboxes</a>
+            </li>
+            <li>
+              <a href="#buttons">Buttons</a>
+            </li>
+            <li>
+              <a href="#pulldowns">Pulldowns</a>
+            </li>
+            <li>
+              <a href="#forms">Forms</a>
+            </li>
+            <li>
+              <a href="#content-entry">Content Entry</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</nav>

--- a/client/app/pods/styleguide/admin/template.hbs
+++ b/client/app/pods/styleguide/admin/template.hbs
@@ -1,0 +1,97 @@
+<h2 id="admin">
+  Admin
+</h2>
+
+<div class="constrain">
+
+  <hr>
+
+  <section>
+    <h3>
+      card-preview
+    </h3>
+
+    {{card-preview paper=paper
+                   task=task
+                   canRemoveCard=true
+                   showDeleteConfirm="showDeleteConfirm"
+                   canDragCard=true
+                   action="viewCard"}}
+  </section>
+
+  <hr>
+
+  <section>
+    <h3>
+      phase-column
+    </h3>
+
+    <ul class="columns">
+      {{phase-column phase=phase
+                     paper=paper
+                     savePhase="savePhase"
+                     addPhase="addPhase"
+                     showDeleteConfirm="showDeleteConfirm"
+                     removePhase="removePhase"
+                     rollbackPhase="rollbackPhase"
+                     viewCard="viewCard"
+                     chooseNewCardTypeOverlay="chooseNewCardTypeOverlay"
+                     changePhaseForTask="changePhaseForTask"}}
+    </ul>
+  </section>
+
+  <hr>
+
+  <section>
+    <h3>
+      flow-column
+    </h3>
+
+    <ul class="columns">
+      {{flow-column flow=flow
+                    papers=flow.papers
+                    editable=false
+                    journalName=flow.journalName
+                    journalLogo=flow.journalLogo
+                    saveFlow="saveFlow"
+                    removeFlow="removeFlow"
+                    viewCard="viewCard"}}
+    </ul>
+  </section>
+
+
+  <hr>
+
+  <section>
+    <h3>
+      flow-task-group
+    </h3>
+
+    {{flow-task-group task=task
+                      viewCard="viewCard"}}
+  </section>
+
+  <hr>
+
+  <section>
+    <h3>
+      add-column
+    </h3>
+
+    {{add-column position=1 action="addPhase"}}
+  </section>
+
+  <hr>
+
+  <section>
+    <h3>
+      user-role-selector
+    </h3>
+
+    {{user-role-selector journalRoles=cities
+                         userJournalRoles=cities
+                         selected="assignRole"
+                         removed="removeRole"}}
+
+  </section>
+</div>

--- a/client/app/pods/styleguide/cards/template.hbs
+++ b/client/app/pods/styleguide/cards/template.hbs
@@ -514,31 +514,6 @@
 
   <section>
     <h3>
-      card-preview
-    </h3>
-
-    {{card-preview paper=paper
-                   task=task
-                   canRemoveCard=true
-                   showDeleteConfirm="showDeleteConfirm"
-                   canDragCard=true
-                   action="viewCard"}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      add-column
-    </h3>
-
-    {{add-column position=1 action="addPhase"}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
       inline-edit-body-part
     </h3>
 
@@ -610,23 +585,6 @@
         {{option.text}}
       </label>
     {{/each}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      flow-column
-    </h3>
-
-    {{flow-column flow=flow
-                  papers=flow.papers
-                  editable=false
-                  journalName=flow.journalName
-                  journalLogo=flow.journalLogo
-                  saveFlow="saveFlow"
-                  removeFlow="removeFlow"
-                  viewCard="viewCard"}}
   </section>
 
   <hr>
@@ -780,17 +738,6 @@
 
   <section>
     <h3>
-      flow-task-group
-    </h3>
-
-    {{flow-task-group task=task
-                      viewCard="viewCard"}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
       dashboard-link
     </h3>
 
@@ -831,25 +778,6 @@
                             canEdit=true
                             isEditing=false}}
 
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      phase-column
-    </h3>
-
-    {{phase-column phase=phase
-                   paper=paper
-                   savePhase="savePhase"
-                   addPhase="addPhase"
-                   showDeleteConfirm="showDeleteConfirm"
-                   removePhase="removePhase"
-                   rollbackPhase="rollbackPhase"
-                   viewCard="viewCard"
-                   chooseNewCardTypeOverlay="chooseNewCardTypeOverlay"
-                   changePhaseForTask="changePhaseForTask"}}
   </section>
 
   <hr>
@@ -900,20 +828,6 @@
 
   <section>
     <h3>
-      user-role-selector
-    </h3>
-
-    {{user-role-selector journalRoles=cities
-                         userJournalRoles=cities
-                         selected="assignRole"
-                         removed="removeRole"}}
-
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
       datum-definition
     </h3>
 
@@ -924,128 +838,4 @@
 
   <hr>
 
-  <section>
-    <h3>
-      comment-board
-    </h3>
-
-    {{comment-board comments=comments
-                    currentUser=user
-                    postComment="postComment"}}
-
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      expanding-textarea
-    </h3>
-
-    {{#expanding-textarea}}
-      {{textarea value="Reply Text Goes Here" class="inset-form-control-textarea discussion-topic-comment-field" placeholder="First comment!"}}
-    {{/expanding-textarea}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      discussion-reply
-    </h3>
-
-    {{discussion-reply reply=commentReply}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      inline-edit-text
-    </h3>
-
-    {{inline-edit-text
-      bodyPart=inlineEditBody
-      isNew=true
-      delete="deleteItem"
-      saveModel="saveModel"}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      inline-edit-checkbox
-    </h3>
-
-    {{inline-edit-checkbox
-      bodyPart=inlineEditBody
-      isNew=true
-      delete="deleteItem"
-      saveModel="saveModel"}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      inline-edit-email
-    </h3>
-
-    {{inline-edit-email
-      bodyPart=inlineEditBody
-      allUsers=users
-      overlayParticipants=view.overlayParticipants
-      isNew=view.isNew
-      isSendable=view.isSendable
-      delete="deleteItem"
-      saveModel="saveModel"
-      sendEmail="sendEmail"}}
-
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      journal-thumbnail
-    </h3>
-
-    {{journal-thumbnail model=journal canEdit=true}}
-    <br>
-    <br>
-    {{journal-thumbnail model=journal canEdit=false}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      admin-role
-    </h3>
-
-    {{admin-role model=role}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      admin-journal-user
-    </h3>
-
-    {{admin-journal-user model=user
-                         journalRoles=journalRoles
-                         assignRole="assignRoleToUser"}}
-  </section>
-
-  <hr>
-
-  <section>
-    <h3>
-      journal-task-type-edit
-    </h3>
-
-    {{journal-task-type-edit model=journalTaskType}}
-  </section>
 </div>

--- a/client/app/pods/styleguide/core/template.hbs
+++ b/client/app/pods/styleguide/core/template.hbs
@@ -13,7 +13,7 @@
   </div>
 
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-12">
       <h2 id="devices">
         Devices
       </h2>

--- a/client/app/pods/styleguide/nav/template.hbs
+++ b/client/app/pods/styleguide/nav/template.hbs
@@ -1,9 +1,12 @@
 <ul id="tabs" class="nav nav-tabs">
   <li class="active">
-    <a href="#core" data-toggle="tab">Core</a>
+    <a href="#core-tab" data-toggle="tab">Core</a>
   </li>
   <li class="">
     <a href="#cards-tab" data-toggle="tab">Cards</a>
+  </li>
+  <li class="">
+    <a href="#admin-tab" data-toggle="tab">Admin</a>
   </li>
   <li class="">
     <a href="#overlays-tab" data-toggle="tab">Overlays</a>

--- a/client/app/pods/styleguide/template.hbs
+++ b/client/app/pods/styleguide/template.hbs
@@ -8,7 +8,7 @@
     {{partial 'styleguide/nav'}}
 
     <div id="myTabContent" class="tab-content">
-      <div class="tab-pane active in" id="core">
+      <div class="tab-pane active in" id="core-tab">
         <div class="row">
           <div class="col-md-2">
             {{partial 'styleguide/core/nav'}}
@@ -25,6 +25,16 @@
           </div>
           <div class="col-md-10">
             {{partial 'styleguide/cards'}}
+          </div>
+        </div>
+      </div>
+      <div class="tab-pane" id="admin-tab">
+        <div class="row">
+          <div class="col-md-2">
+            {{partial 'styleguide/admin/nav'}}
+          </div>
+          <div class="col-md-10">
+            {{partial 'styleguide/admin'}}
           </div>
         </div>
       </div>


### PR DESCRIPTION
I'm about done with styleguide work for now. It currently represents all the components used in core (thus, some external card components may not be included). 

Notes:
- There may be some weird CSS issues that are caused by components being rendered without necessary CSS context (ie: `phase-column` and `flow-column` requiring to be rendered within an element with a `.columns` class).  We can look at resolving this.
- There are 4 sections "Core", "Cards", "Admins", and "Overlays".  I think we can consolidate Admins and Overlays back to Core, but it is worth delineating the areas at least.
- And, finally, consider hiding or removing everything except "Cards" for external devs (might not be an issue since we only show it in Dev/Staging anyhow).  I like having all components inventoried for our purposes, but the styleguide is primarily for Card builders, rather than Core builders at this time.

Thoughts / Ideas? :bulb: 
