### PR TITLE
Avoid unbound searches in Flow Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 -
 
 ### Fixed
--
+- No longer perform unfiltered searches in Flow Manager
 
 ### Security
 -

--- a/app/services/flow_query.rb
+++ b/app/services/flow_query.rb
@@ -7,7 +7,7 @@ class FlowQuery
   end
 
   def tasks
-    return Task.none if flow.query.nil?
+    return Task.none if flow.query.blank?
 
     scope = by_journal(Task.all)
 

--- a/spec/services/flow_query_spec.rb
+++ b/spec/services/flow_query_spec.rb
@@ -17,11 +17,16 @@ describe FlowQuery do
   end
 
   describe "#tasks" do
-    it "returns an empty relation if flow query is empty" do
-      flow = FactoryGirl.build(:flow, query: {})
-      tasks = FlowQuery.new(user, flow).tasks
 
-      expect(tasks).to match_array []
+    context "query is empty" do
+      let!(:task) { FactoryGirl.create(:task, phase: phase) } # this test always passes unless a Task exists...
+      let(:query) { {} }
+      let(:flow) { FactoryGirl.build(:flow, journal: user_journal, query: query) }
+
+      it "returns an empty relation" do
+        tasks = FlowQuery.new(user, flow).tasks
+        expect(tasks).to be_empty
+      end
     end
 
     context "scoping tasks by journal" do


### PR DESCRIPTION
When an Admin first adds a new Flow in the Admin Flow Manager interface
none of the filters are selected. This fires off a search for all Papers
in the Journal.

This can be an exceptionally large number and the query is very 
unoptimized. A sample transaction trace from NewRelic on Staging reveals
more than 600 `Paper.find` calls in a single request. Fixing the N+1s in
FlowQuery would be optimal, but tricky to do with all the dynamic
filters. Reducing the amount of data loaded here continues to help with
the memory pressure we see in environments with large numbers of Papers.

In the end, the purpose of the Admin Flow Manager is to apply these
filters to shrink down the dataset anyway. There was already a check for
`.nil?` that tries to shortcut the unbound query. However, `flow.query`
is never nil. It is a serialized column, and empty queries will be
represented as an empty Hash. Changing the nil-check to a blank-check
helps correct the worst-case performance without changing the intended
behavior of the page.

The spec was misleading since no Tasks were ever created, so the empty
check was unable to fail.
