### PR TITLE
APERTA-5690 Author card can't be reopened after error

### DIFF
--- a/client/app/pods/paper/task/controller.js
+++ b/client/app/pods/paper/task/controller.js
@@ -41,7 +41,7 @@ export default Ember.Controller.extend(
     }, (response) => {
       this.displayValidationErrorsFromResponse(response);
       this.set('model.completed', false);
-      this.get('model').get('errors').clear();
+      this.get('model').rollback();
     });
   },
 

--- a/spec/features/authors_card_spec.rb
+++ b/spec/features/authors_card_spec.rb
@@ -22,12 +22,11 @@ feature 'Authors card', js: true do
         find('.author-title').send_keys('title')
         find('.author-department').send_keys('department')
         find_button('done').click
-        overlay.completed_checkbox.click
-        overlay.ensure_not_completed
+        overlay.expect_task_to_be_incomplete
         overlay.dismiss
 
         find_link('Authors').click
-        expect(overlay.completed?).to eq(false)
+        overlay.expect_task_to_be_incomplete
       end
     end
   end

--- a/spec/support/pages/overlay.rb
+++ b/spec/support/pages/overlay.rb
@@ -37,7 +37,12 @@ class CardOverlay < Page
     find(checkbox_selector).checked?
   end
 
-  def ensure_not_completed
+  # This method takes advantage of Capybara's default wait time to ensure
+  # that the checkbox is in the state we want. Without expecting the state
+  # Capybara would return the checkbox right away since it is on the page.
+  # By expecting the state in the checkbox selector Capybara handles all
+  # of the waiting and retries which helps us avoid sleep calls in our code.
+  def expect_task_to_be_incomplete
     expect(self).to have_selector(
       'footer input[type=checkbox]:not(:checked)')
   end


### PR DESCRIPTION
JIRA issue: [APERTA-5690](https://developer.plos.org/jira/browse/APERTA-5690)
#### What this PR does:

This is a one line change that will allow records to be reloaded after a server error.

The authors card (and probably others) couldn't reopened because the model was in "root.loaded.updated.uncomitted".  Records in that state can't be reloaded, so the card couldn't be reopened.  Clearing the errors on the object fixes this problem.  Even though the errors are cleared, the error messages are still displayed to the user giving them a chance to fix the problem.
#### Notes

I'm not sure if there's a better way than clearing the errors on the record. I saw examples online that directly interact with the state manager, but that seems worse.
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- ~~[ ] I like the CHANGELOG entry~~ (n/a)
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
