### PR TITLE
Return all papers but unsubmitted

### DIFF
--- a/app/controllers/paper_tracker_controller.rb
+++ b/app/controllers/paper_tracker_controller.rb
@@ -5,7 +5,7 @@ class PaperTrackerController < ApplicationController
 
   def index
     # show all papers that user is connected to across all journals
-    papers = papers_submmited.where(journal_id: journal_ids)
+    papers = papers_submitted.where(journal_id: journal_ids)
     respond_with papers, each_serializer: PaperTrackerSerializer, root: 'papers'
   end
 
@@ -15,8 +15,8 @@ class PaperTrackerController < ApplicationController
     current_user.roles.pluck(:journal_id).uniq
   end
 
-  def papers_submmited
+  def papers_submitted
     # All papers unless it has not yet been submitted for the first time
-    Paper.where.not(publishing_state: 'unsubmitted')
+    Paper.where.not(publishing_state: :unsubmitted)
   end
 end


### PR DESCRIPTION
Update from the latest feedback from Pivotal Card [#102278984](https://www.pivotaltracker.com/story/show/102278984)

This PR change the condition from returning only submitted papers to return all but unsubmitted papers:

"We want everything unless it has not yet been submitted for the first time."

---

Reviewer Checks & Merges:
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
