### PR TITLE
Run roles-and-permissions:seed rake task on staging deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -63,4 +63,4 @@ deployment:
     commands:
       - git push git@heroku.com:tahi-staging.git $CIRCLE_SHA1:refs/heads/master
       - heroku run rake db:migrate --app tahi-staging
-      - heroku run rake nested-questions:seed --app tahi-staging
+      - heroku run rake nested-questions:seed roles-and-permissions:seed --app tahi-staging


### PR DESCRIPTION
This makes sure the `roles-and-permissions:seed` rake task is run on a staging deploy from circle.
