### PR TITLE
Add missing validations for Paper model

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -34,6 +34,8 @@ class Paper < ActiveRecord::Base
   validates :short_title, presence: true, uniqueness: true
   validates :journal, presence: true
 
+  validates :short_title, :title, length: { maximum: 255 }
+
   delegate :admins, :editors, :reviewers, to: :journal, prefix: :possible
 
   aasm column: :publishing_state do

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -52,6 +52,20 @@ describe Paper do
       end
     end
 
+    describe "title" do
+      it "is within 255 chars" do
+        paper = FactoryGirl.build(:paper, title: "a" * 256)
+        expect(paper).to_not be_valid
+        expect(paper).to have(1).errors_on(:title)
+
+        paper.title = "a" * 254
+        expect(paper).to be_valid
+
+        paper.title = "a" * 255
+        expect(paper).to be_valid
+      end
+    end
+
     describe "short_title" do
       it "must be present" do
         paper = FactoryGirl.build(:paper, short_title: nil)
@@ -64,6 +78,18 @@ describe Paper do
         dup_paper = FactoryGirl.build(:paper, short_title: 'Duplicate')
         expect(dup_paper).to_not be_valid
         expect(dup_paper).to have(1).errors_on(:short_title)
+      end
+
+      it "is within 255 chars" do
+        paper = FactoryGirl.build(:paper, short_title: "a" * 256)
+        expect(paper).to_not be_valid
+        expect(paper).to have(1).errors_on(:short_title)
+
+        paper.short_title = "a" * 254
+        expect(paper).to be_valid
+
+        paper.short_title = "a" * 255
+        expect(paper).to be_valid
       end
     end
 


### PR DESCRIPTION
This adds length validations for paper#title and paper#short_title.

https://bugsnag.com/tahi-project/tahi-lean/errors/5592ce976b8d2dd06f9bfe94?event_id=5592cea4a69b1f3834e991a1
