### PR TITLE
APERTA-5725-add journal name to all gradual engagement cases before revision state

### DIFF
--- a/client/app/pods/components/paper-sidebar/template.hbs
+++ b/client/app/pods/components/paper-sidebar/template.hbs
@@ -6,10 +6,14 @@
 
   <div id="submission-state-information">
     {{#if getsGradualEngagementToggle}}
-      <i id="submission-process-toggle"
-         title="Submission Process"
-         class="fa fa-question-circle" {{action "toggleSubmissionProcess"}}>
-      </i>
+      <div id='submission-process-toggle-box'>
+        <i id="submission-process-toggle"
+           title="Submission Process"
+           class="fa fa-question-circle" {{action "toggleSubmissionProcess"}}>
+        </i>
+
+        <p><b>{{paper.journal.name}} Submission Process </b></p>
+      </div>
     {{/if}}
 
     {{#if readyToSubmit}}

--- a/client/app/templates/submission/sidebar-gradual-engagement-presubmission.hbs
+++ b/client/app/templates/submission/sidebar-gradual-engagement-presubmission.hbs
@@ -1,8 +1,4 @@
 <div class='gradual-engagement-presubmission-messaging {{paper.engagementState}}'>
-  <b>{{paper.journal.name}} Submission Process </b>
-
-  <br />
-
   Please provide the following information to submit your
     {{#unless paper.isInRevision}}
       manuscript for <span class='text-capitalize'>{{paper.engagementState}}</span> Submission.

--- a/spec/features/gradual_engagment_spec.rb
+++ b/spec/features/gradual_engagment_spec.rb
@@ -47,7 +47,7 @@ feature 'Gradual Engagement', js: true do
                                    creator: user,
                                    gradual_engagement: true
         visit "/papers/#{paper.id}"
-        expect(find('.gradual-engagement-presubmission-messaging.initial'))
+        expect(find('#submission-process-toggle-box'))
           .to have_content(paper.journal.name)
         expect(find('.gradual-engagement-presubmission-messaging.initial'))
           .to have_content('Please provide the following information to submit')
@@ -80,7 +80,7 @@ feature 'Gradual Engagement', js: true do
                         publishing_state: :invited_for_full_submission,
                         gradual_engagement: true
         visit "/papers/#{paper.id}"
-        expect(find('.gradual-engagement-presubmission-messaging.full'))
+        expect(find('#submission-process-toggle-box'))
           .to have_content(paper.journal.name)
         expect(find('.gradual-engagement-presubmission-messaging.full'))
           .to have_content('Please provide the following information to submit
@@ -99,8 +99,6 @@ feature 'Gradual Engagement', js: true do
                                    publishing_state: :in_revision,
                                    gradual_engagement: true
         visit "/papers/#{paper.id}"
-        expect(find('.gradual-engagement-presubmission-messaging'))
-          .to have_content(paper.journal.name)
         expect(find('.gradual-engagement-presubmission-messaging'))
           .to have_content('Please provide the following information to submit
             your manuscript.')


### PR DESCRIPTION
JIRA issue: [APERTA-5725](https://developer.plos.org/jira/browse/APERTA-5725)
#### What this PR does:

It looks like the Journal name wasn't showing in a specific state (of which there are many) during Gradual Submission. I made an adjustment so the (?) trigger and the journal name are always diplayed together, and updated the specs. 
#### Acceptance Criteria

You will have to get a paper into the state of "ready for initial submission" and verify that the journal name is present, and compare to the QA screenshot where it wasn't. 

If you need help understanding how to get a paper in to that state, you can consult the description [of this PR](https://github.com/Tahi-project/tahi/pull/1900)
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [NA] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
