### PR TITLE
APERTA-3522 Add manuscript_id to dashboard view

### DIFF
--- a/app/assets/stylesheets/screens/_dashboards.scss
+++ b/app/assets/stylesheets/screens/_dashboards.scss
@@ -56,6 +56,10 @@
   }
 }
 
+.dashboard-manuscript-id {
+  color: $tahi-grey;
+}
+
 .dashboard-paper-title {
   position: relative;
   margin: 15px 0px 20px 0px;

--- a/client/app/pods/components/dashboard-link/template.hbs
+++ b/client/app/pods/components/dashboard-link/template.hbs
@@ -5,6 +5,9 @@
              title=model.roleList}}
     {{{model.displayTitle}}}
   {{/link-to}}
+  <div class='dashboard-manuscript-id'>
+    ID: {{model.manuscript_id}}
+  </div>
   {{#if unreadCommentsCount}}
     <span class="badge badge--red link-tooltip" title={{badgeTitle}}>
       {{unreadCommentsCount}}


### PR DESCRIPTION
[APERTA-3522](https://developer.plos.org/jira/browse/APERTA-3522)

Dashboards to display manuscript id: 
![gray_id](https://cloud.githubusercontent.com/assets/4078758/10803663/8d527084-7d80-11e5-8936-9da1b8c7caf2.png)

---
#### How to test
1. Go to the dashboard ('/')
2. Notice you can see the manuscript id.

---
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
