### PR TITLE
Fix/rspec gems to dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem 'twitter-text'
 gem 'uglifier'
 gem 'unf'
 # We need any version of yaml_db after 0.3.0 since it will namespace SerializationHelper
-gem 'yaml_db', github: 'yamldb/yaml_db', ref: 'f980a67dfcfef76824676f3938b176b68c260e68' 
+gem 'yaml_db', github: 'yamldb/yaml_db', ref: 'f980a67dfcfef76824676f3938b176b68c260e68'
 
 group :staging, :production do
   gem 'heroku-deflater'
@@ -83,7 +83,6 @@ group :development, :test do
   gem 'rspec-activemodel-mocks'
   gem 'rspec-collection_matchers'
   gem 'rspec-instafail'
-  gem 'rspec-its'
   gem 'rspec-rails'
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,9 +508,6 @@ GEM
       rspec-support (~> 3.3.0)
     rspec-instafail (0.4.0)
       rspec
-    rspec-its (1.2.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
@@ -679,7 +676,6 @@ DEPENDENCIES
   rspec-activemodel-mocks
   rspec-collection_matchers
   rspec-instafail
-  rspec-its
   rspec-rails
   rspec_junit_formatter
   rubocop


### PR DESCRIPTION
Moving gems required for testing to the development and test groups.

Remove the `rspec-its` gem which does not seem to be used.
