### PR TITLE
Bugs/docx and image processing

### DIFF
--- a/app/uploaders/adhoc_attachment_uploader.rb
+++ b/app/uploaders/adhoc_attachment_uploader.rb
@@ -6,8 +6,8 @@ class AdhocAttachmentUploader < AttachmentUploader
     "uploads/attachments/#{model.id}/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  version :detail, if: :image? do
-    process resize_to_limit: [986, -1]
+  version :detail, if: :is_image? do
+    process resize_to_limit: [986, -1], if: :image?
     process :convert_to_png, if: :needs_transcoding?
 
     def full_filename(orig_file)
@@ -15,8 +15,8 @@ class AdhocAttachmentUploader < AttachmentUploader
     end
   end
 
-  version :preview, if: :image? do
-    process resize_to_limit: [475, 220]
+  version :preview, if: :is_image? do
+    process resize_to_limit: [475, 220], if: :image?
     process :convert_to_png, if: :needs_transcoding?
 
     def full_filename(orig_file)
@@ -26,7 +26,7 @@ class AdhocAttachmentUploader < AttachmentUploader
 
   protected
 
-  def image?(_image)
+  def is_image?(_image)
     model.image?
   end
 end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -12,7 +12,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   version :detail do
-    process resize_to_limit: [986, -1], if: :needs_transcoding?
+    process resize_to_limit: [986, -1], if: :image?
     process :convert_to_png, if: :needs_transcoding?
 
     def full_filename(orig_file)
@@ -21,7 +21,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   version :preview do
-    process resize_to_limit: [475, 220], if: :needs_transcoding?
+    process resize_to_limit: [475, 220], if: :image?
     process :convert_to_png, if: :needs_transcoding?
 
     def full_filename(orig_file)
@@ -53,6 +53,14 @@ class AttachmentUploader < CarrierWave::Uploader::Base
       ["image/tiff", "application/postscript"].include?(file.content_type)
     else
       !!(File.extname(file) =~ /(tif?f|eps)/i)
+    end
+  end
+
+  def image?(file)
+    if file.respond_to?('content_type')
+      ["image/tiff", "application/postscript"].include?(file.content_type)
+    else
+      !!(File.extname(file) =~ /(tif?f|eps|jpg|jpeg|gif|png)/i)
     end
   end
 end


### PR DESCRIPTION
This pull request replaces https://github.com/Tahi-project/tahi/pull/1653 and relates to Pivotal card [#101697856](https://www.pivotaltracker.com/story/show/101697856)

Things still todo:
- [x] Known/supported image types are resized 
- [x] TIFF/EPS files are converted to PNGs, and resized
- [x] DocX and other non-image files are not attempted to be converted or resized
- [ ] Add some unit tests around processing images
- [ ] Centralize the logic that determines if a file is an image or not

There was a bug where non-image supporting files were attempting to be resized and preview images generated.  This bug fix just adds the guard statement by the resize in the attachment_uploader.rb

 Reviewer tasks (reviewer, please merge when complete):
- [ ] I ran the code locally
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
