### PR TITLE
APERTA-5782 Adding a default title of 'Untitled' if none is given

### DIFF
--- a/app/services/paper_factory.rb
+++ b/app/services/paper_factory.rb
@@ -2,6 +2,7 @@ class PaperFactory
   attr_reader :paper, :creator
 
   def self.create(paper_params, creator)
+    paper_params[:title] = 'Untitled' if paper_params[:title].blank?
     paper = creator.submitted_papers.build(paper_params)
     pf = new(paper, creator)
     pf.create

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -135,7 +135,9 @@ describe PapersController do
       end
 
       it "renders the errors for the paper if it can't be saved" do
-        post :create, paper: { short_title: '', journal_id: journal.id }, format: :json
+        post :create, paper: { short_title: '', journal_id: journal.id },
+                      format: :json
+
         expect(response.status).to eq(422)
       end
 
@@ -144,6 +146,14 @@ describe PapersController do
                                                     message: "Manuscript was created",
                                                     feed_name: 'manuscript'))
         do_request
+      end
+
+      it 'has a default title' do
+        post :create, paper: { journal_id: journal.id,
+                               paper_type: journal.paper_types.first },
+                      format: :json
+
+        expect(res_body['paper']['title']).to eq('Untitled')
       end
     end
   end


### PR DESCRIPTION
JIRA issue: [APERTA-5782](https://developer.plos.org/jira/browse/APERTA-5782)
#### What this PR does:

If the user does not supply a title, a default title of 'Untitled' is added.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
