### PR TITLE
Feature/aperta 3502 billing log file

### DIFF
--- a/app/services/cloud_services/s3_service.rb
+++ b/app/services/cloud_services/s3_service.rb
@@ -1,0 +1,24 @@
+module CloudServices
+  class S3Service
+
+    def connection
+      CloudServices::S3Service::Connector.instance.connection
+    end
+
+    class Connector
+      include Singleton
+
+      attr_reader :connection
+
+      def initialize
+        @connection = Fog::Storage.new(
+          provider:             'AWS',
+          region:                ENV['AWS_REGION'],
+          aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],
+          aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+        )
+      end
+    end
+
+  end
+end

--- a/engines/plos_billing/app/services/plos_services/billing_log_manager.rb
+++ b/engines/plos_billing/app/services/plos_services/billing_log_manager.rb
@@ -1,0 +1,112 @@
+require 'csv'
+
+module PlosServices
+  class BillingLogManager
+
+    def initialize(paper:)
+      @paper = paper
+    end
+
+    def paper_to_billing_log_hash
+      {
+        guid:                          'PONE-2', # @paper.creator.em_guid, when em_guid is merged
+        document_id:                   @paper.manuscript_id,
+        title:                         answer_for('title'),
+        first_name:                    answer_for('first_name'),
+        middlename:                    '',
+        lastname:                      answer_for('last_name'),
+        institute:                     'placeholderInstitute',
+        department:                    'placeholderDepartment',
+        address1:                      answer_for('address1'),
+        address2:                      answer_for('address2'),
+        address3:                      '',
+        city:                          answer_for('city'),
+        state:                         answer_for('state'),
+        zip:                           answer_for('postal_code'),
+        country:                       answer_for('country'),
+        phone1:                        answer_for('phone_number'),
+        phone2:                        '',
+        fax:                           '',
+        email:                         answer_for('email'),
+        journal:                       @paper.journal.name,
+        pubdnumber:                    'placeholderPubDNumber',
+        doi:                           @paper.doi,
+        dtitle:                        @paper.title,
+        issn:                          '',
+        price:                         '',
+        waiver_text:                   '', # highlighted in Linda's spreadsheet. not sure why
+        discount_institution:          '', # highlighted
+        collection:                    '', # highlighted
+        direct_bill:                   '', # highlighted
+        import_date:                   '',
+        line_no:                       '',
+        original_submission_start_date:'',
+        actual_online_pub_date:        '',
+        batch_no:                      '',
+        exception:                     '',
+        direct_bill_expense:           '', # highlighted
+        date_first_entered_production: '', # highlighted
+        pub_charge_response:           '', # highlighted
+        pub_waiver_response:           '', # highlighted
+        institutional_response:        '', # highlighted
+        gpi_response:                  '', # highlighted
+        gpi_tier:                      '',
+        base_price:                    '',
+        discount_price:                '',
+        discount_percent:              '',
+        waiver_amount:                 '',
+        collections_response:          '', # highlighted
+        eligible:                      '',
+        rescind:                       '',
+        standard_collection_id:        '',
+        terms1:                        '',
+        terms2:                        '',
+        terms3:                        '',
+        terms4:                        '',
+        terms5:                        '',
+        final_dispo_accept:            'placeholderFinalDispoAccept',
+        terms6:                        '',
+        category:                      'placeholderCategory',
+        split:                         ''
+      }
+    end
+
+    def to_csv
+
+      data = paper_to_billing_log_hash
+
+      csv = CSV.new ""
+      csv << data.keys
+      csv << data.values
+      csv
+    end
+
+    def to_s3
+      s3       = CloudServices::S3Service.new.connection
+
+      directory = s3.directories.new(
+        key:    Rails.application.config.s3_bucket,
+        public: false
+      )
+
+      s3_file = directory.files.create(
+        key:    "billing/#{filename}",
+        body:   to_csv.string,
+        public: true
+      )
+
+      s3_file.save # returns true if !errors
+    end
+
+    def filename
+      @filename ||= "billing-log-paper-#{@paper.id}-#{Time.now.utc.to_i}.csv"
+    end
+
+    private
+
+    def answer_for(ident)
+      answer = @paper.billing_card.answer_for(ident)
+      answer.value if answer
+    end
+  end
+end

