### PR TITLE
Integrate skylight.io for memory and resource tracking.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem "carrierwave"
 gem "fog"
 gem "unf"
 gem 'newrelic_rpm'
+gem "skylight"
 gem "rest-client"
 gem 'gepub', "~> 0.7.0beta1"
 gem 'rubyzip', require: 'zip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,6 +543,8 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    skylight (0.6.1)
+      activesupport (>= 3.0.0)
     slop (3.6.0)
     sprockets (3.2.0)
       rack (~> 1.0)
@@ -654,6 +656,7 @@ DEPENDENCIES
   sidetiq
   simplecov
   sinatra
+  skylight
   tahi-assign_team!
   tahi_epub!
   tahi_standard_tasks!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,4 +36,7 @@ Tahi::Application.configure do
   config.carrierwave_storage = :fog
 
   config.action_mailer.default_url_options = {host: "localhost", port: 5000, protocol: "http://"}
+
+  # Enable skylight.io
+  # config.skylight.environments += ['development']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,4 +87,7 @@ Tahi::Application.configure do
     domain: 'heroku.com',
     enable_starttls_auto: true
   }
+
+  # Skylight.io is enabled by default for the production environment
+  # config.skylight.environments += ['production']
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -6,4 +6,7 @@ Tahi::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "//assets.example.com"
   config.action_controller.asset_host = ENV.fetch("RAILS_ASSET_HOST")
+
+  # Enable skylight.io
+  config.skylight.environments += ['staging']
 end


### PR DESCRIPTION
This commit turns on skylight.io in the following RAILS_ENV:  staging, production (lean)

The following ENV need set:
SKYLIGHT_APPLICATION=tahi
SKYLIGHT_AUTHENTICATION= < get from skylight.io site >
