### PR TITLE
APERTA-5896 Replace file-uploader component

### DIFF
--- a/client/app/pods/components/manuscript-new/component.js
+++ b/client/app/pods/components/manuscript-new/component.js
@@ -9,14 +9,8 @@ export default Ember.Component.extend(EscapeListenerMixin, {
   journals: null,
   paper: null,
   isSaving: false,
-
   journalEmpty: computed.empty('paper.journal.content'),
-
-  titleCharCount: computed('paper.title', function() {
-    return Ember.$('<div></div>')
-                .append(this.get('paper.title'))
-                .text().length;
-  }),
+  hasTitle: computed.notEmpty('paper.title'),
 
   actions: {
     selectJournal(journal) {

--- a/client/app/pods/components/manuscript-new/template.hbs
+++ b/client/app/pods/components/manuscript-new/template.hbs
@@ -10,7 +10,7 @@
                  placeholder="Crystalized Magnificence in the Modern World"
                  displayBold=false}}
 
-  {{#if titleCharCount}}
+  {{#if hasTitle}}
     <span class="paper-new-valid-icon animation-fade-in"><i class="fa fa-check"></i></span>
   {{/if}}
 </div>

--- a/client/tests/unit/manuscript-new-test.js
+++ b/client/tests/unit/manuscript-new-test.js
@@ -17,13 +17,3 @@ moduleForComponent('manuscript-new', 'Unit: Manuscript New Component', {
     c = null;
   }
 });
-
-test('it returns correct title count', function(assert) {
-  c.set('paper.title', 'Test');
-  assert.equal(c.get('titleCharCount'), 4, 'Char count is correct');
-});
-
-test('it returns correct title count with html', function(assert) {
-  c.set('paper.title', '<p>Test</p>');
-  assert.equal(c.get('titleCharCount'), 4, 'Char count is correct');
-});


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-5896
#### What this PR does:

This PR replaces the `file-uploader` with the component `s3-file-uploader`

This second component have less magic ( it doesn't make a request to rails always ) and it does not throw errors of bad signature.
#### Notes

I've removed the `titleCharCount` computed property, because this was used only as a flag, I replace this with `hasTitle` that is the flag to show the check icon.

This component does not depend on the mixin `FileUploadMixin` in order to work.

Another side effect of this fix is that no paper is created if the upload to s3 fails, as you can see before of this change, even when the request to s3 failed, a request was made to the server to create the paper model.

---
##### For the Code Reviewer:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code locally
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
##### For the Product Owner:
- [ ] I have verified the expected behavior in the Review environment
