### PR TITLE
Fixes jQuery version to fix Ember

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "tahi",
   "dependencies": {
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "ember": "1.13.10",
     "ember-data": "1.0.0-beta.18",
     "ember-resolver": "~0.1.20",


### PR DESCRIPTION
***_Fixes Ember crashing**_*

Ember would completely crash after an `npm run clean` since it would upgrade jQuery to a breaking version.  This freezes jQuery so that jQuery can be updated when we upgrade Ember cli
