### PR TITLE
Remove Intelligibility Question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 -
 
 ### Removed
--
+- Intelligibility Question from the ReviewerReportTask
 
 ### Fixed
 -

--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/reviewer_report_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/reviewer_report_task.rb
@@ -77,29 +77,10 @@ module TahiStandardTasks
       questions << NestedQuestion.new(
         owner_id:nil,
         owner_type: name,
-        ident: "intelligible",
-        value_type: "boolean",
-        text: "Is the manuscript presented in an intelligible fashion and written in standard English?",
-        position: 5,
-        children: [
-          NestedQuestion.new(
-            owner_id:nil,
-            owner_type: name,
-            ident: "explanation",
-            value_type: "text",
-            text: "Intelligible Explanation",
-            position: 1
-          )
-        ]
-      )
-
-      questions << NestedQuestion.new(
-        owner_id:nil,
-        owner_type: name,
         ident: "additional_comments",
         value_type: "text",
         text: "(Optional) Please offer any additional comments to the author.",
-        position: 6
+        position: 5
       )
 
       questions << NestedQuestion.new(
@@ -108,7 +89,7 @@ module TahiStandardTasks
         ident: "identity",
         value_type: "text",
         text: "(Optional) If you'd like your identity to be revealed to the authors, please include your name here.",
-        position: 7
+        position: 6
       )
 
       questions.each do |q|

--- a/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-questions.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-questions.hbs
@@ -63,25 +63,6 @@
   </li>
 
   <li class="question">
-    {{#nested-question-radio ident="intelligible"
-                      owner=model
-                      decision=decision
-                      helpText="<li>PLOS ONE does not copyedit accepted manuscripts, so the language in submitted articles must be clear, correct, and unambiguous. Any typographical or grammatical errors should be corrected at revision, so please note any specific errors below.</li>"
-                      wrapperClass="yes-no-with-comments"
-                      readonly=readonly as |radio|}}
-      {{#if radio.yieldingForAdditionalData}}
-        {{nested-question-textarea
-            ident="intelligible.explanation"
-            owner=model
-            decision=decision
-            noResponseText=""
-            displayQuestionText=false
-            readonly=readonly}}
-      {{/if}}
-    {{/nested-question-radio}}
-  </li>
-
-  <li class="question">
     {{nested-question-textarea ident="additional_comments"
                         owner=model
                         decision=decision

--- a/engines/tahi_standard_tasks/spec/support/pages/overlays/reviewer_report_overlay.rb
+++ b/engines/tahi_standard_tasks/spec/support/pages/overlays/reviewer_report_overlay.rb
@@ -36,7 +36,6 @@ class ReviewerReportOverlay < CardOverlay
       "support_conclusions.explanation" => "default support_conclusions.explanation content",
       "statistical_analysis.explanation" => "default statistical_analysis.explanation content",
       "standards.explanation" => "default standards.explanation content",
-      "intelligible.explanation" => "default intelligible.explanation content",
       "additional_comments" => "default additional_comments content",
       "identity" => "default identity content"
     )

--- a/lib/data_migrator/reviewer_report_questions_migrator.rb
+++ b/lib/data_migrator/reviewer_report_questions_migrator.rb
@@ -10,8 +10,6 @@ class DataMigrator::ReviewerReportQuestionsMigrator < DataMigrator::Base
       STATISTICAL_ANALYSIS_EXPLANATION_IDENT: "reviewer_report.statistical_analysis.explanation",
       STANDARDS_IDENT: "reviewer_report.standards",
       STANDARDS_EXPLANATION_IDENT: "reviewer_report.standards.explanation",
-      INTELLIGIBLE_IDENT: "reviewer_report.intelligible",
-      INTELLIGIBLE_EXPLANATION_IDENT: "reviewer_report.intelligible.explanation",
       ADDITIONAL_COMMENTS_IDENT: "reviewer_report.additional_comments",
       IDENTITY_IDENT: "reviewer_report.identity"
     },
@@ -24,8 +22,6 @@ class DataMigrator::ReviewerReportQuestionsMigrator < DataMigrator::Base
       STATISTICAL_ANALYSIS_EXPLANATION_IDENT: "explanation",
       STANDARDS_IDENT: "standards",
       STANDARDS_EXPLANATION_IDENT: "explanation",
-      INTELLIGIBLE_IDENT: "intelligible",
-      INTELLIGIBLE_EXPLANATION_IDENT: "explanation",
       ADDITIONAL_COMMENTS_IDENT: "additional_comments",
       IDENTITY_IDENT: "identity"
     }
@@ -130,25 +126,6 @@ class DataMigrator::ReviewerReportQuestionsMigrator < DataMigrator::Base
           ident: "explanation",
           value_type: "text",
           text: "Standards Explanation",
-          position: 1
-        )
-      ]
-    )
-
-    questions << NestedQuestion.new(
-      owner_id: nil,
-      owner_type: TASK_OWNER_TYPE,
-      ident: "intelligible",
-      value_type: "boolean",
-      text: "Is the manuscript presented in an intelligible fashion and written in standard English?",
-      position: 5,
-      children: [
-        NestedQuestion.new(
-          owner_id: nil,
-          owner_type: TASK_OWNER_TYPE,
-          ident: "explanation",
-          value_type: "text",
-          text: "Intelligible Explanation",
           position: 1
         )
       ]

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -5,4 +5,21 @@ namespace :one_off do
     Activity.where(activity_key: ["participation.created", "participation.destroyed"]).update_all(feed_name: "workflow")
   end
 
+  task :remove_intelligible_question_from_reviewer_report => :environment do
+    ActiveRecord::Base.transaction do
+      task = TahiStandardTasks::ReviewerReportTask
+      question = task.nested_questions.where(ident: 'intelligible').first
+      deleted_position = question.position
+
+      # child questions are *not* dependently destroyed (must do explicitly)
+      # nested_question_answers are dependently destroyed by the nested_question
+      question.children.destroy_all
+      question.destroy!
+
+      # after removing a top level question, the others have out-of-date position values
+      top_level_questions = task.nested_questions.where(parent_id: nil).where('position > ?', deleted_position)
+      top_level_questions.update_all('position = position - 1')
+    end
+  end
+
 end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-5377
#### What this PR does:

This question doesn't apply to PLOS Bio, as it _does_ have a copyediting step.

Remove the Question itself, its sub-questions, its answers, and its sub-questions' answers, and the template. Reposition the remaining questions.

Remove any mention of the intelligibility question from the migration of "old Questions" to "new NestedQuestions". No need to migrate dead data.
#### Notes

Run `rake one_off:remove_intelligible_question_from_reviewer_report` to migrate the question data.

---
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- ~~[ ] I have found the tests to be sufficient~~ (n/a)
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
