### PR TITLE
APERTA-5695 Updating alignment of paragraphs and checkboxes

### DIFF
--- a/app/assets/stylesheets/ui/_overlay-card.scss
+++ b/app/assets/stylesheets/ui/_overlay-card.scss
@@ -117,6 +117,10 @@ $ov--card-breakpoint: 900px;
     label {
       padding-right: 25px;
     }
+
+    .model-question {
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
This is a quick bug fix for the alignment of checkboxes.

Before:
![before](https://cloud.githubusercontent.com/assets/2379553/11543727/41082c44-990c-11e5-9698-17ce94ba087a.gif)

After:
![after](https://cloud.githubusercontent.com/assets/2379553/11543726/41067d2c-990c-11e5-9b03-98db239bc1fe.gif)
