### PR TITLE
Revert "Being more succinct and readable with removing orphaned tasks…

### DIFF
--- a/lib/tasks/data-migrations/remove-orphaned-task-items.rake
+++ b/lib/tasks/data-migrations/remove-orphaned-task-items.rake
@@ -2,11 +2,17 @@ namespace :data do
   namespace :migrate do
     desc "Remove orphaned task items"
     task remove_orphaned_task_items: :environment do
-      TahiStandardTasks::ApexDelivery.where(task_id: nil).destroy_all
-      TahiStandardTasks::Funder.where(task_id: nil).destroy_all
-      TahiStandardTasks::ReviewerRecommendation.where(
-        reviewer_recommendations_task_id: nil
-      ).destroy_all
+      TahiStandardTasks::ApexDelivery.all.select do |delivery|
+        delivery.task.nil?
+      end.map(&:destroy)
+
+      TahiStandardTasks::Funder.all.select do |funder|
+        funder.task.nil?
+      end.map(&:destroy)
+
+      TahiStandardTasks::ReviewerRecommendation.all.select do |recommendation|
+        recommendation.task.nil?
+      end.map(&:destroy)
     end
   end
 end


### PR DESCRIPTION
This reverts commit 580f2af00c71b0cbe4d5b1aa88c7053459bb24d2.

This is because the IDs aren't null, the referenced item just doesn't exist. So try to load the reference item and only delete if it doesn't exist.
