### PR TITLE
Configure fog uploads as public

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -11,6 +11,10 @@ class AttachmentUploader < CarrierWave::Uploader::Base
     "uploads/paper/#{model.paper.id}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
+  def fog_public
+    true
+  end
+
   version :detail do
     process resize_to_limit: [986, -1]
     process :convert_to_png, if: :needs_transcoding?


### PR DESCRIPTION
#### WARNING
##### WHEN YOU'RE READY TO MERGE THIS PR, PLEASE DON'T MERGE. _CLOSE_ IT , AND MERGE A PR INTO THE `acceptance` BRANCH INSTEAD. THANK YOU!
#### END WARNING

Pivotal Card: [#102097022](https://www.pivotaltracker.com/n/projects/880854/stories/102097022)

Right now the actual configuration `config.fog_public` makes amazon return an url like this:

https://tahi.s3.amazonaws.com/uploads/paper/1/figure/attachment/5/detail_ember.png?X-Amz-Expires=600&X-Amz-Date=20150910T160318Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIZ3FPKZVDJTIB77A/20150910/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=284ef07e3367a8208063b94342e0ade53cfa78956d687092b8cb2c43c81822a8

This happens in the `DownloadFigureWorker` when after downloading the image we call save in the image object.

If we change this uploader configuration to return `fog_public` as true when saving the object we obtain a cleaner url like:
https://tahi.s3.amazonaws.com/uploads/paper/1/figure/attachment/5/detail_ember.png

We can configure the Amazon bucket policy to accept some referrers only (us)

If we want more flexibility to handle privacy of the files and expiration we could use this provider for fog 
https://github.com/sorentwo/carrierwave-aws

I want to know your thoughts about alternatives when serving this images :smiley: 
