### PR TITLE
CHORE: Resolve development environment reloading issue

### DIFF
--- a/lib/subscriptions/subscriber.rb
+++ b/lib/subscriptions/subscriber.rb
@@ -10,8 +10,14 @@ module Subscriptions
     #
     def self.subscribe(event, subscribers)
       subscribers.flatten.each do |subscriber|
+        # +subscriber_name+ is so we do not reference the subscriber directly.
+        # If we do it breaks auto reloading in development environment by
+        # keeping an old class reference around. Instead, store its name and
+        # constantize at the we need to use it.
+        subscriber_name = subscriber.name
+
         ActiveSupport::Notifications.subscribe(/\A#{APPLICATION_EVENT_NAMESPACE}:#{event}/) do |name, _start, _finish, _id, data|
-          subscriber.call(name, data)
+          subscriber_name.constantize.call(name, data)
         end
       end
     end


### PR DESCRIPTION
This resolves an issue with reloading code in the development environment, e.g. 

```
ArgumentError: A copy of <Some Class Here> has been removed from the module 
tree but is still active!
```

JIRA issue: NO JIRA ISSUE. Just a technical chore.
### Details

This was because we were keeping a class reference within scope. To resolve this only store the name and re-constantize when the time is necessary to pass along the event notification.
### How-to test

Without this fix open up `rails console`:

``` ruby
Paper.last.update(abstract: "foo")
reload!
Paper.last.update(abstract: "bar")
# => ArgumentError: A copy of EventStreamSubscriber has been removed from the module tree but is still active!
```

With the fix this should no longer occur.
### Code Reviewer:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- ~~[ ] I have found the tests to be sufficient~~ (not applicable)
- ~~[ ] I agree the code fulfills the Acceptance Criteria~~ (not applicable)

~~Product Owner:~~ (not applicable)
~~\- [ ] I have verified the expected behavior in the Review environment~~ 
