### PR TITLE
Fix UserMailer#add_collaborator typo

### DIFF
--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -7,10 +7,10 @@ class CollaborationsController < ApplicationController
   end
   respond_to :json
 
-  def create # rubocop:disable Metrics/MethodLength
+  def create
     collaboration = paper.add_collaboration(collaborator)
     Activity.collaborator_added!(collaboration, user: current_user)
-    UserMailer.delay.add_collaboration(
+    UserMailer.delay.add_collaborator(
       current_user.id,
       collaboration.user_id,
       paper.id

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -61,6 +61,8 @@ describe CollaborationsController do
         expect do
           post :create, format: :json, collaboration: collaborator_params
         end.to change(Sidekiq::Extensions::DelayedMailer.jobs, :size).by(1)
+        expect(UserMailer).to receive(:add_collaborator).with(user.id, collaborator.id, paper.id).and_call_original
+        Sidekiq::Extensions::DelayedMailer.drain
       end
     end
 


### PR DESCRIPTION
Quick fix for a bug I saw locally.
- add_collaborator, not add_collaboration
- Extend test to catch error in the future
