### PR TITLE
APERTA-5712 break tags in short title fix

### DIFF
--- a/app/assets/stylesheets/components/_content-editable.scss
+++ b/app/assets/stylesheets/components/_content-editable.scss
@@ -14,6 +14,7 @@ label[contenteditable=true] {
 
 div[contenteditable=true] {
   background-color: $tahi-white;
+  white-space: pre-wrap;
 }
 
 .two-element-form {

--- a/engines/tahi_standard_tasks/client/app/templates/overlays/publishing-related-questions.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/overlays/publishing-related-questions.hbs
@@ -128,6 +128,7 @@
     </ul>
 
     {{format-input value=model.paper.shortTitle
+                   class="publishing-related-questions-short-title"
                    displayBold=false
                    focus-out=(action "savePaperShortTitle")}}
   </li>

--- a/spec/features/publishing_related_questions_card_spec.rb
+++ b/spec/features/publishing_related_questions_card_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+feature 'Authors card', js: true do
+  let(:author) { create :user, first_name: 'Author' }
+  let!(:paper) { FactoryGirl.create(:paper, :with_tasks) }
+  let!(:task) do
+    FactoryGirl.create(:publishing_related_questions_task, paper: paper)
+  end
+
+  before do
+    paper.tasks.each { |t| t.participants << author }
+  end
+
+  def short_title_selector
+    "//div[contains(@class, 'publishing-related-questions-short-title')]" \
+      "//div[@contenteditable='true']"
+  end
+
+  context 'As an author' do
+    scenario 'sets the short title properly', selenium: true do
+      login_as(author, scope: :user)
+      visit "/papers/#{paper.id}"
+
+      edit_paper = PaperPage.new
+      edit_paper.view_card('Publishing Related Questions', CardOverlay) do |_|
+        content_editable = find(:xpath, short_title_selector)
+        # <br> tags are only added when the space key is hit. So we clear the
+        # field first then type in known text.
+        content_editable.set('T')
+        content_editable.send_keys('his is a short title', :tab)
+        wait_for_ajax
+        paper.reload
+
+        expect(paper.short_title).not_to include('<br')
+        expect(paper.short_title).to eq('This is a short title')
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: [APERTA-5712](https://developer.plos.org/jira/browse/APERTA-5712)
#### What this PR does:

CSS fix so Firefox won't add &lt;br&gt; tags in contenteditable fields.

---
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
