### PR TITLE
Display properly resized image preview on adhoc card

### DIFF
--- a/app/serializers/attachment_serializer.rb
+++ b/app/serializers/attachment_serializer.rb
@@ -8,10 +8,10 @@ class AttachmentSerializer < ActiveModel::Serializer
   end
 
   def preview_src
-    object.file.preview.url if object.image?
+    object.file.url(:preview) if object.image?
   end
 
   def detail_src
-    object.file.url if object.image?
+    object.file.url(:detail) if object.image?
   end
 end

--- a/spec/features/adhoc_cards_spec.rb
+++ b/spec/features/adhoc_cards_spec.rb
@@ -23,7 +23,7 @@ feature 'Adhoc cards', js: true do
 
         find(".thumbnail-preview").hover
         find(".view-attachment-detail").click
-        expect(page).to have_css(".big-preview img[src*='#{Attachment.last.file.path}']")
+        expect(page).to have_css(".big-preview img[src*='#{Attachment.last.file.versions[:detail].path}']")
       end
     end
   end

--- a/spec/serializers/attachment_serializer_spec.rb
+++ b/spec/serializers/attachment_serializer_spec.rb
@@ -33,7 +33,7 @@ describe AttachmentSerializer do
       end
 
       it "has :detail_src" do
-        expect(deserialized_attachment[:detail_src]).to match(/\/yeti.tiff/)
+        expect(deserialized_attachment[:detail_src]).to match(/\/detail_yeti.tiff/)
       end
     end
 


### PR DESCRIPTION
This is to address the comments by @egh on a previous PR here:  https://github.com/Tahi-project/tahi/pull/1460#

--- AC + ZD
