### PR TITLE
fixes flakey controller spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -145,6 +145,10 @@ RSpec.configure do |config|
     Subscriptions.reload
   end
 
+  config.before(:each, type: :controller) do
+    Authorizations.reload_configuration
+  end
+
   config.append_after(:each) do
     DatabaseCleaner.clean
   end


### PR DESCRIPTION
Some controller specs relied on the authorizations configuration, however some feature specs clear it out.
This reloads the Authorizations::Configuration for each controller spec.

`CommentsController#index returns the tasks comments` is an example spec that was failing because the authorization configuration was cleared.
