### PR TITLE
Bugfix — Make billing type select responsive

### DIFF
--- a/engines/plos_billing/app/assets/stylesheets/plos_billing/_application.scss
+++ b/engines/plos_billing/app/assets/stylesheets/plos_billing/_application.scss
@@ -17,3 +17,7 @@
 .billing-payee-country .select2-container {
   min-width: 180px;
 }
+
+.payment-method .select2-container {
+  max-width: 39rem;
+}

--- a/engines/plos_billing/client/app/templates/components/billing-task.hbs
+++ b/engines/plos_billing/client/app/templates/components/billing-task.hbs
@@ -153,14 +153,14 @@
         {{nested-question-display ident="plos_billing--payment_method" owner=task}}
       </h3>
 
-      <div class="form-group author-half author-bump payment-method {{if validationErrors.affiliation "error"}}">
+      <div class="form-group author-bump payment-method {{if validationErrors.affiliation "error"}}">
         {{nested-question-select ident="plos_billing--payment_method"
                           owner=task
                           displayQuestionText=false
                           class="affiliation-field"
                           selectionSelected="paymentMethodSelected"
                           source=responses
-                          width="350"
+                          width="100%"
                           enable=isSubmissionTaskEditable}}
       </div>
     </li>


### PR DESCRIPTION
Bugfix for responsive Billing Task ticket:
https://developer.plos.org/jira/browse/APERTA-5806

The select will now take the space it needs, shrink if the column is too small, not grow too large.