--- a/engines/plos_billing/lib/tasks/plos_billing.rake
+++ b/engines/plos_billing/lib/tasks/plos_billing.rake
@@ -22,4 +22,18 @@ namespace :plos_billing do
     end
   end
 
+  # Usage:
+  #   rake plos_billing:upload_log_file_to_s3[33]
+  #   where:
+  #     args[:paper_id] => "33"
+  desc "Uploads a CSV billing log file to S3"
+  task :upload_log_file_to_s3, [:paper_id] => :environment do |t, args|
+    if args[:paper_id]
+      paper = Paper.find args[:paper_id]
+      bm    = PlosServices::BillingLogManager.new paper: paper
+      bm.to_s3 && puts("Uploaded #{bm.filename}")
+    else
+      puts "Missing paper_id. Please see usage instructions in #{__FILE__}"
+    end
+  end
 end

--- a/engines/plos_billing/spec/plos_services/billing_log_manager_spec.rb
+++ b/engines/plos_billing/spec/plos_services/billing_log_manager_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+describe PlosServices::BillingLogManager do
+  let(:paper)   { make_paper }
+  let(:bm)      { PlosServices::BillingLogManager.new paper: paper }
+
+  describe "#paper_to_billing_log_hash" do
+    it "sets paper's data in the hash" do
+      data = bm.paper_to_billing_log_hash
+
+      # if size changes don't forget to add/remove data checks below
+      expect(data.size).to                             eq 59
+
+      expect(data[:guid]).to                           eq "PONE-2"
+      expect(data[:document_id]).to                    eq paper.manuscript_id
+      expect(data[:title]).to                          eq "title"
+      expect(data[:first_name]).to                     eq "bob"
+      expect(data[:middlename]).to                     eq ""
+      expect(data[:lastname]).to                       eq "barker"
+      expect(data[:institute]).to                      eq "placeholderInstitute"
+      expect(data[:department]).to                     eq "placeholderDepartment"
+      expect(data[:address1]).to                       eq "address1"
+      expect(data[:address2]).to                       eq "address2"
+      expect(data[:address3]).to                       eq ""
+      expect(data[:city]).to                           eq "city"
+      expect(data[:state]).to                          eq "state"
+      expect(data[:zip]).to                            eq "postal_code"
+      expect(data[:country]).to                        eq "country"
+      expect(data[:phone1]).to                         eq "phone_number"
+      expect(data[:phone2]).to                         eq ""
+      expect(data[:fax]).to                            eq ""
+      expect(data[:email]).to                          eq "email"
+      expect(data[:journal]).to                        eq paper.journal.name
+      expect(data[:pubdnumber]).to                     eq "placeholderPubDNumber"
+      expect(data[:doi]).to                            eq paper.doi
+      expect(data[:dtitle]).to                         eq paper.title
+      expect(data[:issn]).to                           eq ""
+      expect(data[:price]).to                          eq ""
+      expect(data[:waiver_text]).to                    eq ""
+      expect(data[:discount_institution]).to           eq ""
+      expect(data[:collection]).to                     eq ""
+      expect(data[:direct_bill]).to                    eq ""
+      expect(data[:import_date]).to                    eq ""
+      expect(data[:line_no]).to                        eq ""
+      expect(data[:original_submission_start_date]).to eq ""
+      expect(data[:actual_online_pub_date]).to         eq ""
+      expect(data[:batch_no]).to                       eq ""
+      expect(data[:exception]).to                      eq ""
+      expect(data[:direct_bill_expense]).to            eq ""
+      expect(data[:date_first_entered_production]).to  eq ""
+      expect(data[:pub_charge_response]).to            eq ""
+      expect(data[:pub_waiver_response]).to            eq ""
+      expect(data[:institutional_response]).to         eq ""
+      expect(data[:gpi_response]).to                   eq ""
+      expect(data[:gpi_tier]).to                       eq ""
+      expect(data[:base_price]).to                     eq ""
+      expect(data[:discount_price]).to                 eq ""
+      expect(data[:discount_percent]).to               eq ""
+      expect(data[:waiver_amount]).to                  eq ""
+      expect(data[:collections_response]).to           eq ""
+      expect(data[:eligible]).to                       eq ""
+      expect(data[:rescind]).to                        eq ""
+      expect(data[:standard_collection_id]).to         eq ""
+      expect(data[:terms1]).to                         eq ""
+      expect(data[:terms2]).to                         eq ""
+      expect(data[:terms3]).to                         eq ""
+      expect(data[:terms4]).to                         eq ""
+      expect(data[:terms5]).to                         eq ""
+      expect(data[:final_dispo_accept]).to             eq "placeholderFinalDispoAccept"
+      expect(data[:terms6]).to                         eq ""
+      expect(data[:category]).to                       eq "placeholderCategory"
+      expect(data[:split]).to                          eq ""
+    end
+  end
+
+  describe "#to_csv" do
+    it "returns a csv obj" do
+      csv = bm.to_csv
+      expect(csv).to be_a(CSV)
+
+      parsed = CSV.parse(csv.string)
+      expect(parsed.first.size).to eq(59)
+    end
+  end
+
+  describe "#to_s3" do
+    it "returns true" do
+      expect(bm.to_s3).to be true
+    end
+  end
+
+  describe "#answer_for" do
+    it "returns the questions's answer" do
+      expect(bm.send(:answer_for, 'address1')).to eq 'address1'
+    end
+  end
+
+  def make_paper
+    journal = FactoryGirl.create(:journal, :with_doi, { name: 'journal name' })
+    paper = FactoryGirl.create :paper_with_task, {
+      creator: FactoryGirl.create(:user, { first_name: 'lou', last_name: 'prima', email: 'pfa@pfa.com' }),
+      journal: journal,
+      short_title: "my title",
+      task_params: { title: "Billing", type: "PlosBilling::BillingTask", role: "author" }
+    }
+    make_questions paper
+    paper
+  end
+
+  def make_questions(paper)
+    add_text_question_with_answer(paper, 'address1',      'address1')
+    add_text_question_with_answer(paper, 'address2',      'address2')
+    add_text_question_with_answer(paper, 'city',          'city')
+    add_text_question_with_answer(paper, 'state',         'state')
+    add_text_question_with_answer(paper, 'phone_number',  'phone_number')
+    add_text_question_with_answer(paper, 'postal_code',   'postal_code')
+    add_text_question_with_answer(paper, 'title',         'title')
+    add_text_question_with_answer(paper, 'email',         'email')
+    add_text_question_with_answer(paper, 'first_name',    'bob')
+    add_text_question_with_answer(paper, 'last_name',     'barker')
+    add_text_question_with_answer(paper, 'country',       'country')
+  end
+
+  def add_text_question_with_answer(paper, ident, answer)
+    nested_question = FactoryGirl.create(:nested_question, ident: ident, value_type: "text")
+    nested_question_answer = FactoryGirl.create(:nested_question_answer, value_type: "text",
+      nested_question: nested_question,
+      owner: paper.billing_card,
+      value: answer,
+    )
+  end
+end

