### PR TITLE
Private dependencies require credentials

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,8 +38,8 @@
     "express": "^4.8.5",
     "glob": "^4.0.5",
     "liquid-fire": "0.19.4",
-    "tahi-fileupload": "Tahi-project/tahi-fileupload#3d68c7702cc1b6ba0a544c13f3d65d66a0ab33e6",
-    "tahi-editor-ve": "Tahi-project/tahi-editor-ve#1f2e07bdeb97cbe0939438fe65c51e4351c25cf3"
+    "tahi-fileupload": "git+https://f11148f2df58b9d5966b2543f6a0d3c035985f88:x-oauth-basic@github.com/Tahi-project/tahi-fileupload#3d68c7702cc1b6ba0a544c13f3d65d66a0ab33e6",
+    "tahi-editor-ve":  "git+https://f11148f2df58b9d5966b2543f6a0d3c035985f88:x-oauth-basic@github.com/Tahi-project/tahi-editor-ve#1f2e07bdeb97cbe0939438fe65c51e4351c25cf3"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
`tahi-fileupload` and `tahi-editor-ve` will be private soon and will need credentials.
