### PR TITLE
Fix some Ember deprecation warnings

### DIFF
--- a/client/app/controllers/overlays/admin-journal.js
+++ b/client/app/controllers/overlays/admin-journal.js
@@ -1,13 +1,13 @@
-import TaskController from 'tahi/pods/paper/task/controller';
+import Ember from 'ember';
 
-export default TaskController.extend({
-  needs: ['admin/journal/index'],
+export default Ember.Controller.extend({
+  journalController: Ember.inject.controller('admin/journal/index'),
   overlayClass: 'overlay--fullscreen journal-edit-overlay',
   propertyName: '',
 
   actions: {
     save() {
-      this.get('controllers.admin/journal/index')
+      this.get('journalController')
           .set(`${this.get('propertyName')}SaveStatus`, 'Saved')
           .get('model').save();
 

--- a/client/app/mixins/controllers/paper-index.js
+++ b/client/app/mixins/controllers/paper-index.js
@@ -13,7 +13,7 @@ export default Ember.Mixin.create({
     return Ember.isBlank($(this.get('model.body')).text());
   }),
 
-  statusMessage: computed.any('processingMessage', 'userEditingMessage', 'saveStateMessage'),
+  statusMessage: computed.or('processingMessage', 'userEditingMessage', 'saveStateMessage'),
 
   processingMessage: computed('model.status', function() {
     return this.get('model.status') === 'processing' ? 'Processing Manuscript' : null;

--- a/client/app/mixins/discussions/index/controller.js
+++ b/client/app/mixins/discussions/index/controller.js
@@ -5,7 +5,7 @@ export default Ember.Mixin.create(DiscussionsRoutePathsMixin, {
 
   paperId: undefined,
 
-  filteredTopics: Ember.computed('model.@each', 'paperId', function() {
+  filteredTopics: Ember.computed('model.[]', 'paperId', function() {
     return this.get('model').filterBy('paperId', this.get('paperId'));
   }),
 

--- a/client/app/pods/admin/journal/flow-manager/view.js
+++ b/client/app/pods/admin/journal/flow-manager/view.js
@@ -4,5 +4,5 @@ import Utils from 'tahi/services/utils';
 export default Ember.View.extend({
   columnCountDidChange: function() {
     Ember.run.scheduleOnce('afterRender', this, Utils.resizeColumnHeaders);
-  }.on('didInsertElement').observes('controller.model.flows.@each')
+  }.on('didInsertElement').observes('controller.model.flows.[]')
 });

--- a/client/app/pods/flow-manager/view.js
+++ b/client/app/pods/flow-manager/view.js
@@ -4,5 +4,5 @@ import Utils from 'tahi/services/utils';
 export default Ember.View.extend({
   columnCountDidChange: function() {
     Ember.run.scheduleOnce('afterRender', this, Utils.resizeColumnHeaders);
-  }.on('didInsertElement').observes('controller.model.@each')
+  }.on('didInsertElement').observes('controller.model.[]')
 });

--- a/client/app/pods/paper/workflow/view.js
+++ b/client/app/pods/paper/workflow/view.js
@@ -4,5 +4,5 @@ import Utils from 'tahi/services/utils';
 export default Ember.View.extend({
   setupColumnHeights: function() {
     Ember.run.scheduleOnce('afterRender', this, Utils.resizeColumnHeaders);
-  }.on('didInsertElement').observes('controller.phases.@each')
+  }.on('didInsertElement').observes('controller.phases.[]')
 });


### PR DESCRIPTION
#### Author notes:
- remove controller `needs`
- @each to []

Not sure why admin-journal overlay was inheriting from TaskController

---
#### For the reviewer:
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
