### PR TITLE
Lock node version to 4.2.1 at top level

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "## Development Notes",
   "main": "index.js",
+  "engines": {
+    "node": "4.2.1"
+  },
   "directories": {
     "doc": "doc",
     "test": "test"


### PR DESCRIPTION
Heroku needs the node version locked at the top level to work properly. :(
