### PR TITLE
Prevent clipping of reviewer report form elements

### DIFF
--- a/app/assets/stylesheets/_flex-base.scss
+++ b/app/assets/stylesheets/_flex-base.scss
@@ -11,7 +11,7 @@
 .flex-element {
   @include flex(10 10 auto);
 
-  input  { width: 100%; }
+  input[type=text] { width: 100%; }
   select { width: 100%; }
 }
 

--- a/app/assets/stylesheets/overlays/_reviewer_report_overlay.scss
+++ b/app/assets/stylesheets/overlays/_reviewer_report_overlay.scss
@@ -3,8 +3,8 @@
   margin-left: 30px;
 }
 
-.reviewer-report-wrapper {
-  width: 640px;
+.reviewer-report-wrapper .flex-element input[type=radio] {
+  margin-right: 5px;
 }
 
 .reviewer-report-confirmation {

--- a/client/app/pods/components/nested-question-radio-decision/template.hbs
+++ b/client/app/pods/components/nested-question-radio-decision/template.hbs
@@ -18,8 +18,8 @@
     <ul class="question-help">{{{helpText}}}</ul>
   {{/if}}
 
-  <div class="row {{wrapperClass}}">
-    <label class="col-md-3">
+  <div class="flex-group {{wrapperClass}}">
+    <label class="flex-element">
       {{radio-button value="accept"
                      name=namePrefix
                      selection=model.answer.value
@@ -27,7 +27,7 @@
       Accept
     </label>
 
-    <label class="col-md-3">
+    <label class="flex-element">
       {{radio-button value="reject"
                      name=namePrefix
                      selection=model.answer.value
@@ -35,7 +35,7 @@
       Reject
     </label>
 
-    <label class="col-md-3">
+    <label class="flex-element">
       {{radio-button value="major_revision"
                      name=namePrefix
                      selection=model.answer.value
@@ -43,7 +43,7 @@
       Major Revision
     </label>
 
-    <label class="col-md-3">
+    <label class="flex-element">
       {{radio-button value="minor_revision"
                      name=namePrefix
                      selection=model.answer.value


### PR DESCRIPTION
JIRA issues: 
- https://developer.plos.org/jira/browse/APERTA-5818
- https://developer.plos.org/jira/browse/APERTA-5823
#### What this PR does:

Prevents the clipping / cut-off of form elements in the accordion for the Reviewer Report Task
##### Before

![reviewer-report-before](https://cloud.githubusercontent.com/assets/18446/12066154/bdd8edac-afb0-11e5-9663-aecc26daaa6e.png)
##### After

![reviewer-report-after](https://cloud.githubusercontent.com/assets/18446/12066156/c2c59f0e-afb0-11e5-9535-d48f872ecee8.png)

---
#### For the Reviewer:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
