### PR TITLE
Remove limit and change column type for caption column in Figures

### DIFF
--- a/db/migrate/20150709230305_change_caption_type_in_figures.rb
+++ b/db/migrate/20150709230305_change_caption_type_in_figures.rb
@@ -1,0 +1,5 @@
+class ChangeCaptionTypeInFigures < ActiveRecord::Migration
+  def change
+    change_column :figures, :caption, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150702193023) do
+ActiveRecord::Schema.define(version: 20150709230305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,7 +167,7 @@ ActiveRecord::Schema.define(version: 20150702193023) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "title",      limit: 255
-    t.string   "caption",    limit: 255
+    t.text     "caption"
     t.string   "status",     limit: 255, default: "processing"
   end
 


### PR DESCRIPTION
Captions don't need to limited to 255 characters. We've seen a user trying to save a caption longer than 255 characters.

https://bugsnag.com/tahi-project/tahi-staging/errors/558c469ef1726aac685d5949
