### PR TITLE
Return 422 rather than error on bad paper creation

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -6,6 +6,10 @@ class PapersController < ApplicationController
   before_action :sanitize_title, only: [:create, :update]
   before_action :prevent_update_on_locked!, only: [:update, :toggle_editable, :submit, :upload]
 
+  rescue_from ActionController::ParameterMissing do
+    render nothing: true, status: :unprocessable_entity
+  end
+
   respond_to :json
 
   def index
@@ -107,7 +111,11 @@ class PapersController < ApplicationController
   private
 
   def paper_params
-    params.require(:paper).permit(
+    pp = params.require(:paper)
+    # ensure we have a journal_id & paper_type
+    pp.require(:journal_id)
+    pp.require(:paper_type)
+    pp.permit(
       :short_title, :title, :abstract,
       :body, :paper_type, :submitted, :editable,
       :journal_id,

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -135,6 +135,21 @@ describe PapersController do
         expect(json['paper']['id']).to eq(Paper.first.id)
       end
 
+      it 'returns a 422 if no journal_id supplied' do
+        post :create, { paper: { title: new_title,
+                                 short_title: 'ABC101' },
+                        format: :json }
+        expect(response.status).to eq(422)
+      end
+
+      it 'returns a 422 if no article_type supplied' do
+        post :create, { paper: { title: new_title,
+                                 short_title: 'ABC101',
+                                 journal_id: journal.id },
+                        format: :json }
+        expect(response.status).to eq(422)
+      end
+
       it "renders the errors for the paper if it can't be saved" do
         post :create, paper: { short_title: '', journal_id: journal.id }, format: :json
         expect(response.status).to eq(422)


### PR DESCRIPTION
If user fails to supply a journal or article type when creating a paper,
return a 422 rather than 500 error.

It would be nice if ember prevented the user from clicking "create" until they have selected a journal & paper type.
