### PR TITLE
Lock node version to 4.2.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Tahi client application",
   "private": true,
+  "engines": {
+    "node": "4.2.1"
+  },
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
There was a new version of node released recently. (5.0). It is breaking some things. All this fix does is lock us to the old, working version for the time being.
