### PR TITLE
Remove unnecessary redis rspec filters

### DIFF
--- a/spec/controllers/admin/journals_controller_spec.rb
+++ b/spec/controllers/admin/journals_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Admin::JournalsController, redis: true do
+describe Admin::JournalsController do
   let(:journal) { create(:journal) }
   let(:admin) { create :user, :site_admin }
   let(:image_file) { fixture_file_upload 'yeti.jpg' }

--- a/spec/controllers/files_controller_spec.rb
+++ b/spec/controllers/files_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe SupportingInformationFilesController, redis: true do
+describe SupportingInformationFilesController do
   let(:user) { create :user }
   let(:paper) do
     FactoryGirl.create(:paper, creator: user)

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -96,7 +96,7 @@ describe InvitationsController do
     end
   end
 
-  describe "DELETE /invitations/:id", redis: true do
+  describe "DELETE /invitations/:id" do
     let(:invitation) { FactoryGirl.create(:invitation, :invited, invitee: invitee, task: task) }
 
     it "initiates the task callback" do
@@ -110,7 +110,7 @@ describe InvitationsController do
     context "Invitation with invitee" do
       let(:invitation) { FactoryGirl.create(:invitation, :invited, invitee: invitee, task: task) }
 
-      it "deletes the invitation queues up email job", redis: true do
+      it "deletes the invitation queues up email job" do
         delete(:destroy, {
           format: "json",
           id: invitation.id
@@ -123,7 +123,7 @@ describe InvitationsController do
     context "Invitation witout invitee" do
       let(:invitation) { FactoryGirl.create(:invitation, :invited, invitee: nil, email: "test@example.com", task: task) }
 
-      it "deletes the invitation queues up email job", redis: true do
+      it "deletes the invitation queues up email job" do
         expect(invitation.invitee).to be nil
         delete(:destroy, {
           format: "json",

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe TasksController, redis: true do
+describe TasksController do
   let(:user) { create :user, :site_admin }
 
   let!(:paper) do

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include ClientRouteHelper
 
-describe FeedbackMailer, redis: true do
+describe FeedbackMailer do
   let(:app_name) { 'TEST-APP-NAME' }
   let(:user) { FactoryGirl.create(:user) }
   let(:feedback) {

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 include ClientRouteHelper
 
-describe UserMailer, redis: true do
+describe UserMailer do
   let(:app_name) { 'TEST-APP-NAME' }
 
   before do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Comment, redis: true do
+describe Comment do
 
   let(:author) { FactoryGirl.create(:user) }
   let(:author2) { FactoryGirl.create(:user) }

--- a/spec/models/figure_spec.rb
+++ b/spec/models/figure_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Figure, redis: true do
+describe Figure do
   let(:paper) { FactoryGirl.create :paper }
   let(:figure) {
     with_aws_cassette('figure') do
@@ -27,15 +27,6 @@ describe Figure, redis: true do
       %w{doc docx pdf epub raw bmp}.each do |type|
         expect(Figure.acceptable_content_type? "image/#{type}").to eq false
       end
-    end
-  end
-
-  describe "removing the attachment" do
-    it "destroys the attachment on destroy" do
-      # remove_attachment! is a built-in callback.
-      # this spec exists so that we don't duplicate that behavior
-      expect(figure).to receive(:remove_attachment!)
-      figure.destroy
     end
   end
 end

--- a/spec/models/supporting_information_file_spec.rb
+++ b/spec/models/supporting_information_file_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe SupportingInformationFile, redis: true do
+describe SupportingInformationFile do
   let(:paper) { FactoryGirl.create :paper }
   let(:file) do
     with_aws_cassette 'supporting_info_files_controller' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -90,7 +90,6 @@ RSpec.configure do |config|
 
   config.before(:each) do
     DatabaseCleaner[:active_record].strategy = :transaction
-    DatabaseCleaner[:redis].strategy = :truncation
   end
 
   config.before(:each, js: true) do

--- a/spec/services/download_avatar_spec.rb
+++ b/spec/services/download_avatar_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DownloadAvatar, redis: true do
+describe DownloadAvatar do
   let(:user) { FactoryGirl.create(:user) }
   let(:url) { "https://tahi-test.s3.amazonaws.com/temp/500px-Jack_black.jpg" }
 

--- a/spec/services/download_epub_cover_spec.rb
+++ b/spec/services/download_epub_cover_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DownloadEpubCover, redis: true do
+describe DownloadEpubCover do
   let(:journal) { FactoryGirl.create(:journal) }
   let(:url) { "https://tahi-test.s3.amazonaws.com/temp/500px-Jack_black.jpg" }
 

--- a/spec/workers/download_adhoc_task_attachment_worker_spec.rb
+++ b/spec/workers/download_adhoc_task_attachment_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DownloadAdhocTaskAttachmentWorker, redis: true do
+describe DownloadAdhocTaskAttachmentWorker do
   let(:attachment) { FactoryGirl.create(:attachment, :with_task) }
   let(:url) { "http://tahi-test.s3.amazonaws.com/temp/bill_ted1.jpg" }
   let(:worker) { DownloadAdhocTaskAttachmentWorker.new }

--- a/spec/workers/download_figure_worker_spec.rb
+++ b/spec/workers/download_figure_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DownloadFigureWorker, redis: true do
+describe DownloadFigureWorker do
   let(:paper) { FactoryGirl.create(:paper) }
   let(:figure) { paper.figures.create }
   let(:url) { "http://tahi-test.s3.amazonaws.com/temp/bill_ted1.jpg" }

--- a/spec/workers/download_manuscript_worker_spec.rb
+++ b/spec/workers/download_manuscript_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DownloadManuscriptWorker, redis: true do
+describe DownloadManuscriptWorker do
   let(:paper) { FactoryGirl.create(:paper) }
   let(:url) { "https://tahi-test.s3.amazonaws.com/temp/about_equations.docx" }
 

--- a/spec/workers/download_question_attachment_worker_spec.rb
+++ b/spec/workers/download_question_attachment_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DownloadQuestionAttachmentWorker, redis: true do
+describe DownloadQuestionAttachmentWorker do
   let(:question_attachment) { FactoryGirl.create(:question_attachment) }
   let(:url) { "http://tahi-test.s3.amazonaws.com/temp/bill_ted1.jpg" }
 

--- a/spec/workers/download_supporting_info_worker_spec.rb
+++ b/spec/workers/download_supporting_info_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DownloadSupportingInfoWorker, redis: true do
+describe DownloadSupportingInfoWorker do
   let(:paper) { FactoryGirl.create(:paper) }
   let(:file) { paper.supporting_information_files.create }
   let(:url) { "http://tahi-test.s3.amazonaws.com/temp/bill_ted1.jpg" }

--- a/spec/workers/paper_unlocker_worker_spec.rb
+++ b/spec/workers/paper_unlocker_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe PaperUnlockerWorker do
+describe PaperUnlockerWorker, redis: true do
   let(:paper) { FactoryGirl.create(:paper, locked_by_id: 99) }
 
   describe "#perform" do


### PR DESCRIPTION
Redis wasn't actually required to run these tests. We suspect that our
Sidekiq test helpers have gotten better since the `redis: true` tag was
added to these tests.

Unfortunately, we were unable to completely remove Redis as a test
dependency. The PaperUnlockerWorker is performing queries directly
against Sidekiq. Maybe someday this will change and we can run all the
tests without Redis.

---

Reviewer tasks (merge when completed):
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
