### PR TITLE
Hiding the top bar if the window isn't wide enough

### DIFF
--- a/app/assets/stylesheets/screens/_papers.scss
+++ b/app/assets/stylesheets/screens/_papers.scss
@@ -14,16 +14,15 @@ $paper-edit-sidebar-width: 280px;
 
 #control-bar-paper-short-title {
   min-width: 5px;
-  font-size: 18px;
-  max-width: 90%;
+  max-width: 50%;
   z-index: 1;
+  padding-top: 2px;
   h2 {
-    overflow: hidden;
-    padding: 21px 0 0 5px;
     font-family: $tahi-article-font-family;
-    font-size: 18px;
-    line-height: 22px;
-    white-space: nowrap;
+    font-size: 16px;
+    line-height: 18px;
+    white-space: wrap;
+    height: 44px;
   }
 }
 

--- a/client/app/pods/paper/workflow/template.hbs
+++ b/client/app/pods/paper/workflow/template.hbs
@@ -10,11 +10,12 @@
           {{model.journal.name}}
         </li>
       {{/if}}
+
+    </ul>
+    <ul style="max-width:80%">
       <li id="control-bar-paper-short-title" class="control-bar-item">
         <h2 class="tasks-paper-title">{{model.title}}</h2>
       </li>
-    </ul>
-    <ul>
       <li class="control-bar-item">
         <label class="control-bar-link control-bar-button">
           <div class="control-bar-link-icon"></div>


### PR DESCRIPTION
This is in reference to Pivotal card [100167260](https://www.pivotaltracker.com/story/show/100167260)

@tadp and I looked at making the text shrink and wrap, but with the current design of the top bar that proved to require a lot of development.  We chatted with @andibyday and came up with the short term fix of hiding the title if the window gets too small.  We'll keep the fade out and hope that someone can add a story to Pivotal to make the top bar truly responsive.  
