### PR TITLE
APERTA-3633 Fix bug where billing card complete box is disabled

### DIFF
--- a/engines/plos_billing/client/app/controllers/overlays/billing.js
+++ b/engines/plos_billing/client/app/controllers/overlays/billing.js
@@ -369,22 +369,26 @@ export default TaskController.extend({
   /*
     Sets error message bound to validationErrors.completed in -overlay-completed-checkbox when data invalid
   */
-  _disableCompletedWhenInvalid: Ember.observer('pfaData.isValid', function(){
-    var msg = this.get('pfaData.isValid') ? null : 'Errors in form';
+  _showErrorsInFormMsg: Ember.observer('pfa', 'pfaData.isValid', function(){
+    var msg = null;
+
+    if (this.get('pfa')) { //only if payment method is pfa
+      if (!this.get('pfaData.isValid')) msg = 'Errors in form';
+    }
+
     this.set('validationErrors.completed', msg)
   }),
 
   /*
     Overloads inherited isEditable in TaskController
     When false, makes complete box uncheckable
-    Strongly feel we should discuss new strategy for disabling of complete
-    that would allow for something more flexible and more robust
   */
-  isEditable: computed('pfaData.isValid', 'isUserEditable', 'currentUser.siteAdmin', function() {
-    return (
-      this.get('pfaData.isValid') &&
-      (this.get('isUserEditable') || this.get('currentUser.siteAdmin'))
-    );
+  isEditable: computed('pfa', 'pfaData.isValid', 'isUserEditable', 'currentUser.siteAdmin', function() {
+    if (this.get('pfa')){
+      return this.get('pfaData.isValid') && this._super();
+    } else {
+      return this._super();
+    }
   }),
 
   countries: Ember.inject.service(),

--- a/spec/features/paper_spec.rb
+++ b/spec/features/paper_spec.rb
@@ -46,26 +46,35 @@ feature "Editing paper", js: true do
       find('.workflow-link').click
       click_link('Billing')
 
-      find(".affiliation-field b[role='presentation']").click #select PFA from dropdown
-      find("li.select2-result div", :text => /PLOS Publication Fee Assistance Program \(PFA\)/).click #select PFA from dropdown
+      expect(find("input#task_completed")[:disabled]).to be(nil) # not disabled at start
+
+      find(".affiliation-field b[role='presentation']").click # open payment types dropdown
+      find("div.select2-result-label", :text => /PLOS Publication Fee Assistance Program \(PFA\)/).click #select PFA from dropdown
 
       expect(find("input#task_completed")[:disabled]).to be(nil)
-
+      expect(page).not_to have_selector(".overlay-completed-checkbox .error-message") # make sure no error msg
 
       within(".question-dataset") do
-        find("input[id='plos_billing.pfa_question_1-yes']").click  #doesn't work: find("#plos_billing.pfa_question_1-yes").click
+        find("input[id='plos_billing.pfa_question_1-yes']").click  # doesn't work: find("#plos_billing.pfa_question_1-yes").click
         find("input[id='plos_billing.pfa_question_2-yes']").click
         find("input[id='plos_billing.pfa_question_3-yes']").click
         find("input[id='plos_billing.pfa_question_4-yes']").click
 
-        #numeric fields
+        # numeric fields
         ['pfa_question_1b', 'pfa_question_2b', 'pfa_question_3a', 'pfa_question_4a', 'pfa_amount_to_pay'].each do |ident|
           find("input[name='plos_billing.#{ident}']").set "foo"
           expect(find("#error-for-#{ident}")).to have_content("Must be a number and contain no symobls, or letters")
         end
       end
 
-      expect(find("input#task_completed")[:disabled]).to be_truthy
+      expect(find("input#task_completed")[:disabled]).to be_truthy # complete is disabled
+      expect(find(".overlay-completed-checkbox .error-message").text).to eq("Errors in form") # shows error
+
+      # change to a different payment system
+      find(".affiliation-field b[role='presentation']").click # open payment types dropdown
+      find("div.select2-result-label", :text => /I will pay the full fee/).click # change back to non-pfa
+      expect(find("input#task_completed")[:disabled]).to be(nil) # not disabled after change
+      expect(page).not_to have_selector(".overlay-completed-checkbox .error-message") # make sure no error msg
     end
   end
 end


### PR DESCRIPTION
#### What this PR does:
- reworked isEditable computed property to call super()
- made isEditable computed property dependend on pfa payment method
- reworked when Errors in form message is shown to dependon payment method
- beefed up feature specs to ensure that the states of completed are accurate
#### For the reviewer:

Reviewer tasks (reviewer, please merge this PR when all tasks are complete):
- [ ] I ran the code locally
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
#### How To Accept
- make a paper with a billing card
- open billing card
  - make sure that the complete box is not disabled on load before any data entry
  - it should stay "enabled" for all situations where pfa data is not selected
  - it should be disabled with an error message when there is pfa data errors
  - to create a pfa data error: on 1st question select partial, and then type non-numbers into the text box
  - this should disable the complete box, and show error message next to it
  - even with errors in the form and a disabled complete box, you should be able to change away from the pfa payment option, and the form comple box with "re-enable"
