### PR TITLE
APERTA-5711 Fix paper ordering on dashboard

### DIFF
--- a/app/serializers/lite_paper_serializer.rb
+++ b/app/serializers/lite_paper_serializer.rb
@@ -5,24 +5,23 @@ class LitePaperSerializer < ActiveModel::Serializer
 
   def related_at_date
     return unless scoped_user.present?
-
-    my_roles.map(&:created_at).sort.first
+    first_role = my_roles.order(created_at: :desc).first
+    return unless first_role.present?
+    first_role.created_at
   end
 
   def roles
     return unless scoped_user.present?
 
     roles = my_roles.map(&:description)
-    roles << "My Paper" if object.user_id == scoped_user.id
+    roles << 'My Paper' if object.creator == scoped_user
     roles
   end
 
   private
 
   def my_roles
-    @my_roles_mem ||= object.paper_roles.select do |role|
-      role.user_id == scoped_user.id
-    end
+    object.paper_roles.where(user: scoped_user)
   end
 
   def scoped_user

--- a/spec/serializers/lite_paper_serializer_spec.rb
+++ b/spec/serializers/lite_paper_serializer_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe LitePaperSerializer do
+  subject(:serializer) { LitePaperSerializer.new(paper, user: user) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:paper) { FactoryGirl.create :paper }
+  let(:serialized_content) { serializer.to_json }
+  let(:deserialized_content) do
+    JSON.parse(serialized_content, symbolize_names: true)
+  end
+
+  describe 'a paper' do
+    it 'serializes successfully' do
+      expect(deserialized_content[:lite_paper])
+        .to match(hash_including(title: /Feature Recognition from 2D Hints in \
+Extruded Solids/,
+                                 short_title: /Test Paper/,
+                                 publishing_state: 'unsubmitted',
+                                 editable: true,
+                                 active: true))
+    end
+  end
+
+  describe 'a paper created by a user' do
+    let(:paper) { FactoryGirl.create :paper, creator: user }
+    it "includes the 'My Paper' role" do
+      expect(deserialized_content[:lite_paper])
+        .to match(hash_including(roles: include('My Paper')))
+    end
+  end
+
+  describe 'for a paper with multiple roles' do
+    let(:early_date) { Time.now.utc - 10 }
+    let(:later_date) { Time.now.utc }
+    let!(:paper_role1) do
+      FactoryGirl.create(:paper_role, :editor, created_at: early_date,
+                                               user: user, paper: paper)
+    end
+    let!(:paper_role2) do
+      FactoryGirl.create(:paper_role, :admin, created_at: later_date,
+                                              user: user, paper: paper)
+    end
+
+    it 'should use the latest role for the related_at_date' do
+      expect(deserialized_content[:lite_paper])
+        .to match(hash_including(related_at_date: later_date.as_json))
+    end
+  end
+end


### PR DESCRIPTION
We were not ordering the roles by created_at descending, but rather
ascending.

Link to story: https://developer.plos.org/jira/browse/APERTA-5711
#### What this PR does:

This fixes a bug with sort ordering. We should sort by the most recently created role a user has on a paper. But we were sorting by the least recently created role a user has on a paper.
#### Notes

This is a tricky one to test, because you will need to have users with multiples roles on a paper with just the right created_at times. You might find it easiest to access the db directly.

You need roles like:

```
| role         | paper_id | user_id | created_at          |
| collaborator |        1 |       1 | 2015-12-04T19:47:18 |
| admin        |        2 |       1 | 2015-12-04T19:45:18 |
| admin        |        1 |       1 | 2015-12-04T19:40:18 |
```

Note that paper `2` should sort after paper `1`. Before this change, paper `1`
would sort first.

---
#### For the reviewer:

Reviewer tasks (reviewer, please merge this PR when all tasks are complete):
- [ ] I ran the code locally
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
