### PR TITLE
Use include for glob in broccoli funnel

### DIFF
--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -1,6 +1,5 @@
 /* global require, module */
 var EmberApp   = require('ember-cli/lib/broccoli/ember-app');
-var mergeTrees = require('broccoli-merge-trees');
 var Funnel     = require('broccoli-funnel');
 
 module.exports = function(defaults) {
@@ -33,7 +32,7 @@ module.exports = function(defaults) {
   app.import('bower_components/select2/select2.css');
   var select2Assets = new Funnel('bower_components/select2', {
     srcDir: '/',
-    files: ['*.gif', '*.png'],
+    include: ['*.gif', '*.png'],
     destDir: '/assets'
   });
 
@@ -53,5 +52,5 @@ module.exports = function(defaults) {
     app.import('vendor/pusher-test-stub.js', { type: 'test' });
   }
 
-  return mergeTrees([app.toTree(), select2Assets], {overwrite: true});
+  return app.toTree(select2Assets);
 };


### PR DESCRIPTION
select2 assets were not being included, because files was used instead
of include.

Also, mergeTrees need not be called directly.

---

Reviewer tasks (merge when completed):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
