### PR TITLE
Updating README with information on how to run Ember tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ You can run the javascript specs via the command line with `rake ember:test`.
 
 ## Running qunit tests from the browser
 
-You can also run the javascript specs from the browser. To do this, visit http://localhost:5000/ember-tests/tahi.
+You can also run the javascript specs from the browser. To do this run
+`ember test --serve` from `client/` to see the results in the
+browser.
 
 For help writing ember tests please see the [ember-cli testing section](http://www.ember-cli.com/#testing)
 


### PR DESCRIPTION
Visiting the URL to run the Ember tests no longer works.  Updating the readme for when I forget how to run them now.
