### PR TITLE
Avoid redundant validation

### DIFF
--- a/app/models/paper_role.rb
+++ b/app/models/paper_role.rb
@@ -65,6 +65,8 @@ class PaperRole < ActiveRecord::Base
   private
 
   def role_exists
+    return unless paper.journal
+
     errors.add(:base, "Invalid role provided") unless role.in?(paper.journal.valid_roles)
   end
 end

--- a/spec/services/paper_factory_spec.rb
+++ b/spec/services/paper_factory_spec.rb
@@ -94,5 +94,12 @@ describe PaperFactory do
         expect(subject.errors[:paper_type].length).to eq(1)
       end
     end
+
+    context "without a journal" do
+      let(:paper_attrs) { FactoryGirl.attributes_for(:paper, journal_id: nil, paper_type: mmt.paper_type) }
+
+      specify { expect(subject).to_not be_valid }
+      specify { expect(subject.errors[:journal].length).to eq(1) }
+    end
   end
 end


### PR DESCRIPTION
When a Paper is built without a Journal, it will be invalid due to the
missing association. Since the Journal is missing, there certainly won't
be any Journal-specific-Roles that need to be validated. Just bail out
early in this case instead of calling `nil.valid_roles`.
