### PR TITLE
Hiding the title if the editor window gets too small

### DIFF
--- a/app/assets/stylesheets/screens/_papers.scss
+++ b/app/assets/stylesheets/screens/_papers.scss
@@ -19,11 +19,17 @@ $paper-edit-sidebar-width: 280px;
   z-index: 1;
   h2 {
     overflow: hidden;
-    padding: 21px 0 0 5px;
+    padding: 21px 0 0 15px;
     font-family: $tahi-article-font-family;
     font-size: 18px;
     line-height: 22px;
     white-space: nowrap;
+    display: none;
+  }
+  @media(min-width: 970px) {
+    h2 {
+      display: inline-block;
+    }
   }
 }
 


### PR DESCRIPTION
This is in reference to Pivotal card [100167260](https://www.pivotaltracker.com/story/show/100167260)

@tadp and I looked at making the text shrink and wrap, but with the current design of the top bar that proved to require a lot of development.  We chatted with @andibyday and came up with the short term fix of hiding the title if the window gets too small.  We'll keep the fade out and hope that someone can add a story to Pivotal to make the top bar truly responsive.  
