### PR TITLE
Rspec feature fixes

### DIFF
--- a/spec/features/flow_manager_spec.rb
+++ b/spec/features/flow_manager_spec.rb
@@ -23,10 +23,6 @@ feature "Flow Manager", js: true, selenium: true do
     visit "/"
   end
 
-  after do
-    page.driver.browser.manage.window.size = @old_size
-  end
-
   let(:journal) { FactoryGirl.create(:journal) }
 
   let!(:paper1) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,4 +121,8 @@ RSpec.configure do |config|
   config.before(:each) do
     ActionMailer::Base.deliveries.clear
   end
+
+  config.before(:each, js: true) do
+    Capybara.page.driver.browser.manage.window.resize_to(1500, 1000)
+  end
 end


### PR DESCRIPTION
Resize browser window to 1500x1000 before all tests. This seems to finally fix flakiness, which I think was due to somewhat random browser window sizes hiding certain elements at smaller sizes.
(TODO: define set of browser sizes that _should_ work so we can run tests on those too).
