### PR TITLE
fix unhandled action and infinite loop

### DIFF
--- a/client/app/pods/paper/edit/html-editor/controller.js
+++ b/client/app/pods/paper/edit/html-editor/controller.js
@@ -53,10 +53,8 @@ export default Ember.Controller.extend(PaperBaseMixin, PaperEditMixin, Discussio
   releaseLock() {
     let paper = this.get('model');
     paper.set('lockedBy', null);
-    paper.save().then(()=>{
-      // FIXME: don't know why but when calling this during willDestroyElement
-      // this action will not be handled.
-      this.send('stopEditing');
+    paper.save().then(() => {
+      this.disconnectEditor();
     });
   },
 


### PR DESCRIPTION
This function was calling stopEditing as an action which is not, is a function so after changing to call the function directly I notice that this action ‘stopEditing’ was calling to ‘releaseLock’ so we have a infinite loop, now calls the ‘disconnectEditor’ method instead.
