### PR TITLE
Fix blank decision emails for major and minor revisions

### DIFF
--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/register_decision_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/register_decision_task.rb
@@ -28,11 +28,7 @@ module TahiStandardTasks
 
     def send_email
       RegisterDecisionMailer.delay.notify_author_email(
-        decision_id: decision_content.id)
-    end
-
-    def decision_content
-      paper.decisions.select(&:verdict_valid?).first
+        decision_id: paper.decisions.completed.latest)
     end
 
     def send_emails

--- a/engines/tahi_standard_tasks/spec/models/register_decision_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/register_decision_task_spec.rb
@@ -195,6 +195,17 @@ describe TahiStandardTasks::RegisterDecisionTask do
       end
     end
 
+    describe "#send_email" do
+      let(:task) { FactoryGirl.create(:register_decision_task, paper: paper) }
+      let!(:decision_one) { FactoryGirl.create(:decision, :major_revision, paper: paper) }
+      let!(:decision_pending) { FactoryGirl.create(:decision, :pending, paper: paper) }
+
+      it "will email using latest non-pending decision" do
+        expect(TahiStandardTasks::RegisterDecisionMailer).to receive_message_chain(:delay, :notify_author_email).with(decision_id: decision_one)
+        task.send_email
+      end
+    end
+
     describe "#complete_decision" do
       let(:decision) { paper.decisions.first }
 
@@ -216,18 +227,6 @@ describe TahiStandardTasks::RegisterDecisionTask do
         expect {
           task.complete_decision
         }.to change { paper.tasks.where(type: task_type).count }.by(1)
-      end
-    end
-
-    describe "#decision_content" do
-      let(:decision) { Decision.create(paper: paper, verdict: "major_revision") }
-      let(:latest_decision) { Decision.create(paper: paper, verdict: "minor_revision") }
-
-      it "gets the made decision" do
-        paper.decisions << decision
-        paper.decisions << latest_decision
-
-        expect(task.decision_content).to eq(latest_decision)
       end
     end
   end

--- a/spec/factories/decision_factory.rb
+++ b/spec/factories/decision_factory.rb
@@ -4,5 +4,18 @@ FactoryGirl.define do
     sequence(:revision_number) { |n| n }
     letter 'Test Decision Letter'
     verdict 'accept'
+
+    trait :pending do
+      verdict nil
+      letter nil
+    end
+
+    trait :rejected do
+      verdict 'reject'
+    end
+
+    trait :major_revision do
+      verdict 'major_revision'
+    end
   end
 end

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -55,25 +55,43 @@ describe Decision do
     end
   end
 
+  describe ".completed" do
+    context "with a verdict" do
+      let(:decision) { FactoryGirl.create(:decision, :rejected) }
+
+      it "is returned" do
+        Decision.completed.should eq([decision])
+      end
+    end
+
+    context "without a verdict" do
+      let(:decision) { FactoryGirl.create(:decision, :pending) }
+
+      it "is not returned" do
+        Decision.completed.should be_empty
+      end
+    end
+  end
+
   describe '#verdict_valid?' do
     context 'when the verdict is valid' do
       it 'validates for major_revision' do
-        decision.update_attribute(:verdict, 'major_revision')   
+        decision.update_attribute(:verdict, 'major_revision')
         expect(decision.valid?).to be true
       end
 
       it 'validates for minor_revision' do
-        decision.update_attribute(:verdict, 'minor_revision') 
+        decision.update_attribute(:verdict, 'minor_revision')
         expect(decision.valid?).to be true
       end
 
       it 'validates for accept' do
-        decision.update_attribute(:verdict, 'accept') 
+        decision.update_attribute(:verdict, 'accept')
         expect(decision.valid?).to be true
       end
 
       it 'validates for reject' do
-        decision.update_attribute(:verdict, 'reject') 
+        decision.update_attribute(:verdict, 'reject')
         expect(decision.valid?).to be true
       end
     end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-5844
#### What this PR does:

The major change here is that when the `RegisterDecisionTask` goes to send an email, it uses the latest `decision` that has been "completed".  In other words, rather than just picking the latest `decision`, it makes sure it has a verdict applied.

The rest of the changes are refactors to support this behavior.

---

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
