### PR TITLE
Disable jshint strict mode

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -44,7 +44,7 @@
   "quotmark": "single",
 
   // Enforce placing 'use strict' at the top function scope
-  "strict": true,
+  "strict": false,
 
   // Prohibit use of explicitly undeclared variables.
   "undef": true,


### PR DESCRIPTION
This setting requires 'use strict' in every function.

^ @egh 
