### PR TITLE
[CHORE] Turn on Capybara.wait_on_first_by_default

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,7 @@ Capybara.register_driver :selenium do |app|
 end
 
 Capybara.javascript_driver = :selenium
+Capybara.wait_on_first_by_default = true
 
 # Store screenshots in artifacts dir on circle
 if ENV['CIRCLE_TEST_REPORTS']


### PR DESCRIPTION
Turn on Capybara.wait_on_first_by_default so `#first(...)`will use Capybara's traditional waiting behavior.

This is to resolve an intermittent spec failure in spec/features/journal_administration_spec.rb where it cannot find a button using #first(...) in order to click on it.

Additional musings: The app should not need to use #first(...) but it uses spans and divs for representing clickable areas (as opposed to buttons or anchor tags). Because of this it can't take advantage of Capybara's #click_button, #click_link, #click_on helper methods which automatically provide the waiting behavior.
