### PR TITLE
Display uploading feedback in feedback overlay

### DIFF
--- a/app/assets/stylesheets/overlays/_feedback_overlay.scss
+++ b/app/assets/stylesheets/overlays/_feedback_overlay.scss
@@ -54,3 +54,13 @@
   margin-top: 0;
   padding: 0;
 }
+
+.feedback-overlay-uploading {
+  height: 18px;
+  line-height: 18px;
+
+  .progress-spinner {
+    float: left;
+    margin-right: 6px;
+  }
+}

--- a/client/app/controllers/overlays/feedback.js
+++ b/client/app/controllers/overlays/feedback.js
@@ -16,6 +16,8 @@ export default Ember.Controller.extend({
 
   actions: {
     submit() {
+      if(this.get('isUploading')) { return; }
+
       this.set('model.referrer', window.location);
       this.get('model').save().then(()=> {
         this.set('feedbackSubmitted', true);

--- a/client/app/templates/overlays/feedback.hbs
+++ b/client/app/templates/overlays/feedback.hbs
@@ -25,7 +25,7 @@
       <div class="overlay-footer-content feedback-overlay-footer-content">
         <div class="overlay-action-buttons">
           <button class="button-link button--green" {{action "closeAction"}}>cancel</button>
-          <button class="button-primary button--green" {{action "submit"}}>Send Feedback</button>
+          <button class="button-primary button--green {{if isUploading "button--disabled"}}" {{action "submit"}}>Send Feedback</button>
         </div>
       </div>
       <ul class="feedback-overlay-screenshots">
@@ -37,5 +37,11 @@
         {{/each}}
       </ul>
     </div>
+
+    {{#if isUploading}}
+      <div class="feedback-overlay-uploading">
+        {{progress-spinner visible=true size="mini"}} Uploading attachment
+      </div>
+    {{/if}}
   </div>
 {{/if}}


### PR DESCRIPTION
Feedback Overlay:

There is no progress indicator of the file being uploaded.  If the user selects "Send Feedback" before the file finishes uploading, no file is attached to the feedback.

Bugfix for: [APERTA-5573](https://developer.plos.org/jira/browse/APERTA-5573)

**Steps to Reproduce**
1. Login as anyone
2. Select "Give feedback on PLOS" from hamburger menu
3. Type in feedback
4. Upload a file
5. Submit

---
#### For the Reviewer:

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this bug fix
