### PR TITLE
Fixes Tahi is not defined error

### DIFF
--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -7,6 +7,7 @@ module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     storeConfigInMeta: false,
     emberCliFontAwesome: { includeFontAwesomeAssets: false },
+    exportApplicationGlobal: true,
     markers: {
       enabled: true,
       kinds: ['TODO', 'FIXME']


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/101535368

By default, ember-cli gives you a global reference to the App instance in development mode (probably to make it easier to muck around).

This commit enables the global for all environments

_This should be a temporary fix. References to the global should be removed._
