### PR TITLE
Only resizing images that are uploaded

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -12,7 +12,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   version :detail do
-    process resize_to_limit: [986, -1]
+    process resize_to_limit: [986, -1], if: :needs_transcoding?
     process :convert_to_png, if: :needs_transcoding?
 
     def full_filename(orig_file)
@@ -21,7 +21,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   version :preview do
-    process resize_to_limit: [475, 220]
+    process resize_to_limit: [475, 220], if: :needs_transcoding?
     process :convert_to_png, if: :needs_transcoding?
 
     def full_filename(orig_file)


### PR DESCRIPTION
#### WARNING
##### WHEN YOU'RE READY TO MERGE THIS PR, PLEASE DON'T MERGE. _CLOSE_ IT , AND MERGE A PR INTO THE `acceptance` BRANCH INSTEAD. THANK YOU!
#### END WARNING

This relates to Pivotal card [#101697856](https://www.pivotaltracker.com/story/show/101697856)

There was a bug where non-image supporting files were attempting to be resized and preview images generated.  This bug fix just adds the guard statement by the resize in the attachment_uploader.rb

 Reviewer tasks (reviewer, please merge when complete):
- [ ] I ran the code locally
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
