### PR TITLE
Revise Overlay: Prevent toggling of input when user starts typing

### DIFF
--- a/engines/tahi_standard_tasks/client/app/controllers/overlays/revise.coffee
+++ b/engines/tahi_standard_tasks/client/app/controllers/overlays/revise.coffee
@@ -15,7 +15,7 @@ ReviseOverlayController = TaskController.extend
     @get('model.paper.decisions').sortBy('revisionNumber').reverse()[2..-1]
   ).property('model.paper.decisions.@each')
 
-  editingAuthorResponse: Ember.computed.empty('latestDecision.authorResponse')
+  editingAuthorResponse: false
 
   actions:
 

--- a/engines/tahi_standard_tasks/client/app/views/overlays/revise.js
+++ b/engines/tahi_standard_tasks/client/app/views/overlays/revise.js
@@ -1,7 +1,15 @@
+import Ember from 'ember';
 import OverlayView from 'tahi/views/overlay';
 
 export default OverlayView.extend({
   templateName: 'overlays/revise',
   layoutName:   'layouts/overlay',
-  cardName: 'revise'
+  cardName: 'revise',
+
+  _editIfResponseIsEmpty: Ember.on('didInsertElement', function() {
+    this.set(
+      'controller.editingAuthorResponse',
+      Ember.isEmpty(this.get('controller.latestDecision.authorResponse'))
+    );
+  })
 });


### PR DESCRIPTION
When an author would start to type their response in the textarea, the field would be hidden. This was happening because the `editingAuthorResponse` boolean used to toggle visibility was bound to the empty state of the `latestDecision.authorResponse` property. 
