### PR TITLE
Only show participation activity on workflow feed

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -147,7 +147,7 @@ class Activity < ActiveRecord::Base
 
   def self.participation_created!(participation, user:)
     create(
-      feed_name: "manuscript",
+      feed_name: "workflow",
       activity_key: "participation.created",
       subject: participation.paper,
       user: user,
@@ -157,7 +157,7 @@ class Activity < ActiveRecord::Base
 
   def self.participation_destroyed!(participation, user:)
     create(
-      feed_name: "manuscript",
+      feed_name: "workflow",
       activity_key: "particpation.destroyed",
       subject: participation.paper,
       user: user,

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -1,0 +1,8 @@
+namespace :one_off do
+
+  desc "migrate existing activity records to hide reviewers from authors"
+  task :migrate_participations_activity_to_workflow => :environment do
+    Activity.where(activity_key: ["participation.created", "participation.destroyed"]).update_all(feed_name: "workflow")
+  end
+
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -226,7 +226,7 @@ describe Activity do
 
     it {
       is_expected.to have_attributes(
-        feed_name: "manuscript",
+        feed_name: "workflow",
         activity_key: "participation.created",
         subject: participation.paper,
         user: user,
@@ -240,7 +240,7 @@ describe Activity do
 
     it {
       is_expected.to have_attributes(
-        feed_name: "manuscript",
+        feed_name: "workflow",
         activity_key: "particpation.destroyed",
         subject: participation.paper,
         user: user,


### PR DESCRIPTION
When a Reviewer is invited to review a Paper, a ReviewerReportTask is
created for them. That Reviewer is added to that task as a Participant.
This creates a Activity record, recording this action.

It was deemed useful for the staff to add the Reviewer's name to that
Activity record. Unfortunately, it is a huge privacy hole for the anyone
else. The Author absolutely should not see who is reviewing their Paper.

To hide this from them, only publish these types of Activities to the
workflow feed, not the manuscript feed.

---

Original PR to Acceptance: https://github.com/Tahi-project/tahi/pull/1759
JIRA issue: https://developer.plos.org/jira/browse/APERTA-2928

Code Reviewer:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria

Product Owner:
- [x] I have verified the expected behavior in the Review environment
