### PR TITLE
APERTA-5898 Get rid of MathJax error on dashboard.

### DIFF
--- a/client/app/pods/paper/index/view.js
+++ b/client/app/pods/paper/index/view.js
@@ -25,8 +25,9 @@ export default Ember.View.extend(PaperIndexMixin, {
     else if (!window.MathJax) { this.loadMathJax(); return; }
     else if (!window.MathJax.Hub) { return; }
 
+    var view = this.$()[0];
     Ember.run.next(() => {
-      MathJax.Hub.Queue(['Typeset', MathJax.Hub, this.$()[0]]);
+      MathJax.Hub.Queue(['Typeset', MathJax.Hub, view]);
     });
   }
 


### PR DESCRIPTION
MathJax was giving an error when the controller was destroyed.  This fix prevents that.

Note: Removing the `.observes('controller.model.body')` would have also fixed this, but then math would not render until the page was refreshed after a manuscript was returned from ihat.
