### PR TITLE
APERTA-6099 Notify the user who uploaded a paper, not The Creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 - Password reset buttons
 
 ### Fixed
--
+- Document upload success message now displays to the uploader, not the creator of a paper.
 
 ### Security
 -

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -87,7 +87,8 @@ class PapersController < ApplicationController
     DownloadManuscriptWorker.perform_async(paper.id,
                                            params[:url],
                                            ihat_jobs_url,
-                                           paper_id: paper.id)
+                                           paper_id: paper.id,
+                                           user_id: current_user.id)
     respond_with paper
   end
 

--- a/app/services/ihat_job_response.rb
+++ b/app/services/ihat_job_response.rb
@@ -13,6 +13,10 @@ class IhatJobResponse
     metadata[:paper_id]
   end
 
+  def user_id
+    metadata[:user_id]
+  end
+
   def format_url(format)
     retval = outputs.detect { |o| o[:file_type] == format.to_s }
     retval && retval[:url]

--- a/engines/tahi_standard_tasks/app/subscribers/paper/data_extracted/notify_user.rb
+++ b/engines/tahi_standard_tasks/app/subscribers/paper/data_extracted/notify_user.rb
@@ -1,6 +1,6 @@
 class Paper::DataExtracted::NotifyUser < FlashMessageSubscriber
   def user
-    Paper.find(@event_data[:record].paper_id).creator
+    User.find(@event_data[:record].user_id)
   end
 
   def message_type

--- a/engines/tahi_standard_tasks/spec/subscribers/paper/data_extracted/notify_user_spec.rb
+++ b/engines/tahi_standard_tasks/spec/subscribers/paper/data_extracted/notify_user_spec.rb
@@ -10,8 +10,25 @@ describe Paper::DataExtracted::NotifyUser do
   let(:upload_task) do
     FactoryGirl.create(:upload_manuscript_task, paper: paper)
   end
-  let(:successful_response) { IhatJobResponse.new(state: 'completed', options: { metadata: { paper_id: upload_task.paper.id } }) }
-  let(:errored_response) { IhatJobResponse.new(state: 'errored', options: { metadata: { paper_id: upload_task.paper.id } }) }
+  let(:user) { paper.creator }
+  let(:successful_response) do
+    IhatJobResponse.new(state: 'completed',
+                        options: {
+                          metadata: {
+                            paper_id: upload_task.paper.id,
+                            user_id: user.id
+                          }
+                        })
+  end
+  let(:errored_response) do
+    IhatJobResponse.new(state: 'errored',
+                        options: {
+                          metadata: {
+                            paper_id: upload_task.paper.id,
+                            user_id: user.id
+                          }
+                        })
+  end
 
   it 'sends a message on successful upload' do
     expect(pusher_channel).to receive_push(payload: hash_including(:message, messageType: 'success'), down: 'user', on: 'flashMessage')

--- a/spec/controllers/ihat/jobs_controller_spec.rb
+++ b/spec/controllers/ihat/jobs_controller_spec.rb
@@ -8,9 +8,13 @@ describe Ihat::JobsController, type: :controller do
       controller.request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Token.encode_credentials(token)
     end
 
-    let(:encrypted_metadata) { Verifier.new(paper_id: "123").encrypt }
+    let(:encrypted_metadata) { Verifier.new(paper_id: "123", user_id: "456").encrypt }
     let(:ihat_job_params) { { job: { id: 4, state: ihat_job_state, options: { metadata: encrypted_metadata }, outputs: [{ file_type: "epub", url: "http://amazon.localhost/1234" }] }, format: :json } }
-    let(:worker_params) { { id: 4, state: ihat_job_state, options: { metadata: { paper_id: "123" } }, outputs: [{ file_type: "epub", url: "http://amazon.localhost/1234" }] } }
+    let(:worker_params) do
+      { id: 4, state: ihat_job_state,
+        options: { metadata: { paper_id: "123", user_id: "456" } },
+        outputs: [{ file_type: "epub", url: "http://amazon.localhost/1234" }] }
+    end
 
     context "the ihat job status is 'completed'" do
       let(:ihat_job_state) { "completed" }

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -240,6 +240,8 @@ describe PapersController do
     let(:url) { "http://theurl.com" }
     it "initiates manuscript download" do
       expect(DownloadManuscriptWorker).to receive(:perform_async)
+        .with(paper.id, url, "http://test.host/api/ihat/jobs",
+              paper_id: paper.id, user_id: user.id)
       put :upload, id: paper.id, url: url, format: :json
     end
   end


### PR DESCRIPTION
JIRA issue: [APERTA-6099](https://developer.plos.org/jira/secure/RapidBoard.jspa?rapidView=260&view=detail&selectedIssue=APERTA-6099)
#### What this PR does:

Upon document upload completion we will stop automatically showing a flash message to the creator of the paper assuming they triggered the upload. Instead we will keep track of the user who actually triggered the upload, and direct the flash message to them.
#### Notes

Jeffrey and I are skeptical that this will actually fix the failures he's seeing in the test suite since the test suite doesn't seem to change users. But since it's taking so long to get to the bottom of this, we're going to try out this solution and see if the tests run any better. If not, we'll either keep looking or alter the test suite to stop using the flash message as a semaphore.

Unfortunately, I was not able to reproduce any other error mode.
#### Major UI changes

Nothing major

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
