### PR TITLE
update verdict_valid? to return true when true

### DIFF
--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -13,7 +13,7 @@ class Decision < ActiveRecord::Base
   VERDICTS = ['minor_revision', 'major_revision', 'accept', 'reject']
 
   def verdict_valid?
-    errors.add(:verdict, "must be a valid choice.") unless VERDICTS.include?(verdict)
+    VERDICTS.include?(verdict) || errors.add(:verdict, "must be a valid choice.")
   end
 
   def self.latest


### PR DESCRIPTION
I'm seeing RegisterDecision feature specs errors (https://circleci.com/gh/Tahi-project/tahi/2929), and found this.  

We're also using `verdict_valid?` to `select` items from an array, so we should return `true` when `true`.
