### PR TITLE
hard code salesforce manuscript recordtypeid

### DIFF
--- a/app/services/salesforce_services/object_translations.rb
+++ b/app/services/salesforce_services/object_translations.rb
@@ -9,7 +9,7 @@ module SalesforceServices
 
       def paper_to_manuscript_hash
         {
-          "RecordTypeId" => "012U0000000DqUyIAK",
+          "RecordTypeId" => "012U0000000E4ASIA0",
           "OwnerId" => @user_id,
           "Editorial_Process_Close__c" => false,
           "Display_Technical_Notes__c" => false,


### PR DESCRIPTION
This should be the last change to this value.

We now have hard-coded `RecordTypeID` values for `Manuscript` and `Case`, provided by Allyndreth at PLoS.
