### PR TITLE
APERTA-5558 hot fix for broken migration

### DIFF
--- a/db/migrate/20151117184931_drop_question_table.rb
+++ b/db/migrate/20151117184931_drop_question_table.rb
@@ -1,7 +1,7 @@
 # Removes old question database table
 class DropQuestionTable < ActiveRecord::Migration
   def up
-    QuestionAttachment.where(question_type: 'Question').destroy_all
+    execute("DELETE FROM question_attachments WHERE question_type = 'Question'")
     drop_table :questions
 
     remove_column :question_attachments, :question_type


### PR DESCRIPTION
This is a hotfix for removing the polymorphic association on QuestionAttachment.  The migration depended on the model which won't work if the model changes.

---
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
