### PR TITLE
Fix for replacing figures 

### DIFF
--- a/client/app/pods/components/attachment-thumbnail/component.js
+++ b/client/app/pods/components/attachment-thumbnail/component.js
@@ -29,11 +29,12 @@ export default Ember.Component.extend({
 
   attachmentUrl: Ember.computed('attachment.id', 'figure', function() {
     let urlRoot = '/api/supporting_information_files/';
-    if (this.get('figure')) {
-      urlRoot = '/api/figures/';
-    }
-    if (this.get('attachment')) {
+
+    if (this.get('attachment.task')) {
       urlRoot = '/api/tasks/' + this.get('attachment.task.id') + '/attachments/';
+    }
+    else if (this.get('figure')) {
+      urlRoot = '/api/figures/';
     }
 
     return urlRoot + this.get('attachment.id') + '/update_attachment';


### PR DESCRIPTION
This addresses Pivotal issue [101530256](https://www.pivotaltracker.com/story/show/101530256)

The attachment-thumbnail component was falling through and trying to use the task ID in the replace file case when it didn't have one.  The Ember property attachmentUrl was updated to make sure only one case would be used, falling from the more specific case (where we have an attachment task) to the more general case (when we have a figure).
