### PR TITLE
Show confirmation when leaving editor with unsaved changes.

### DIFF
--- a/client/app/pods/paper/index/route.coffee
+++ b/client/app/pods/paper/index/route.coffee
@@ -93,4 +93,17 @@ PaperIndexRoute = AuthorizedRoute.extend
 
       @set 'fromSubmitOverlay', true
 
+    # ask for confirmation while autosaving has not finished yet
+    willTransition: (transition) ->
+      editorController = @controllerFor(@get('editorLookup'))
+      if editorController.get('isSaving') and not confirm("Are you sure you want to discard changes?")
+        transition.abort()
+        # In fact, when this is get's called, the URL has already been updated
+        # so we do a history forward to actually preserve the URL.
+        if window.history
+          window.history.forward()
+        false
+      else
+        true
+
 `export default PaperIndexRoute`


### PR DESCRIPTION
It should not be possible anymore to leave the page while auto-save is ongoing.

---

Reviewer tasks (merge when completed):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
