### PR TITLE
APERTA-5824 Prevent double clicking from crashing everything

### DIFF
--- a/client/app/pods/components/task-load/component.js
+++ b/client/app/pods/components/task-load/component.js
@@ -35,7 +35,10 @@ export default Ember.Component.extend({
       task.get('participations'),
       store.find('task', task.get('id')) // see "NOTE: task find"
     ]).then(()=> {
-      this.set('dataLoading', false);
+      // Note: the line below prevents a race condition when double clicking
+      if ( !(this.get('isDestroyed') || this.get('isDestroying')) ) {
+        this.set('dataLoading', false);
+      }
     });
   }
 });

--- a/spec/features/accordion_spec.rb
+++ b/spec/features/accordion_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+feature 'Accordion cards', js: true do
+  let(:admin) { FactoryGirl.create :user, :site_admin }
+
+  let(:author) { create :user, first_name: 'Author' }
+  let!(:paper) {
+    FactoryGirl.create(
+      :paper_with_task,
+      task_params: { type: 'Task' },
+      creator: author)
+  }
+
+  before do
+    paper.tasks.each { |t| t.participants << author }
+  end
+
+  context 'As a participant' do
+    scenario 'opens card content on click', js: true do
+      login_as(author, scope: :user)
+      visit "/papers/#{paper.id}"
+      find('.task-disclosure-heading').click
+      expect(page).to have_css('.task-main-content')
+    end
+
+    scenario 'closes card content on click', js: true do
+      login_as(author, scope: :user)
+      visit "/papers/#{paper.id}"
+      find('.task-disclosure-heading').click
+      expect(page).to have_css('.task-main-content')
+      find('.task-disclosure-heading').click
+      expect(page).not_to have_css('.task-main-content')
+    end
+
+    scenario 'does not crash Ember on double click', js: true do
+      login_as(author, scope: :user)
+      visit "/papers/#{paper.id}"
+      find('.task-disclosure-heading').double_click
+      find('.task-disclosure-heading').click
+      expect(page).to have_css('.task-main-content')
+    end
+  end
+end


### PR DESCRIPTION
Jira ticket: https://developer.plos.org/jira/browse/APERTA-5824
#### What this PR does:

It fixes the bug below:

_Steps to Reproduce_
1. Visit the manuscript page of a paper
2. In the accordion, double-click a task
3. In the accordion, attempt to open any other task

_Expected Behavior_
Double clicking on a task opens then closes a task.

_Actual Behavior_
Double clicking on a task crashes ember, preventing further interaction until a page refresh.

_Technical Notes_
Tasks are loaded on first click, then are destroyed on second click. The error happens when the task is closed before fully loading. with error :
`Uncaught Error: Assertion Failed: calling set on destroyed object`

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] If there is a migration, I updated the seeds appropriately
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
