### PR TITLE
add validations to production metadata input fields

### DIFF
--- a/client/app/pods/components/error-message/component.js
+++ b/client/app/pods/components/error-message/component.js
@@ -2,13 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   classNames: ['error-message'],
-  classNameBindings: ['visible', 'addPassedClass'],
+  classNameBindings: ['visible'],
 
   visible: Ember.computed('message', function() {
     return this.get('message') ? '' : 'error-message--hidden';
-  }),
-
-  addPassedClass: Ember.computed(function() {
-    return this.get('class') ? this.get('class') : '';
   })
 });

--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/production_metadata_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/production_metadata_task.rb
@@ -3,7 +3,7 @@ module TahiStandardTasks
 
     register_task default_title: 'Production Metadata', default_role: 'admin'
 
-    validate :publication_date, :volume_number, :issue_number, if: :task_completed?
+    validate :publication_date, :volume_number, :issue_number, if: :newly_complete?
 
     def active_model_serializer
       ProductionMetadataTaskSerializer
@@ -25,10 +25,6 @@ module TahiStandardTasks
     end
 
     private
-
-    def task_completed?
-      self.completed?
-    end
 
     def a_question(type)
       questions.detect { |q| q.ident == "production_metadata.#{type}" }

--- a/engines/tahi_standard_tasks/client/app/templates/overlays/production-metadata.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/overlays/production-metadata.hbs
@@ -3,7 +3,7 @@
 </h1>
 
 <div class='production-metadata'>
-  <div class="form-group production_metadata">
+  <div class="form-group">
     <div class="inset-form-control required publication-date {{if validationErrors.publicationDate "error"}}">
       {{error-message message=validationErrors.publicationDate class="inset-form-control-text"}}
       <label class="inset-form-control-text">Publication Date</label>

--- a/spec/features/production_metadata_spec.rb
+++ b/spec/features/production_metadata_spec.rb
@@ -74,9 +74,9 @@ feature 'Production Metadata Card', js: true do
        describe 'with invalid input in required fields' do
         it 'shows an error'do
           find('#task_completed').click
-          wait_for_ajax
-          expect(page).to have_content "Can't be blank"
-          expect(page).to have_content "Invalid Volume Number"
+          expect(find(".publication-date")).to have_text("Can't be blank")
+          expect(find(".volume-number")).to have_text("Invalid Volume Number")
+          expect(find(".issue-number")).to have_text("Invalid Issue Number")
         end
       end
     end


### PR DESCRIPTION
server-side input validations - a little rejiggering of error-message component to include passed in classes

---
#### For the reviewer:

Reviewer tasks (author, please merge this PR when all tasks are complete):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
