### PR TITLE
[chore] - Auto db:migrate on deploy to RC env

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs
 https://github.com/heroku/heroku-buildpack-ruby
+https://github.com/gunpowderlabs/buildpack-ruby-db-migrate.git


### PR DESCRIPTION
This is so release-candidate will auto-migrate when it auto-deploys. 

Reference: http://gunpowderlabs.com/blog/automatically-run-migrations-when-deploying-to-heroku/
