### PR TITLE
Remove dead dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,8 +137,6 @@ GEM
     bullet (4.14.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
-    byebug (4.0.5)
-      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)


### PR DESCRIPTION
Pretty sure this was a bad merge. Shows up every time after running
`bundle install`.
