### PR TITLE
Remove duplicate activemodel-mocks dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,6 @@ group :test do
   gem 'timecop'
   gem 'pusher-fake'
   gem 'rspec_junit_formatter'
-  gem 'rspec-activemodel-mocks'
 end
 
 group :staging, :performance do


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-5483
#### What this PR does:

Removes a duplicated line from the Gemfile. Very straightforward. Only effects the test environment anyway. I ran `bundle install` just to make sure nothing changed in the `Gemfile.lock`.

---
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
