### PR TITLE
add three migrations that open classes

### DIFF
--- a/db/migrate/20151218161518_remove_me_open_figures.rb
+++ b/db/migrate/20151218161518_remove_me_open_figures.rb
@@ -1,0 +1,9 @@
+class RemoveMeOpenFigures < ActiveRecord::Migration
+  class Figure < ActiveRecord::Base
+  end
+
+  def change
+    # do something
+    Figure.last
+  end
+end

--- a/db/migrate/20151218161536_remove_me_add_figure_attributes.rb
+++ b/db/migrate/20151218161536_remove_me_add_figure_attributes.rb
@@ -1,0 +1,5 @@
+class RemoveMeAddFigureAttributes < ActiveRecord::Migration
+  def change
+    add_column :figures, :aaron, :string
+  end
+end

--- a/db/migrate/20151218161555_remove_me_set_figure_attributes.rb
+++ b/db/migrate/20151218161555_remove_me_set_figure_attributes.rb
@@ -1,0 +1,10 @@
+class RemoveMeSetFigureAttributes < ActiveRecord::Migration
+  class Figure < ActiveRecord::Base
+  end
+
+  def change
+    f = Figure.new
+    f.aaron = "hello"
+    f.save
+  end
+end


### PR DESCRIPTION
This is a branch for demonstration purposes.  It adds three new migrations:
1.  The first migration simply opens the `Figure` class
2.  The second migration adds a new attribute `aaron` to `figures` table
3.  The third migration tries to set the `aaron` attribute on `Figure`

Output:

``` ruby
tahi (ac: master) ~ be rake db:migrate
== 20151218161518 RemoveMeOpenFigures: migrating ==============================
== 20151218161518 RemoveMeOpenFigures: migrated (0.0090s) =====================

== 20151218161536 RemoveMeAddFigureAttributes: migrating ======================
-- add_column(:figures, :aaron, :string)
   -> 0.0047s
== 20151218161536 RemoveMeAddFigureAttributes: migrated (0.0048s) =============

== 20151218161555 RemoveMeSetFigureAttributes: migrating ======================
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

undefined method `aaron=' for #<RemoveMeSetFigureAttributes::Figure:0x007fbf5d432848>/Users/plos/.rvm/gems/ruby-2.2.3/gems/activemodel-4.2.4/lib/active_model/attribute_methods.rb:433:in `method_missing'
/Users/plos/Projects/tahi/db/migrate/20151218161555_remove_me_set_figure_attributes.rb:7:in `change'
```

I looked into this indepth a few months ago and cannot find my notes on exactly _why_ this happens (obviously due to caching or something), but my take away was never to reopen classes in my migrations.
