### PR TITLE
Add Activity feed messages for +/- collaborators

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -28,6 +28,26 @@ class Activity < ActiveRecord::Base
     )
   end
 
+  def self.collaborator_added!(collaborator_paper_role, user:)
+    create(
+      feed_name: "manuscript",
+      activity_key: "collaborator.added",
+      subject: collaborator_paper_role.paper,
+      user: user,
+      message: "#{collaborator_paper_role.user.full_name} has been assigned as collaborator"
+    )
+  end
+
+  def self.collaborator_removed!(collaborator_paper_role, user:)
+    create(
+      feed_name: "manuscript",
+      activity_key: "collaborator.removed",
+      subject: collaborator_paper_role.paper,
+      user: user,
+      message: "#{collaborator_paper_role.user.full_name} has been removed as collaborator"
+    )
+  end
+
   def self.task_sent_to_author!(task, user:)
     create(
       feed_name: "workflow",

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 require 'sidekiq/testing'
 
 describe CollaborationsController do
-  describe 'POST "create"' do
-    let(:user) { create :user }
+  describe "#create" do
+    let(:user) { FactoryGirl.create(:user) }
 
     let(:invitee) { FactoryGirl.create(:user) }
     let(:paper) { FactoryGirl.create(:paper, creator: user) }
@@ -12,10 +12,31 @@ describe CollaborationsController do
 
     before { sign_in user }
 
+    it 'adds activities to the feeds' do
+      expect {
+        post :create, format: :json, collaboration: collab_params
+      }.to change(Activity, :count).by(1)
+    end
+
     it 'adds an email to the sidekiq queue' do
       expect {
         post :create, format: :json, collaboration: collab_params
       }.to change(Sidekiq::Extensions::DelayedMailer.jobs, :size).by(1)
+    end
+  end
+
+  describe "#destroy" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    let(:paper) { FactoryGirl.create(:paper, creator: user) }
+    let!(:collaborator) { FactoryGirl.create(:paper_role, :collaborator, paper: paper) }
+
+    before { sign_in user }
+
+    it 'adds activities to the feeds' do
+      expect {
+        delete :destroy, format: :json, id: collaborator.id, paper_id: paper.id
+      }.to change(Activity, :count).by(1)
     end
   end
 end

--- a/spec/factories/paper_role_factory.rb
+++ b/spec/factories/paper_role_factory.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :paper_role do
     user
+    paper
 
     trait(:admin) do
       role 'admin'

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -176,6 +176,36 @@ describe Activity do
     end
   end
 
+  describe "#collaborator_added!" do
+    subject(:activity) { Activity.collaborator_added!(paper_role, user: user) }
+    let!(:paper_role) { FactoryGirl.create(:paper_role, :collaborator) }
+
+    it {
+      is_expected.to have_attributes(
+        feed_name: "manuscript",
+        activity_key: "collaborator.added",
+        subject: paper_role.paper,
+        user: user,
+        message: "#{paper_role.user.full_name} has been assigned as collaborator"
+      )
+    }
+  end
+
+  describe "#collaborator_added!" do
+    subject(:activity) { Activity.collaborator_removed!(paper_role, user: user) }
+    let!(:paper_role) { FactoryGirl.create(:paper_role, :collaborator) }
+
+    it {
+      is_expected.to have_attributes(
+        feed_name: "manuscript",
+        activity_key: "collaborator.removed",
+        subject: paper_role.paper,
+        user: user,
+        message: "#{paper_role.user.full_name} has been removed as collaborator"
+      )
+    }
+  end
+
   describe "#paper_submitted!" do
     subject(:activity) { Activity.paper_submitted!(paper, user: user) }
     let(:paper) { FactoryGirl.build(:paper) }


### PR DESCRIPTION
References: https://www.pivotaltracker.com/story/show/103144840

Add `Activity` records when collaborator is added and removed.  Should show up on both the workflow and manuscript feeds.

---

Reviewer tasks (merge when completed):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
