### PR TITLE
APERTA-5361- Update paper downloader service to use the versioned figure inline path

### DIFF
--- a/app/services/paper_downloader.rb
+++ b/app/services/paper_downloader.rb
@@ -15,7 +15,7 @@ class PaperDownloader
   private
 
   def paper_body_with_figures
-    paper.body.gsub(/\/attachments\/figures\/(\d+)/) do
+    paper.body.gsub(/\/attachments\/figures\/(\d+)\?version=detail/) do
       Figure.find($1).attachment.detail.url
     end
   end

--- a/spec/services/paper_downloader_spec.rb
+++ b/spec/services/paper_downloader_spec.rb
@@ -18,7 +18,7 @@ describe PaperDownloader do
       it "returns the content of inline figures redirected to s3" do
         figure = paper.figures.create! attachment: tiff_file
         # Let's assume that this is valid html content
-        html_with_url = "src='/attachments/figures/#{figure.id}'"
+        html_with_url = "src='/attachments/figures/#{figure.id}?version=detail'"
         paper.latest_version.update(text: html_with_url)
 
         expect(body).to match(/'https:\/\/tahi.+detail_yeti.png\?X-Amz-Expires/)


### PR DESCRIPTION
#### What this PR does:

This PR updates the Paper Downloader service class to use the versioned form of the path of the inline figure after this PR https://github.com/Tahi-project/tahi/pull/1741 was merged.

Before this change we were using the original path with returns the real url in amazon s3 for the tiff and eps file, so it will not work on the browser, for that we have a previewable version, `detail` that returns a png file
#### Notes

I have to create this branch from `acceptance` because this new service class PaperDownloader it has not reached the `release-candidate` branch

Should I create a rake task to update the full path reference to the versioned one?

---
#### For the reviewer:

Reviewer tasks (reviewer, please merge this PR when all tasks are complete):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense (@zdennis reviewed)
- [x] I read the code; it looks good (@zdennis reviewed)
