### PR TITLE
Allow multiple reviewers on PaperReviewerTask

### DIFF
--- a/engines/tahi_standard_tasks/app/services/reviewer_report_task_creator.rb
+++ b/engines/tahi_standard_tasks/app/services/reviewer_report_task_creator.rb
@@ -35,7 +35,7 @@ class ReviewerReportTaskCreator
 
   # multiple `assignee` can exist on `paper` as a reviewer
   def assign_paper_role!
-    paper.paper_roles.for_role(PaperRole::REVIEWER).first_or_create!(user: assignee)
+    paper.paper_roles.for_role(PaperRole::REVIEWER).where(user: assignee).first_or_create!
   end
 
   def default_phase

--- a/engines/tahi_standard_tasks/spec/services/reviewer_report_task_creator_spec.rb
+++ b/engines/tahi_standard_tasks/spec/services/reviewer_report_task_creator_spec.rb
@@ -9,15 +9,37 @@ describe ReviewerReportTaskCreator do
     ReviewerReportTaskCreator.new(originating_task: paper_reviewer_task, assignee_id: assignee.id)
   end
 
-  it "assigns the specified role to the assignee" do
-    subject.process
-    expect(paper.role_for(user: assignee, role: PaperRole::REVIEWER)).to exist
-  end
+  context "assigning reviewer role" do
+    context "with no existing reviewer" do
+      it "assigns reviewer role to the assignee" do
+        subject.process
+        expect(paper.role_for(user: assignee, role: PaperRole::REVIEWER)).to exist
+      end
 
-  it "creates a ReviewerReportTask" do
-    expect {
-      subject.process
-    }.to change { TahiStandardTasks::ReviewerReportTask.count }.by(1)
+      it "creates a ReviewerReportTask" do
+        expect {
+          subject.process
+        }.to change { TahiStandardTasks::ReviewerReportTask.count }.by(1)
+      end
+    end
+
+    context "with an existing reviewer" do
+      before do
+        existing_reviewer = FactoryGirl.create(:user)
+        make_user_paper_reviewer(existing_reviewer, paper)
+      end
+
+      it "assigns reviewer role to the assignee" do
+        subject.process
+        expect(paper.role_for(user: assignee, role: PaperRole::REVIEWER)).to exist
+      end
+
+      it "creates a ReviewerReportTask" do
+        expect {
+          subject.process
+        }.to change { TahiStandardTasks::ReviewerReportTask.count }.by(1)
+      end
+    end
   end
 
   context "with existing ReviewerReportTask for User" do


### PR DESCRIPTION
References bug: https://www.pivotaltracker.com/story/show/103549922

Previously, only the first user added as a reviewer actually received
the "reviewer" role.  Any subsequent reviewers would just be assigned a
"participant" role.  This was a hidden danger.  Now, subsequent users
will still be made participants, but will also be correctly assigned the
"reviewer" role.

---

Reviewer tasks (merge when completed):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
