### PR TITLE
Fix bower_path in ember

### DIFF
--- a/config/initializers/ember.rb
+++ b/config/initializers/ember.rb
@@ -2,7 +2,7 @@ EmberCli.configure do |c|
   c.app(:tahi, {
     path: Rails.root.join('client'),
     # use locally installed bower bin
-    bower_path: Rails.root.join('client', 'node_modules', '.bin', 'bower'),
+    bower_path: Rails.root.join('node_modules', '.bin', 'bower'),
     build_timeout: 40
   })
 end


### PR DESCRIPTION
I really screwed this one up.

While attempting to fix the problem with broken qunit XML output, I realized that we needed to add a `bower_path` config back `config/initializers/ember.rb` to get access to the bower binary, which is not installed globally and not on the path.

For some reason, the build passed (https://circleci.com/gh/Tahi-project/tahi/8900#tests). I think, though, I may have caused a build that should have failed to pass by messing with it via the ssh debug (I was trying to find the location of the bower binary).

Unfortunately, merging in this PR massively broke our master build. :(

This PR should fix the issue by fixing the bower path (we install bower in the project root, not `client/`)

I'm going to leave this for someone else to merge, though.
