### PR TITLE
Attach Pusher's socket id to RESTless calls

### DIFF
--- a/client/app/services/rest-less.coffee
+++ b/client/app/services/rest-less.coffee
@@ -8,6 +8,7 @@ RESTless = Ember.Namespace.create
     adapter.buildURL(resourceType, model.get('id'))
 
   ajaxPromise: (method, path, data) ->
+    socketId = Tahi.__container__.lookup('pusher:main').get('socketId')
     new Ember.RSVP.Promise (resolve, reject) ->
       Ember.$.ajax
         url: path
@@ -15,6 +16,8 @@ RESTless = Ember.Namespace.create
         data: data
         success: resolve
         error: reject
+        headers:
+          'PUSHER_SOCKET_ID': socketId
         dataType: 'json'
 
   delete: (path, data) ->


### PR DESCRIPTION
The server expects all incoming requests to have a socket id. This is
used by the Broadcaster to exclude the original requester from having
events they already know about pushed to them. It is important to
exclude the originator to prevent UI flashing as the request and the
websocket data are both pushed into the store.
