### PR TITLE
APERTA-5482 - Ignore intelligible questions when converting reviewer report questions

### DIFF
--- a/lib/data_migrator/reviewer_report_questions_migrator.rb
+++ b/lib/data_migrator/reviewer_report_questions_migrator.rb
@@ -2,6 +2,10 @@ class DataMigrator::ReviewerReportQuestionsMigrator < DataMigrator::Base
   TASK_OWNER_TYPE = "TahiStandardTasks::ReviewerReportTask"
 
   IDENTS = {
+    ignored: %w(
+      reviewer_report.intelligible
+      reviewer_report.intelligible.explanation
+    ),
     old: {
       COMPETING_INTERESTS_IDENT: "reviewer_report.competing_interests",
       SUPPORT_CONCLUSIONS_IDENT: "reviewer_report.support_conclusions",
@@ -26,6 +30,7 @@ class DataMigrator::ReviewerReportQuestionsMigrator < DataMigrator::Base
       IDENTITY_IDENT: "identity"
     }
   }
+
 
   def initialize
     @subtract_from_expected_count = 0
@@ -204,8 +209,9 @@ class DataMigrator::ReviewerReportQuestionsMigrator < DataMigrator::Base
   end
 
   def verify_counts
+    expected_questions = Question.where("ident LIKE 'reviewer_report.%' AND ident NOT IN (?)", IDENTS[:ignored])
     verify_count(
-      expected: Question.where("ident LIKE 'reviewer_report.%'").count - @subtract_from_expected_count,
+      expected: expected_questions.count - @subtract_from_expected_count,
       actual: NestedQuestionAnswer.includes(:nested_question).where(nested_questions: { owner_type: TASK_OWNER_TYPE, owner_id: nil }).count
     )
   end


### PR DESCRIPTION
JIRA: [APERTA-5482](https://developer.plos.org/jira/browse/APERTA-5482)

These questions were made irrelevant in c6dc0ddcb4217ffa78d09dd17a7b41d773d18126
#### How to test

You should be able to successfully convert questions to nested questions:

```
rake data:migrate:questions-to-nested-questions:reset_all data:migrate:questions-to-nested-questions:migrate_all
```
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I agree the code fulfills the Acceptance Criteria
