### PR TITLE
App name doesn't overwrite the journal logo

### DIFF
--- a/app/assets/stylesheets/components/_control-bar.scss
+++ b/app/assets/stylesheets/components/_control-bar.scss
@@ -24,7 +24,7 @@
   position: relative;
   height: 60px;
   margin: 0 auto;
-  padding-left: 125px;
+  padding-left: 160px;
 }
 
 .control-bar-sub-items {

--- a/app/assets/stylesheets/screens/_papers.scss
+++ b/app/assets/stylesheets/screens/_papers.scss
@@ -19,16 +19,22 @@ $paper-edit-sidebar-width: 280px;
   // TODO: Do we need the h2?
   h2 {
     overflow: hidden;
-    width: 680px;
+    width: 360px;
     padding: 21px 0 0 5px;
     font-family: $tahi-article-font-family;
     font-size: 18px;
     line-height: 22px;
     text-overflow: ellipsis;
     white-space: nowrap;
-
+    display: none;
     // override from generic h2:
     margin: 0;
+  }
+
+  @media (min-width: 890px) {
+    h2 {
+      display: inline-block;
+    }
   }
 }
 


### PR DESCRIPTION
This addresses Pivotal bug [100167260](https://www.pivotaltracker.com/story/show/100167260)
- Increased area for app name to be 160px.  That accommodates "STAGING" which should be our longest app name.
- Paper name now truncates at 360px
- Paper name is not visible if the browser width is less than 890px (the space left over for the paper name would be less than 360px).
