### PR TITLE
APERTA-5728 Add rake task to update title

### DIFF
--- a/lib/tasks/data-migrations/tasks_titles.rake
+++ b/lib/tasks/data-migrations/tasks_titles.rake
@@ -1,0 +1,11 @@
+namespace :data do
+  namespace :migrate do
+    namespace :tasks do
+      desc 'Sets the PRQ Tasks titles to Additional Information'
+      task set_title_to_additional_information: :environment do
+        type = 'TahiStandardTasks::PublishingRelatedQuestionsTask'
+        Task.where(type: type).update_all(title: 'Additional Information')
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-5728
#### What this PR does:

This PR adds a missing rake task to update the existing task titles to the new one

`rake data:migrate:tasks:set_title_to_additional_information`
#### Notes

I think I've missed to create this rake task but we didn't notice it because I've updated the seeds file so when it was deployed to the review app it has the right values. This PR fixes that

---
##### For the Code Reviewer:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I agree the code fulfills the Acceptance Criteria
##### For the Product Owner:
- [ ] I have verified the expected behavior in the Review environment
