### PR TITLE
Bugfix: Aperta 5806 — Sticky Header Reposition

### DIFF
--- a/client/app/pods/components/paper-sidebar/template.hbs
+++ b/client/app/pods/components/paper-sidebar/template.hbs
@@ -8,7 +8,7 @@
 
     <div id="submission-state-information">
       {{#if getsGradualEngagementToggle}}
-        <div id='submission-process-toggle-box'>
+        <div id="submission-process-toggle-box">
           <i id="submission-process-toggle"
              title="Submission Process"
              class="fa fa-question-circle" {{action "toggleSubmissionProcess"}}>

--- a/client/app/pods/components/split-pane/component.js
+++ b/client/app/pods/components/split-pane/component.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  eventBus: Ember.inject.service('event-bus'),
   classNames: ['split-pane'],
 
   minimumWidthPercent: 25,
@@ -66,6 +67,7 @@ export default Ember.Component.extend({
         const rightTooSmall = rightPercentage * 100 < minWidth;
         if(leftTooSmall || rightTooSmall) { return; }
 
+        this.get('eventBus').publish('split-pane-resize');
         firstPane.css(this.flexCss(leftPercentage.toString()));
         lastPane.css(this.flexCss(rightPercentage.toString()));
       });

--- a/client/app/pods/components/sticky-headers/component.js
+++ b/client/app/pods/components/sticky-headers/component.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+  eventBus: Ember.inject.service('event-bus'),
   /**
    *  jquery selector for elements that should be sticky
    *
@@ -34,48 +35,55 @@ export default Ember.Component.extend({
   _teardown: Ember.on('willDestroyElement', function() {
     this.$().off('scroll.' + this.elementId);
     $(window).off('resize.' + this.elementId);
+    this.get('eventBus').unsubscribe('split-pane-resize', this);
   }),
 
   _setup: Ember.on('didInsertElement', function() {
-    const sectionSelector = this.get('sectionSelector');
-    const stickySelector  = this.get('stickySelector');
-    const position = this._position;
-    const handleEvent = function(sections) {
-      sections.each(function() {
-        const section = $(this);
-        const sticky  = section.find(stickySelector);
-        position(section, sticky);
-      });
-    };
+    const position = this._positionAll.bind(this);
 
     Ember.run.scheduleOnce('afterRender', ()=> {
-      const sections = this.$().find(sectionSelector);
-
       // Note: This element needs to be scrollable!
       this.$().on('scroll.' + this.elementId, function() {
-        handleEvent(sections);
+        position();
       });
 
       $(window).on('resize.' + this.elementId, function() {
-        handleEvent(sections);
+        position();
+      });
+
+      this.get('eventBus').subscribe('split-pane-resize', this, function() {
+        position();
       });
     });
   }),
 
-  _position(section, sticky) {
+  _positionAll() {
+    const sections = this.$(this.get('sectionSelector'));
+    const position = this._positionSingle;
+    const stickySelector = this.get('stickySelector');
+
+    sections.each(function() {
+      const stickyElement = $(this).find(stickySelector);
+      position($(this), stickyElement);
+    });
+  },
+
+  _positionSingle(section, stickyElement) {
     const amountAboveTop = section.position().top;
 
     if(amountAboveTop > 0) {
-      sticky.css('top', '');
+      stickyElement.css('top', '');
       return;
     }
 
     const top = amountAboveTop * -1,
-          height = section.outerHeight(),
-          stickyHeight = sticky.outerHeight(),
-          noRoomForSticky = (height + amountAboveTop) < stickyHeight,
-          Y = (noRoomForSticky ? top - (top-height) - stickyHeight : top);
+          sectionHeight = section.outerHeight(),
+          stickyHeight = stickyElement.outerHeight(),
+          noRoomForSticky = (sectionHeight + amountAboveTop) < stickyHeight;
 
-    sticky.css('top', Y);
+    stickyElement.css(
+      'top',
+      noRoomForSticky ? top - (top-sectionHeight) - stickyHeight : top
+    );
   }
 });

--- a/client/app/services/event-bus.js
+++ b/client/app/services/event-bus.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend(Ember.Evented, {
+  publish() {
+    return this.trigger.apply(this, arguments);
+  },
+
+  subscribe() {
+    return this.on.apply(this, arguments);
+  },
+
+  unsubscribe() {
+    return this.off.apply(this, arguments);
+  }
+});

--- a/client/tests/components/paper-sidebar-test.js
+++ b/client/tests/components/paper-sidebar-test.js
@@ -6,7 +6,7 @@ import {
 import Ember from 'ember';
 
 moduleForComponent('paper-sidebar', 'PaperSidebarComponent', {
-  needs: ['component:sticky-headers']
+  needs: ['component:sticky-headers', 'service:event-bus']
 });
 
 test('Returns submitted message when paper is submitted', function(assert) {


### PR DESCRIPTION
Addresses "floating title" bug reported in comments:
https://developer.plos.org/jira/browse/APERTA-5806

To test:
- visit('https://tahi-staging-pr-2011.herokuapp.com/papers/10')
- open some long scrolling tasks (Billing)
- Scroll a bit so the header goes into "sticky" mode
- Resize the browser window, resize the accordion

The header should position correctly.
