### PR TITLE
APERTA-5478 Move EM connection to rake task

### DIFF
--- a/app/models/plos_editorial_manager.rb
+++ b/app/models/plos_editorial_manager.rb
@@ -1,10 +1,10 @@
+# Retrieve GUIDs from EM database for Authors in Aperta
 #
-# This class is to establish a connection to EM
-# and retrieve GUIDs for Authors in Aperta
-#
-class PlosEditorialManager < ActiveRecord::Base
+# You MUST establish a connection manually to an EM database before
+# using this. e.g.
+# =PlosEditorialManager.establish_connection("plos_editorial_manager_#{Rails.env}".to_sym)=
 
-  establish_connection(ENV['EM_DATABASE_URL'].present? ? ENV['EM_DATABASE_URL'] : "plos_editorial_manager_#{Rails.env}".to_sym)
+class PlosEditorialManager < ActiveRecord::Base
 
   def self.find_person_by_email(email:)
     email = email.strip

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -50,18 +50,9 @@ staging:
   password:
 
 production:
-  adapter: postgresql
+  adapter: sqlserver
   encoding: unicode
   host: localhost
-  database: tahi_production
+  database: em
   pool: 48
-  password:
-
-# PLoS Editorial Manager connection
-plos_editorial_manager_test:
-  adapter: postgresql
-  encoding: unicode
-  host: localhost
-  database: tahi_test
-  username:
   password:

--- a/engines/plos_billing/lib/tasks/plos_billing.rake
+++ b/engines/plos_billing/lib/tasks/plos_billing.rake
@@ -5,6 +5,9 @@ namespace :plos_billing do
   end
 
   task :sync_em_guids => :environment do
+    # Connection established manually here. If =PlosEditorialManager=
+    # is used elsewhere, it must be established there as well.
+    PlosEditorialManager.establish_connection(ENV['EM_DATABASE_URL'].present? ? ENV['EM_DATABASE_URL'] : "plos_editorial_manager_#{Rails.env}".to_sym)
     User.where(em_guid: nil).find_each do |user|
       em_match = PlosEditorialManager.find_person_by_email(email: user.email)
 


### PR DESCRIPTION
Move the EM establish_connection call to the rake task. Prevents errors
unless the database is actually used.
