### PR TITLE
APERTA-3272: Do PapersController#show in 3 queries or less

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -18,6 +18,8 @@ class PapersController < ApplicationController
     paper = Paper.eager_load(
       :supporting_information_files,
       { paper_roles: [:user] },
+      :collaborations,
+      :versioned_texts,
       :manuscript,
       :tables,
       :bibitems,

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -14,12 +14,13 @@ class Paper < ActiveRecord::Base
   has_one :manuscript, dependent: :destroy
 
   has_many :figures, dependent: :destroy
-  has_many :versioned_texts, dependent: :destroy
+  has_many :versioned_texts, -> { version_desc }, dependent: :destroy
   has_many :tables, dependent: :destroy
   has_many :bibitems, dependent: :destroy
   has_many :supporting_information_files, dependent: :destroy
   has_many :paper_roles, dependent: :destroy
   has_many :users, -> { uniq }, through: :paper_roles
+  has_many :collaborations, -> { collaborators.uniq }, class_name: "PaperRole"
   has_many :assigned_users, -> { uniq }, through: :paper_roles, source: :user
   has_many :phases, -> { order 'phases.position ASC' }, dependent: :destroy, inverse_of: :paper
   has_many :tasks, through: :phases
@@ -326,7 +327,7 @@ class Paper < ActiveRecord::Base
   end
 
   def latest_version(reload=false)
-    versioned_texts(reload).version_desc.first
+    versioned_texts(reload).first
   end
 
 

--- a/app/serializers/collaboration_serializer.rb
+++ b/app/serializers/collaboration_serializer.rb
@@ -1,9 +1,4 @@
 class CollaborationSerializer < ActiveModel::Serializer
-  attributes :id
+  attributes :id, :paper_id
   has_one :user, embed: :id, include: true
-  has_one :paper, embed: :id
-
-  def id
-    object.id
-  end
 end

--- a/app/serializers/paper_serializer.rb
+++ b/app/serializers/paper_serializer.rb
@@ -15,11 +15,6 @@ class PaperSerializer < LitePaperSerializer
     object.manuscript.try(:status)
   end
 
-  def collaborations
-    # we want the actual join record, not a list of users
-    object.paper_roles.collaborators
-  end
-
   def links
     {
       comment_looks: comment_looks_paper_path(object),


### PR DESCRIPTION
So, now that the performance stuff is on staging, I'm going to have to do a little final tuning to get under the 400ms times proposed in the original stories -- but that tuning possible to do, now that the groundwork has been laid :)

So this is a little tweaking to further reduce the number of database queries for the papers/:id endpoint.

---
#### For the Reviewer:

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
