### PR TITLE
Convert journal_task_types for plos_authors

### DIFF
--- a/db/migrate/20150918192514_convert_plos_authors_task_type.rb
+++ b/db/migrate/20150918192514_convert_plos_authors_task_type.rb
@@ -1,0 +1,21 @@
+class ConvertPlosAuthorsTaskType < ActiveRecord::Migration
+  def up
+    # update existing journal task types to new model name
+    sql = %Q{
+      UPDATE journal_task_types
+      SET kind = 'TahiStandardTasks::AuthorsTask'
+      WHERE kind = 'PlosAuthors::PlosAuthorsTask'
+    }
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def down
+    # update existing journal task types to old model name
+    sql = %Q{
+      UPDATE journal_task_types
+      SET kind = 'PlosAuthors::PlosAuthorsTask'
+      WHERE kind = 'TahiStandardTasks::AuthorsTask'
+    }
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150914183126) do
+ActiveRecord::Schema.define(version: 20150918192514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This should have been included with https://github.com/Tahi-project/tahi/blob/acceptance/db/migrate/20150914145619_remove_plos_authors.rb#L25 but it was already merged into acceptance.

Be sure to convert existing tasks and journal_task_types whenever a namespace changes!
