### PR TITLE
Bugfix — APERTA-6109 — convert discussion line returns to break tags

### DIFF
--- a/client/app/helpers/break-to-tag.js
+++ b/client/app/helpers/break-to-tag.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export function breakToTag(string) {
+  return (string || '').replace(/\n/g, '<br>');
+}
+
+export default Ember.Helper.helper(function(params) {
+  return Ember.String.htmlSafe(breakToTag(params[0]));
+});

--- a/client/app/lib/url-to-href.js
+++ b/client/app/lib/url-to-href.js
@@ -1,15 +1,15 @@
 export default function(text, newWindow=false) {
-  let string     = text;
-  let linkRegExp = /((?:https?:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))/gmi;
-  let wwwRegExp  = /^www\d{0,3}[.]/i;
+  const string     = (text || "");
+  const linkRegExp = /((?:https?:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.])(?:[^\s()<>]+|\([^\s()<>]+\))+(?:\([^\s()<>]+\)|[^`!()\[\]{};:'".,<>?«»“”‘’\s]))/gmi;
+  const wwwRegExp  = /^www\d{0,3}[.]/i;
 
-  let startsWithWWW = function(string) {
+  const startsWithWWW = function(string) {
     return wwwRegExp.test(string);
   };
 
-  let target = newWindow ? ' target="_blank"' : '';
+  const target = newWindow ? ' target="_blank"' : '';
 
-  let toHref = function(match) {
+  const toHref = function(match) {
     let href = match;
     if(startsWithWWW(match)) { href = 'http://' + match; }
 

--- a/client/app/templates/discussions/-show.hbs
+++ b/client/app/templates/discussions/-show.hbs
@@ -33,7 +33,7 @@
       {{user-thumbnail user=reply.replier}}
       <span class="comment-name">{{reply.replier.fullName}}</span>
       <span class="comment-date">posted {{format-date reply.createdAt}}</span>
-      <div class="comment-body">{{url-to-href text=reply.body}}</div>
+      <div class="comment-body">{{url-to-href text=(break-to-tag reply.body)}}</div>
     </div>
   {{/each}}
 </div>

--- a/client/tests/factories/discussion-reply.js
+++ b/client/tests/factories/discussion-reply.js
@@ -2,6 +2,6 @@ import FactoryGuy from 'ember-data-factory-guy';
 
 FactoryGuy.define('discussion-reply', {
   default: {
-    body: 'hey'
+    body: 'hey\nhow are you?'
   }
 });

--- a/client/tests/integration/discussions-test.js
+++ b/client/tests/integration/discussions-test.js
@@ -43,7 +43,7 @@ test('can see a list of topics', function(assert) {
     visit('/papers/' + paper.id + '/workflow/discussions/');
 
     andThen(function() {
-      let topic = find('.discussions-index-topic:first');
+      const topic = find('.discussions-index-topic:first');
       assert.ok(topic.length, 'Topic is found: ' + topic.text());
     });
   });
@@ -57,7 +57,7 @@ test('can see a non-editable topic with view permissions', function(assert) {
     visit('/papers/' + paper.id + '/workflow/discussions/' + topic.get('id'));
 
     andThen(function() {
-      let titleText = find('.discussions-show-title').text().trim();
+      const titleText = find('.discussions-show-title').text().trim();
       assert.equal(titleText, 'Hipster Ipsum Dolor', 'Topic title is found: ' + titleText);
     });
   });
@@ -71,8 +71,22 @@ test('can reply to a topic with view permissions', function(assert) {
     visit('/papers/' + paper.id + '/workflow/discussions/' + topic.get('id'));
 
     andThen(function() {
-      let replyText = find('.comment-body:first').text();
+      const replyText = find('.comment-body:first').text();
       assert.ok(replyText, 'Reply is found: ' + replyText);
+    });
+  });
+});
+
+test('comment body line returns converted to break tags', function(assert) {
+  Factory.createPermission('DiscussionTopic', 1, ['view']);
+
+  Ember.run(function() {
+    TestHelper.handleFind(topic);
+    visit('/papers/' + paper.id + '/workflow/discussions/' + topic.get('id'));
+
+    andThen(function() {
+      const replyText = find('.comment-body:first').html();
+      assert.equal(replyText, 'hey<br>how are you?', 'break tags found');
     });
   });
 });
@@ -86,7 +100,7 @@ test('can see an editable topic with edit permissions', function(assert) {
     visit('/papers/' + paper.id + '/workflow/discussions/' + topic.get('id'));
 
     andThen(function() {
-      let titleText = find('.discussions-show-title input').val();
+      const titleText = find('.discussions-show-title input').val();
       assert.equal(titleText, 'Hipster Ipsum Dolor', 'Topic title is found: ' + titleText);
     });
   });

--- a/client/tests/unit/helpers/break-to-tag-test.js
+++ b/client/tests/unit/helpers/break-to-tag-test.js
@@ -1,0 +1,9 @@
+import { breakToTag } from 'tahi/helpers/break-to-tag';
+
+module('Unit | Helper | break-to-tag');
+
+test('converts line returns to break tags', function(assert) {
+  const string = 'Some\ntext';
+  const result = breakToTag(string);
+  assert.equal(result, 'Some<br>text', 'break tag found')
+});


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6109
#### What this PR does:

Currently, line breaks are displayed by a CSS property `white-space: pre-line`. This is a good solution for display, but when copy and pasting the formatting is lost.

Broken:
![line-breaks](https://cloud.githubusercontent.com/assets/3692/13383392/cba5e992-de56-11e5-959e-c0f99d50c507.gif)

Fixed:
![line-breaks-fixed](https://cloud.githubusercontent.com/assets/3692/13383438/a5f35490-de57-11e5-8873-fc62a0fa0416.gif)

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the author has fulfilled their tasks
