### PR TITLE
Temporary fix for register tasks not being called on reload

### DIFF
--- a/app/services/task_factory.rb
+++ b/app/services/task_factory.rb
@@ -23,6 +23,11 @@ class TaskFactory
   private
 
   def default_options
+    # Temporary fix for register tasks not being called on reload
+    unless TaskType.types[task_klass]
+      eval "#{task_klass.constantize}.register_task"
+    end
+
     {
       title: TaskType.types[task_klass].fetch(:default_title),
       old_role: TaskType.types[task_klass].fetch(:default_role)


### PR DESCRIPTION
This is a temporary fix for a issue occurring with the registered task classes. Upon reload the only task that are registered are the ones specifically called out in `snapshot_serializer_registrations.rb`. Which include only the following:
`TahiStandardTasks::AuthorsTask`
`TahiStandardTasks::CompetingInterestsTask`
`TahiStandardTasks::DataAvailabilityTask`
`TahiStandardTasks::EthicsTask`
`TahiStandardTasks::FigureTask`
`TahiStandardTasks::FinancialDisclosureTask`
`TahiStandardTasks::Funder`
`TahiStandardTasks::PublishingRelatedQuestionsTask`
`TahiStandardTasks::ReportingGuidelinesTask`
`TahiStandardTasks::ReviewerRecommendation`
`TahiStandardTasks::ReviewerRecommendationsTask`
`TahiStandardTasks::SupportingInformationTask`
`TahiStandardTasks::TaxonTask`
`TahiStandardTasks::UploadManuscriptTask`

The lack of all the tasks was surfacing the following error when creating a second new paper: 
_Note: creation of first paper works successfully after app is started. Error is hit when creating second paper._
![screenshot 2016-01-27 16 25 28](https://cloud.githubusercontent.com/assets/82035/12660928/a689ab7e-c5e4-11e5-85f4-27ff4cfe5682.png)
#### How To Test
1. Start app.
2. Create a new paper. Ensure paper page loads with tasks.
3. Return to dashboard to create a new paper. 
4. Complete new paper form, uploading document. 
5. Verify paper page loads for the submission and tasks are loaded.
##### Permanent Solution

A Jira ticket has been created to prioritize a more permanent solution for this issue: https://developer.plos.org/jira/browse/APERTA-5926
