### PR TITLE
Correctly subscribe to Discussion Topics

### DIFF
--- a/app/policies/discussion_topics_policy.rb
+++ b/app/policies/discussion_topics_policy.rb
@@ -1,6 +1,6 @@
 class DiscussionTopicsPolicy < ApplicationPolicy
   primary_resource :discussion_topic
-  require_params :paper
+  allow_params :paper
 
   def index?
     papers_policy.show?
@@ -17,6 +17,12 @@ class DiscussionTopicsPolicy < ApplicationPolicy
   alias :destroy? :show?
 
   private
+
+  def paper
+    # either the paper is sent in when this Policy is initialized, or we have a
+    # valid discussion_topic and can grab the paper off of the topic.
+    @paper ||= discussion_topic.paper
+  end
 
   def participating_in_discussion?
     discussion_topic.discussion_participants.where(user_id: current_user.id).exists?

--- a/client/app/pods/paper/route.js
+++ b/client/app/pods/paper/route.js
@@ -19,7 +19,7 @@ export default AuthorizedRoute.extend({
   },
 
   topicChannelName(topic) {
-    return 'private-discussiontopic@' + topic.get('id');
+    return 'private-discussion_topic@' + topic.get('id');
   },
 
   afterModel(model) {

--- a/spec/policies/discussion_topics_policy_spec.rb
+++ b/spec/policies/discussion_topics_policy_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe DiscussionTopicsPolicy do
+
+  context "initializing without a paper (useful for #index? and event_stream#show?)" do
+    let(:paper) { FactoryGirl.create(:paper) }
+    let(:discussion_topic) { FactoryGirl.create(:discussion_topic, paper: paper) }
+    let(:policy) { DiscussionTopicsPolicy.new(current_user: user, resource: discussion_topic) }
+
+    context "user with access" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      before do
+        make_user_paper_editor(user, paper)
+        discussion_topic.discussion_participants.create!(user: user)
+      end
+
+      specify { expect(policy.index?).to eq(true) }
+      specify { expect(policy.create?).to eq(true) }
+      specify { expect(policy.show?).to eq(true) }
+    end
+
+    context "user without access" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      specify { expect(policy.index?).to eq(false) }
+      specify { expect(policy.create?).to eq(false) }
+      specify { expect(policy.show?).to eq(false) }
+    end
+  end
+
+end


### PR DESCRIPTION
DiscussionTopicsPolicy required that a paper be passed in during
initialization. This was _typically_ the case, but there were two
situations where this fell down:
1. When the policy needed to check `index?`
2. When the EventStream needed to check `show?`

The current policy framework does not well support situations like this
and might need reevaluated. However, that work falls outside the scope
of this bug fix.

---

Original PR to Acceptance: https://github.com/Tahi-project/tahi/pull/1686

Code Reviewer:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
