### PR TITLE
Override CircleCI's default timeout

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,6 +47,7 @@ database:
 test:
   override:
     - bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec.xml:
+        timeout: 1800
         parallel: true
         files:
           - "spec/**/*_spec.rb"


### PR DESCRIPTION
Override circle.yml timeout to 30 minutes instead of the default 10 minutes. This is to prevent timeouts in the build.
