### PR TITLE
fix/APERTA-3633 - Billing validations revised after QA

### DIFF
--- a/engines/plos_billing/client/app/controllers/overlays/billing.js
+++ b/engines/plos_billing/client/app/controllers/overlays/billing.js
@@ -332,10 +332,13 @@ export default TaskController.extend({
     pfa partial is inserted
   */
   buildPfaValidator: function(){
+    const numericMessage = "Must be a number and contain no symbols, or letters, e.g. $1,000.00 should be written 1000";
     const numericalityConfig = { numericality: {
       allowBlank: true,
+      onlyInteger: true,
       messages: {
-        numericality: "Must be a number and contain no symbols, or letters"
+        onlyInteger: numericMessage,
+        numericality: numericMessage
       }
     }};
 


### PR DESCRIPTION
THIS IS A _FIX_, as QA found an edge case where the validation wasn't strict enough. I tightened up validation on numbers so that it doesn't fail in Salesforce.
Nice catch @jgray-PLOS!

The acceptance criteria are the same here as [the original PR](https://github.com/Tahi-project/tahi/pull/1799)
#### What this PR does:

Places client-side validations in billing card. Certain "acceptable" data can make the push to Salesforce fail. We needed some client-level checks to enforce numeric data in the USD fields, and potentially other fields in future.
- added Ember Validations to package.json, and used that in the billing.js controller, and made an addition to the paper feature spec. 
- reworked isEditable computed property to call super()
- made isEditable computed property dependend on pfa payment method
- reworked when Errors in form message is shown to dependon payment method
- beefed up feature specs to ensure that the states of completed are accurate
#### For the reviewer:

Reviewer tasks (reviewer, please merge this PR when all tasks are complete):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
#### Acceptance Instructions
- create a new manuscript with a billing card (may need to be admin)
- click the billing card button
- For the 1st question "Have you investigated if funding is available...", select "Partial"
- in the text box that appears underneath, enter text that has formerly "accepted" (, .) characters, eg "1,000.00."
## \- verify that error messages shows saying these chars are not allowed. 
