### PR TITLE
Non-admins should be able to complete authors card

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -113,6 +113,12 @@ class Author < ActiveRecord::Base
     NestedQuestion.where(owner_id:nil, owner_type:name).all
   end
 
+  # this is a hook for the nested_question_answers_policy to find its related
+  # task (to know if the user is authorized to conduct a specific action).
+  def task
+    authors_task
+  end
+
   def contributions
     contributions_question = self.class.contributions_question
     return [] unless contributions_question

--- a/app/policies/nested_question_answers_policy.rb
+++ b/app/policies/nested_question_answers_policy.rb
@@ -22,7 +22,7 @@ class NestedQuestionAnswersPolicy < ApplicationPolicy
     elsif nested_question_answer.owner.is_a?(Task)
       nested_question_answer.owner
     else
-      raise NotImplementedError, "Don't know how to check authoriziation to NestedQuestionAnswer for #{nested_question_answer.owner.inspect}. You may need to implement this."
+      raise NotImplementedError, "Don't know how to check authorization to NestedQuestionAnswer for #{nested_question_answer.owner.inspect}. You may need to implement this."
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-5432
#### What this PR does:

The NestedQuestionAnswerPolicy was returning a 500 error because the
author record did not have a common method named 'task' that gives it a
relationship to a Task.

This was working for Admin users because the Policy was short-
circuiting thanks to their admin super powers.

---
#### For the Reviewer:

Reviewer tasks:
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
