### PR TITLE
Rubocop spacing config - Open for discussion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,5 @@ Style/EmptyLinesAroundClassBody:
   Enabled: false
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
+Style/ExtraSpacing:
+  Enabled: false


### PR DESCRIPTION
This is a PR to turn off the "unnecessary spacing" warnings from Hound.
