### PR TITLE
Fix ember routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 require 'sidekiq/web'
 
 Tahi::Application.routes.draw do
-  root to: 'ember_cli/ember#index'
   mount TahiStandardTasks::Engine => '/api', as: 'standard_tasks'
   ### DO NOT DELETE OR EDIT. AUTOMATICALLY MOUNTED CUSTOM TASK CARDS GO HERE ###
   mount PlosBioInternalReview::Engine => '/api'
@@ -31,7 +30,6 @@ Tahi::Application.routes.draw do
     get 'users/sign_out' => 'devise/sessions#destroy'
   end
 
-  mount_ember_app :tahi, to: '/'
   authenticate :user, ->(u) { u.site_admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end
@@ -196,4 +194,6 @@ Tahi::Application.routes.draw do
 
   get '/resource_proxy/:resource/:token(/:version)', to: 'resource_proxy#url',
                                                      as: :resource_proxy
+  root to: 'ember_cli/ember#index'
+  mount_ember_app :tahi, to: '/'
 end

--- a/spec/features/resource_proxy_spec.rb
+++ b/spec/features/resource_proxy_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature 'Resource Proxy', js: true do
+  let(:file) do
+    with_aws_cassette('supporting_info_file') do
+      FactoryGirl.create :supporting_information_file,
+                         attachment: File.open('spec/fixtures/yeti.tiff'),
+                         status: 'done'
+    end
+  end
+
+  describe 'GET #url without version' do
+    let(:url) do
+      url_for(controller: :resource_proxy,
+              action: :url,
+              resource: 'supporting_info_file',
+              token: file.token)
+    end
+
+    it 'redirects to S3 URL for supporting_information_files' do
+      visit("/resource_proxy/supporting_information_files/#{file.token}")
+      expect(current_url).to match(%r{\Ahttps://.*.amazonaws\.com/uploads/attachments/[0-9]+/supporting_information_file/attachment/[0-9]+/yeti\.tiff\?X-Amz-Expires.*\Z})
+    end
+  end
+end

--- a/spec/routing/assignments_routing_spec.rb
+++ b/spec/routing/assignments_routing_spec.rb
@@ -2,12 +2,8 @@ require 'rails_helper'
 
 describe "routes for assignments" do
   it "routes /api/assignments to the index action in assignments controller" do
-    expect(get: '/api/assignments', format: :json).to route_to(
-      ember_app: :tahi,
-      controller: 'ember_cli/ember',
-      action: 'index',
-      rest: 'api/assignments'
-    )
+    expect({ get: '/api/assignments', format: :json }).to route_to controller: "assignments",
+      action: "index"
   end
 
   it "routes /api/assignments to the create action in assignments controller" do

--- a/spec/routing/resource_proxy_spec.rb
+++ b/spec/routing/resource_proxy_spec.rb
@@ -4,20 +4,21 @@ describe 'routes for resource_proxy' do
   context 'without version' do
     it 'routes to the right things' do
       expect({ get: '/resource_proxy/my_resource/my_token'}).to route_to(
-        'ember_app'  => :tahi,
-        'controller' => 'ember_cli/ember',
-        'action'     => 'index',
-        'rest'       => 'resource_proxy/my_resource/my_token'
+        'controller' => 'resource_proxy',
+        'action'     => 'url',
+        'resource'   => 'my_resource',
+        'token'      => 'my_token'
       )
     end
   end
   context 'with version' do
     it 'routes to the right things' do
       expect({ get: '/resource_proxy/my_resource/my_token/my_version'}).to route_to(
-        'ember_app'  => :tahi,
-        'controller' => 'ember_cli/ember',
-        'action'     => 'index',
-        'rest'       => 'resource_proxy/my_resource/my_token/my_version'
+        'controller' => 'resource_proxy',
+        'action'     => 'url',
+        'resource'   => 'my_resource',
+        'token'      => 'my_token',
+        'version'    => 'my_version'
       )
     end
   end

--- a/spec/routing/roles_routing_spec.rb
+++ b/spec/routing/roles_routing_spec.rb
@@ -2,11 +2,8 @@ require 'rails_helper'
 
 describe "routes for old_roles" do
   it "routes /old_roles to the index action in old_roles controller" do
-    expect(get: '/api/journals/:id/old_roles', format: :json).to route_to(
-      ember_app: :tahi,
-      controller: 'ember_cli/ember',
-      action: 'index',
-      rest: 'api/journals/:id/old_roles'
+    expect({ get: '/api/journals/:id/old_roles', format: :json }).to route_to(
+      controller: "old_roles", action: "index", journal_id: ":id"
     )
   end
 end

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -2,11 +2,8 @@ require 'rails_helper'
 
 describe "routes for users" do
   it "routes /api/old_roles/:id/users to the index action in users controller" do
-    expect(get: '/api/old_roles/:id/users', format: :json).to route_to(
-      ember_app: :tahi,
-      controller: 'ember_cli/ember',
-      action: 'index',
-      rest: 'api/old_roles/:id/users'
+    expect({ get: '/api/old_roles/:id/users', format: :json }).to route_to(
+      controller: "old_roles/users", action: "index", old_role_id: ":id"
     )
   end
 end


### PR DESCRIPTION
The ember routes should come at the end, so that all other routes are given priority.

Fixes a bug with the resource proxy, for which a test is added.

Sadly, controller _and_ route tests for the resource proxy were unable to catch this bug.
