### PR TITLE
Bug fix for dropping Tasks on new phase column

### DIFF
--- a/client/app/pods/components/phase-column/template.hbs
+++ b/client/app/pods/components/phase-column/template.hbs
@@ -6,7 +6,7 @@
                rollbackPhase="rollbackPhase"}}
 
 <div class="column-content">
-  <div class="sortable {{if noCards "sortable-no-cards"}}" data-phase-id="{{unbound phase.id}}">
+  <div class="sortable {{if noCards "sortable-no-cards"}}" data-phase-id="{{phase.id}}">
     {{#each sortedTasks as |task|}}
       {{card-preview paper=paper
                      task=task


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/102748480

Drag and drop needs the html property `data-phase-id` to be set. The property was `unbound`, so when the new Phase was saved, the id was never updated.
