### PR TITLE
Add EM SQLServer connection

### DIFF
--- a/.env
+++ b/.env
@@ -76,3 +76,10 @@ SEGMENT_IO_WRITE_KEY=write_key
 SENDGRID_PASSWORD=password
 SENDGRID_USERNAME=username
 # }}}
+
+# {{{ PLoS EM Database configs
+EM_HOST=
+EM_DATABASE=
+EM_USERNAME=
+EM_PASSWORD=
+# }}}

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,11 @@ gem 'tahi-assign_team', git: 'https://ea548e3d06f18f2c5287468e46ae5fe262d3f5ac:x
 gem 'rails', '4.2.4'
 gem 'puma'
 gem 'rack-timeout'
+
 gem 'pg'
+gem 'activerecord-sqlserver-adapter'
+gem 'tiny_tds'
+
 gem 'ember-cli-rails'
 gem 'sass-rails'
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
       activemodel (= 4.2.4)
       activesupport (= 4.2.4)
       arel (~> 6.0)
+    activerecord-sqlserver-adapter (4.2.4)
+      activerecord (~> 4.2.1)
     activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -555,6 +557,8 @@ GEM
     timeliness (0.3.7)
     timers (4.0.1)
       hitimes
+    tiny_tds (0.7.0)
+      mini_portile (= 0.6.2)
     twitter-text (1.13.0)
       unf (~> 0.1.0)
     tzinfo (1.2.2)
@@ -584,6 +588,7 @@ DEPENDENCIES
   aasm (~> 4.1.0)
   active_model_serializers (= 0.8.3)
   activemodel-globalid!
+  activerecord-sqlserver-adapter
   acts_as_list!
   american_date
   auto_screenshot
@@ -660,6 +665,7 @@ DEPENDENCIES
   thin
   timecop
   timeliness
+  tiny_tds
   twitter-text
   uglifier
   unf

--- a/app/models/plos_editorial_manager.rb
+++ b/app/models/plos_editorial_manager.rb
@@ -1,0 +1,17 @@
+#
+# This class is to establish a connection to EM
+# and retrieve GUIDs for Authors in Aperta
+#
+class PlosEditorialManager < ActiveRecord::Base
+  establish_connection :plos_editorial_manager
+
+  def self.find_person_by_email(email:)
+    email = email.strip
+    sql = "SELECT TOP (1) * FROM PEOPLE JOIN ADDRESS ON (PEOPLE.PEOPLEID = ADDRESS.PEOPLEID) WHERE ADDRESS.EMAIL LIKE '%#{email}%'"
+    query(sql)
+  end
+
+  def self.query(sql)
+    connection.exec_query(sql).to_hash
+  end
+end

--- a/config/database.shippable.yml
+++ b/config/database.shippable.yml
@@ -74,3 +74,11 @@ production:
   database: tahi_production
   pool: 48
   password:
+
+# PLoS Editorial Manager connection
+plos_editorial_manager:
+  adapter: sqlserver
+  host: <%= ENV['EM_HOST'] %>
+  database: <%= ENV['EM_DATABASE'] %>
+  username: <%= ENV['EM_USERNAME'] %>
+  password: <%= ENV['EM_PASSWORD'] %>

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -56,3 +56,11 @@ production:
   database: tahi_production
   pool: 48
   password:
+
+# PLoS Editorial Manager connection
+plos_editorial_manager:
+  adapter: sqlserver
+  host: <%= ENV['EM_HOST'] %>
+  database: <%= ENV['EM_DATABASE'] %>
+  username: <%= ENV['EM_USERNAME'] %>
+  password: <%= ENV['EM_PASSWORD'] %>

--- a/db/migrate/20150929202135_add_em_guid_to_users.rb
+++ b/db/migrate/20150929202135_add_em_guid_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmGuidToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :em_guid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150918192514) do
+ActiveRecord::Schema.define(version: 20150929202135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -486,6 +486,7 @@ ActiveRecord::Schema.define(version: 20150918192514) do
     t.string   "username"
     t.boolean  "site_admin",             default: false, null: false
     t.string   "avatar"
+    t.string   "em_guid"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/engines/plos_billing/lib/tasks/plos_billing.rake
+++ b/engines/plos_billing/lib/tasks/plos_billing.rake
@@ -3,4 +3,20 @@ namespace :plos_billing do
     paper = Paper.find(args[:paper_id])
     SalesforceServices::API.delay.create_billing_and_pfa_case(paper_id: paper.id) if paper.billing_card
   end
+
+  task :sync_em_guids => :environment do
+    User.where(em_guid: nil).find_each do |user|
+      em_match = PlosEditorialManager.find_person_by_email(email: user.email)
+
+      if em_match.present? && em_match.size == 1
+        guid = em_match.first["GUID"]
+
+        puts "match for #{user.email} - #{guid}"
+        user.update_attribute(:em_guid, guid)
+      else
+        puts "no match for #{user.email}"
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This is another PR that Ryan had merged into `acceptance` but not `release-candidate`. Once again I've tried to consolidate the churn from the original PR.

Original commits for the curious:

```
em-connecting
99d90af29536aa294d99fbba16383fa67990b4c2 adding EM SQLServer connection
7a0ddda09226ab8416bc038c874764f037a9cb41 update ignored database.yml
d13340f6d8bbc44c92819aac232ba5d705805d37 reignore database.yml
ef2aaf53b4277beab1620d3b0b13fa5f8186e58c use .find_each
1d829220848311668f2f5f24fdf3c623dc2632fb use erb for ENV values
f0a175eaeb3b72a954a951eaf43f2b99f5b55130 support wildcard lookups
f9854d2b1b1727414f128d6763c2ff23b367c749 use find_each, and remove unused logic
8bfe5d9ae69e72f057a795a1a532f74a1dbcc7e5 stub EM ENVs
```

It also checked in a previously-ignored `database.yml` file. I do not believe this is desirable. The `database.yml` is generated/copied from the `database.yml.sample`, which was correct in his original commits. I've removed this erroneously added file from being tracked by git.

---

JIRA issue: https://developer.plos.org/jira/browse/APERTA-3369
Original PR to `acceptance`: https://github.com/Tahi-project/tahi/pull/1747

Code Reviewer:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria

Product Owner:
- [ ] I have verified the expected behavior in the Review environment
