### PR TITLE
Remove unused method from papers_controller.rb

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -92,14 +92,6 @@ class PapersController < ApplicationController
 
   ## EDITING
 
-  def heartbeat
-    if paper.locked?
-      paper.heartbeat
-      PaperUnlockerWorker.perform_async(paper.id, true)
-    end
-    head :no_content
-  end
-
   def toggle_editable
     paper.toggle!(:editable)
     status = paper.valid? ? 200 : 422


### PR DESCRIPTION
I noticed this unused code because PaperUnlockerWorker doesn't exist in the codebase. Heartbeat was removed in October but this somehow survived.
