### PR TITLE
APERTA-6244: Change creator task permissions to include only submission tasks

### DIFF
--- a/app/services/journal_factory.rb
+++ b/app/services/journal_factory.rb
@@ -28,6 +28,7 @@ class JournalFactory
 
       # Creator(s) only get access to the submission task types
       task_klasses = Task.submission_task_types
+      task_klasses << PlosBioTechCheck::ChangesForAuthorTask
       task_klasses.each do |klass|
         role.ensure_permission_exists(:view, applies_to: klass)
         role.ensure_permission_exists(:edit, applies_to: klass)

--- a/db/data.yml
+++ b/db/data.yml
@@ -1917,7 +1917,7 @@ authors:
     - 
     - 
     - 
-    - 
+    - AA
     - 
     - 
     - 
@@ -5594,43 +5594,6 @@ nested_questions:
     - '2016-01-26 17:37:47.789077'
     - '2016-01-26 17:37:47.789077'
     - TahiStandardTasks::PublishingRelatedQuestionsTask
-    - 
-  - - '185'
-    - Any persons named in the Acknowledgements section of the manuscript, or referred
-      to as the source of a personal communication, have agreed to being so named.
-    - boolean
-    - authors--persons_agreed_to_be_named
-    - 
-    - '297'
-    - '298'
-    - '1'
-    - '2016-03-08 15:31:47.371936'
-    - '2016-03-08 15:31:47.371936'
-    - TahiStandardTasks::AuthorsTask
-    - 
-  - - '186'
-    - All authors have read, and confirm, that they meet, ICMJE criteria for authorship.
-    - boolean
-    - authors--authors_confirm_icmje_criteria
-    - 
-    - '299'
-    - '300'
-    - '2'
-    - '2016-03-08 15:31:47.387258'
-    - '2016-03-08 15:31:47.387258'
-    - TahiStandardTasks::AuthorsTask
-    - 
-  - - '187'
-    - All contributing authors are aware of and agree to the submission of this manuscript.
-    - boolean
-    - authors--authors_agree_to_submission
-    - 
-    - '301'
-    - '302'
-    - '3'
-    - '2016-03-08 15:31:47.392427'
-    - '2016-03-08 15:31:47.392427'
-    - TahiStandardTasks::AuthorsTask
     - 
 
 ---
@@ -9477,6 +9440,21 @@ permissions_roles:
     - '8'
     - '2016-03-03 19:06:15.383204'
     - '2016-03-03 19:06:15.383204'
+  - - '278'
+    - '77'
+    - '8'
+    - '2016-03-03 19:06:15.483947'
+    - '2016-03-03 19:06:15.483947'
+  - - '279'
+    - '78'
+    - '8'
+    - '2016-03-03 19:06:15.496983'
+    - '2016-03-03 19:06:15.496983'
+  - - '280'
+    - '79'
+    - '8'
+    - '2016-03-03 19:06:15.508468'
+    - '2016-03-03 19:06:15.508468'
   - - '298'
     - '19'
     - '8'
@@ -9867,6 +9845,11 @@ permissions_roles:
     - '8'
     - '2016-03-08 00:13:37.563552'
     - '2016-03-08 00:13:37.563552'
+  - - '483'
+    - '172'
+    - '8'
+    - '2016-03-08 00:13:37.817465'
+    - '2016-03-08 00:13:37.817465'
   - - '486'
     - '175'
     - '8'

--- a/spec/services/journal_factory_spec.rb
+++ b/spec/services/journal_factory_spec.rb
@@ -46,7 +46,7 @@ describe JournalFactory do
 
         describe 'permissions on tasks' do
           let(:accessible_task_klasses) do
-            ::Task.submission_task_types
+            ::Task.submission_task_types + [PlosBioTechCheck::ChangesForAuthorTask]
           end
           let(:all_inaccessible_task_klasses) do
             ::Task.descendants - accessible_task_klasses


### PR DESCRIPTION
JIRA issue: [APERTA-6244](https://developer.plos.org/jira/browse/APERTA-6244)
#### What this PR does:

Currently the creator has permissions to all task types except:
- TahiStandardTasks::ProductionMetadataTask
- PlosBioTechCheck::FinalTechCheckTask

This will change the task permissions for the creator so that they only have permissions to submission task types. Which include:
- PlosBilling::BillingTask
- TahiStandardTasks::AuthorsTask
- TahiStandardTasks::CompetingInterestsTask
- TahiStandardTasks::CoverLetterTask
- TahiStandardTasks::DataAvailabilityTask
- TahiStandardTasks::EthicsTask
- TahiStandardTasks::FigureTask
- TahiStandardTasks::FinancialDisclosureTask
- TahiStandardTasks::PublishingRelatedQuestionsTask
- TahiStandardTasks::ReportingGuidelinesTask
- TahiStandardTasks::ReviewerRecommendationsTask
- TahiStandardTasks::ReviseTask
- TahiStandardTasks::SupportingInformationTask
- TahiStandardTasks::TaxonTask
- TahiStandardTasks::UploadManuscriptTask

---
#### Code Review Tasks:

Author tasks:  
- [ ] I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
  [APERTA-6244]
