### PR TITLE
Ensure that authorization configuration persists

### DIFF
--- a/app/models/authorizations.rb
+++ b/app/models/authorizations.rb
@@ -1,22 +1,27 @@
+# This seems redundant, but DO NOT REMOVE
+# It is necessary to ensure that authorization configuration persists across
+# rails code reloading.
+require 'authorizations/configuration'
+
 # The Authorizations module houses the authorizations sub-system. The namespace
 # is in part so we can isolate the authorization bits in code and in tests.
 module Authorizations
   class << self
     # Yields an Authorizations::Configuration instance
-    def configure(&blk)
+    def configure
       yield(configuration)
     end
 
     # Returns the current Authorizations::Configuration instance
     def configuration
-      @configuration ||= Configuration.new
+      Authorizations::Configuration
     end
 
     # Replaces the current Authorizations::Configuration instance with pristine
     # one. Note: This is primarily used so we can run a variety of tests
     # against the authorization sub-system.
     def reset_configuration
-      @configuration = Configuration.new
+      Authorizations::Configuration.reset
     end
   end
 end

--- a/app/models/authorizations/configuration.rb
+++ b/app/models/authorizations/configuration.rb
@@ -1,24 +1,26 @@
 module Authorizations
   # Configuration houses the individual Authorization(s) being used to
   # configure the authorization sub-system.
-  class Configuration
+  module Configuration
+    extend self
 
     # 'authorizations' returns the collection of authorization(s) that have \
     # been configured
     attr_accessor :authorizations
 
-    def initialize
-      @authorizations = []
-    end
-
     # Creates an authorization thru the given assignment_to object and
     # options.
     def assignment_to(assignment_to, authorizes:, via:)
+      @authorizations ||= []
       @authorizations << Authorizations::Authorization.new(
         assignment_to: assignment_to,
         authorizes: authorizes,
         via: via
       )
+    end
+
+    def reset
+      @authorizations = []
     end
   end
 end


### PR DESCRIPTION
Previously, if rails did its code reload magic, authorization
configuration would be lost. This change ensures that it sticks around.