--- a/spec/services/cloud_services/s3_service_spec.rb
+++ b/spec/services/cloud_services/s3_service_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe CloudServices::S3Service do
+
+  describe "#connection" do
+    it "return a Fog S3 object" do
+      s3_via_fog = CloudServices::S3Service.new.connection
+      expect(s3_via_fog.class.to_s).to include("Fog::Storage::AWS")
+    end
+  end
+
+end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-3502
#### What this PR does:

Gathers data about a paper, and uploads csv log file for billing from Aperta to S3.
#### Notes

This implementation is only part of a bigger process, so currently it must be triggered manually from a rake task (instructions below).

Also note that the data is not meant to be perfect at this stage, so it need not be fully QAed. Data precision will be handled in a later ticket. 
#### PO/QA Acceptance Instructions
- If you are running this locally, make sure you have the following ENV vars set (in .env.development)
  ****\* THIS SPACE INTENTIONALLY LEFT BLANK ****
- These ENV vars should already be set in staging 
- At the command line in the app root run:
  - bundle exec rake billing:upload_log_file_to_s3[1]
- where 1 above is the paper id whose billing data you wish to upload
- Open an S3 client (I use [SHub](http://www.3hubapp.com/)) and verify that that file (name shown after rake task) exists in billing/ on S3
- The file format should be valid csv, and should be roughly the right data, but is not meant to be perfect at present
#### For the reviewer:

Reviewer tasks (reviewer, please merge this PR when all tasks are complete):
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
