### PR TITLE
Update private repo auth token

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -45,8 +45,8 @@
     "express": "^4.8.5",
     "glob": "^4.0.5",
     "liquid-fire": "0.21.2",
-    "tahi-fileupload": "git+https://f11148f2df58b9d5966b2543f6a0d3c035985f88:x-oauth-basic@github.com/Tahi-project/tahi-fileupload#90c3d61fbf76feb33f520dea94163ada17826ab0",
-    "tahi-editor-ve": "git+https://f11148f2df58b9d5966b2543f6a0d3c035985f88:x-oauth-basic@github.com/Tahi-project/tahi-editor-ve#f31ffafcb2b7ae0225d971392b998efa519ac3f3"
+    "tahi-fileupload": "git+https://ea548e3d06f18f2c5287468e46ae5fe262d3f5ac:x-oauth-basic@github.com/Tahi-project/tahi-fileupload#90c3d61fbf76feb33f520dea94163ada17826ab0",
+    "tahi-editor-ve": "git+https://ea548e3d06f18f2c5287468e46ae5fe262d3f5ac:x-oauth-basic@github.com/Tahi-project/tahi-editor-ve#f31ffafcb2b7ae0225d971392b998efa519ac3f3"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
So I noticed that we cannot `npm install` anymore. after some investigation, it looks like the Github Access Token that is embedded in the `package.json` was someone from Neo (I'm not sure how to check who it was...). we'll need to have someone from PLOS generate a new Access Token and use that to reference `tahi-fileupload` and `tahi-editor-ve`.

Alternatively, we could investigate other ways of including private packages in the project. the Github Access Token is used for OAuth. in my very brief searches, it looks like there might be other/newer ways of referencing private npm packges, but i'm not sure if they are compatible with our Heroku/CI builds.

The big downside of the Github Access Tokens is that they are tied to a specific user, not the organization. so we will end up with the same problem whenever the next person leaves the project.
