### PR TITLE
Change slanger app id to be unique

### DIFF
--- a/app.json
+++ b/app.json
@@ -89,7 +89,9 @@
       "required": true
     },
     "EVENT_STREAM_APP_ID": {
-      "required": true
+      "description": "A unique app id for connecting to slanger.  Prevents overlap between review apps.",
+      "required": true,
+      "generator": "secret"
     },
     "EVENT_STREAM_KEY": {
       "required": true


### PR DESCRIPTION
Prior to this change, all heroku review apps were using the standard
slanger app id of 'staging'.  This causes issues where clients would
receive pusher notifications from all review apps instead of just
the one being tested.  This change generates a unique application id
which will essentially namespace and isolate requests on the staging
slanger instance.

![tahi-staging-pr-1820 settings heroku 2015-10-21 10-07-17](https://cloud.githubusercontent.com/assets/18446/10638945/8ebf3c0e-77db-11e5-80cf-292acd7cba26.png)

---

Reviewer:
- [ ] I looked at the screenshot above and it does look unique to me!
- [ ] I went to the reviewer app, opened two browsers with the same logged in user, marked a task as 'complete' and saw that pusher still works
