### PR TITLE
Fixing short title on workflow page

### DIFF
--- a/app/assets/stylesheets/components/_control-bar.scss
+++ b/app/assets/stylesheets/components/_control-bar.scss
@@ -56,6 +56,9 @@
   display: block;
   font-size: 10px;
   line-height: 20px;
+  height: 58px;
+  z-index: 2;
+  background-color: white;
 }
 
 // creates bigger click area in top right corner of screen

--- a/app/assets/stylesheets/screens/_papers.scss
+++ b/app/assets/stylesheets/screens/_papers.scss
@@ -19,22 +19,14 @@ $paper-edit-sidebar-width: 280px;
   // TODO: Do we need the h2?
   h2 {
     overflow: hidden;
-    width: 360px;
     padding: 21px 0 0 5px;
     font-family: $tahi-article-font-family;
     font-size: 18px;
     line-height: 22px;
-    text-overflow: ellipsis;
     white-space: nowrap;
-    display: none;
     // override from generic h2:
     margin: 0;
-  }
-
-  @media (min-width: 990px) {
-    h2 {
-      display: inline-block;
-    }
+    z-index: 1;
   }
 }
 


### PR DESCRIPTION
This is a follow up to (100167260)[https://www.pivotaltracker.com/story/show/100167260]

On staging we have 100px fewer than I thought originally.  Here's the broken state: https://db.tt/OhWccWVv

I removed 100px to fix it: video https://db.tt/DdlcABC7
