### PR TITLE
Match standard Rails as_json method signature

### DIFF
--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/letter_template.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/letter_template.rb
@@ -7,7 +7,7 @@ module TahiStandardTasks
       @body = body
     end
 
-    def as_json
+    def as_json(options = nil)
       { salutation: salutation, body: body }
     end
 


### PR DESCRIPTION
### References
- https://www.pivotaltracker.com/story/show/102110570

When the letter template is being rendered, it is being passed around a
lot of internal Rails rendering methods. Those internals expect the
standard `as_json` signature. They are attempting to pass an options
hash to `LetterTemplate#as_json`, but instead explode with an
ArgumentError. LetterTemplate doesn't need to necessarily do anything
with those options, it just needs to not explode so spectacularly
whenever a Task is updated.

Stack trace for tracking this down:

```
Exception: ArgumentError: wrong number of arguments (1 for 0)
--
 0: /Users/plos/Projects/tahi/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/letter_template.rb:10:in `as_json'
 1: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `block in as_json'
 2: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `each'
 3: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `map'
 4: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `as_json'
 5: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:140:in `block in as_json'
 6: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:140:in `map'
 7: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:140:in `as_json'
 8: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `block in as_json'
 9: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `each'
10: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `map'
11: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `as_json'
12: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `block in as_json'
13: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `each'
14: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `map'
15: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:159:in `as_json'
16: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/json/encoding.rb:35:in `encode'
17: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/json/encoding.rb:22:in `encode'
18: /Users/plos/.rvm/gems/ruby-2.2.2@tahi/gems/activesupport-4.2.3/lib/active_support/core_ext/object/json.rb:37:in `to_json_with_active_support_encoder'
19: (pry):2:in `update'
```
