### PR TITLE
Do not automatically load webmock, vcr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,31 +67,15 @@ end
 
 group :development, :test do
   gem 'auto_screenshot', require: false
-  gem 'capybara'
-  gem 'database_cleaner'
   gem 'dotenv-rails', require: 'dotenv/rails-now'
-  gem 'email_spec'
-  gem 'factory_girl_rails'
-  gem 'fake_ftp'
-  gem 'generator_spec'
   gem 'progressbar'
   gem 'pry-rails'
   gem 'pry-remote'
   gem 'pry-rescue'
-  gem 'pusher-fake'
   gem 'quiet_assets'
-  gem 'rspec-activemodel-mocks'
-  gem 'rspec-collection_matchers'
-  gem 'rspec-instafail'
+  # This needs to be in the development group to make rake tasks work
   gem 'rspec-rails'
-  gem 'rspec_junit_formatter'
-  gem 'selenium-webdriver'
-  gem 'simplecov'
   gem 'test_after_commit'
-  gem 'thin'
-  gem 'timecop'
-  gem 'vcr'
-  gem 'webmock'
 end
 
 group :development do
@@ -107,6 +91,23 @@ group :staging do
 end
 
 group :test do
+  gem 'capybara'
   gem 'capybara-screenshot'
   gem 'codeclimate-test-reporter', require: nil
+  gem 'database_cleaner'
+  gem 'email_spec'
+  gem 'factory_girl_rails'
+  gem 'fake_ftp'
+  gem 'generator_spec'
+  gem 'pusher-fake'
+  gem 'rspec-activemodel-mocks'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-instafail'
+  gem 'rspec_junit_formatter'
+  gem 'selenium-webdriver'
+  gem 'simplecov'
+  gem 'thin'
+  gem 'timecop'
+  gem 'vcr'
+  gem 'webmock'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,12 +4,13 @@ CodeClimate::TestReporter.start
 ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
-require 'rspec/rails'
-require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
-require "email_spec"
-require 'sidekiq/testing'
+require 'capybara/rspec'
+require 'email_spec'
 require 'pusher-fake/support/rspec'
+require 'rspec/rails'
+require 'sidekiq/testing'
+require 'webmock/rspec'
 include Warden::Test::Helpers
 
 # Requires supporting ruby files with custom matchers and macros, etc,

--- a/spec/workers/download_manuscript_worker_spec.rb
+++ b/spec/workers/download_manuscript_worker_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'webmock/rspec'
 
 describe DownloadManuscriptWorker, redis: true do
   let(:paper) { FactoryGirl.create(:paper) }

--- a/spec/workers/paper_update_worker_spec.rb
+++ b/spec/workers/paper_update_worker_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'webmock/rspec'
 
 describe PaperUpdateWorker do
   subject(:worker) { PaperUpdateWorker.new }


### PR DESCRIPTION
Use require: false to prevent autoloading these in dev.

Autoloading webmock will interfere with HTTP requests.
Not autoloading VCR just seems like a good idea too
