### PR TITLE
Fix CHANGELOG template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file. Follow
 guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 
 ## [Unreleased][unreleased]
+### Added
+-
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+### Security
+-
 
 ## [1.4.0] - 2016-02-23
 ### Added
@@ -18,18 +35,9 @@ guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 - The Authors card now enforces validations
 - The Supporting Information now enforces validations
 
-### Deprecated
--
-
-### Removed
--
-
 ### Fixed
 - Fixing an issue where the content stored on an adhoc card was not be preserved
 - Fixing an issue where an email was not being sent out to collaborators when they were added to a paper
-
-### Security
--
 
 ## [1.3.9] - 2016-02-10
 ### Added


### PR DESCRIPTION
Somehow the CHANGELOG template for the next version got lost in the 1.4.0 release.
