### PR TITLE
Change user search fuzziness to default

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ActiveRecord::Base
   pg_search_scope :fuzzy_search,
     against: [:first_name, :last_name, :email, :username],
     ignoring: :accents,
-    using: { tsearch: { prefix: true }, trigram: { threshold: 0.08 } }
+    using: { tsearch: { prefix: true }, trigram: { threshold: 0.3 } } # default threshold is 0.3
 
   has_many :affiliations, inverse_of: :user
   has_many :submitted_papers, inverse_of: :creator, class_name: 'Paper'


### PR DESCRIPTION
Pivotal Story: Consider raising or eliminating the threshold specification for fuzzy user search  
