### PR TITLE
Bug fix for top bar elements overwriting

### DIFF
--- a/app/assets/stylesheets/screens/_papers.scss
+++ b/app/assets/stylesheets/screens/_papers.scss
@@ -15,7 +15,7 @@ $paper-edit-sidebar-width: 280px;
 #control-bar-paper-short-title {
   min-width: 5px;
   font-size: 18px;
-  max-width: 90%;
+  max-width: 80%;
   z-index: 1;
   h2 {
     overflow: hidden;


### PR DESCRIPTION
Updating the max width of the short title so it doesn't drop below the control bar
