### PR TITLE
APERTA-3564 Adding the stock no competing interests statement

### DIFF
--- a/app/serializers/typesetter/competing_interests_serializer.rb
+++ b/app/serializers/typesetter/competing_interests_serializer.rb
@@ -9,7 +9,12 @@ module Typesetter
     end
 
     def competing_interests_statement
+      return no_competing_interests unless competing_interests
       task_answer_value(object, 'competing_interests.statement')
+    end
+
+    def no_competing_interests
+      'The authors have declared that no competing interests exist.'
     end
   end
 end

--- a/spec/serializers/typesetter/competing_interests_serializer_spec.rb
+++ b/spec/serializers/typesetter/competing_interests_serializer_spec.rb
@@ -40,4 +40,32 @@ describe Typesetter::CompetingInterestsSerializer do
       expect(output[:competing_interests_statement]).to eq('entered statement')
     end
   end
+
+  describe 'no competing interests statement' do
+    let!(:no_competing_task) do
+      NestedQuestionableFactory.create(
+        FactoryGirl.create(:competing_interests_task),
+        questions: [
+          {
+            ident: 'competing_interests',
+            answer: 'false',
+            value_type: 'boolean',
+            questions: [{
+              ident: 'statement',
+              answer: 'entered statement',
+              value_type: 'text'
+            }]
+          }
+        ]
+      )
+    end
+
+    it 'has the stock no competing interests statement' do
+      output = Typesetter::CompetingInterestsSerializer.new(
+        no_competing_task).serializable_hash
+
+      expect(output[:competing_interests_statement]).to \
+        eq('The authors have declared that no competing interests exist.')
+    end
+  end
 end


### PR DESCRIPTION
JIRA issue: [APERTA-3564](https://developer.plos.org/jira/browse/APERTA-3564)
#### What this PR does:

This PR adds the PLOS competing interests statement to the Apex metadata if the author declared that no competing interests exist.

[Here is the Jira conversation.](https://developer.plos.org/jira/browse/APERTA-3564?focusedCommentId=91240&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-91240)

---
#### For the Reviewer:

Reviewer tasks (@zdennis):
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:

~~\- [ ] The Product Team has reviewed and approved this feature~~  (talked to Jeffrey, will merge now and he'll QA)
