### PR TITLE
Avoid pointlessly serializing Paper for Heartbeats

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -71,7 +71,7 @@ class PapersController < ApplicationController
       paper.heartbeat
       PaperUnlockerWorker.perform_async(paper.id, true)
     end
-    respond_with paper
+    head :no_content
   end
 
   def download


### PR DESCRIPTION
Not sure why we were doing this. The Ember Heartbeat service never uses
the result it gets back from the heartbeat request. It just drops it on
the ground. It uses the RESTless service and isn't pushing anything into
the Store. No one should even need the data from the heartbeat, as that
data would be eventstreamed to them anyway.

This is an issue since the PaperSerializer serializes everything under
the sun. This should take this endpoint from being one of the most
memory/time intensive to just a blip on the radar.
