### PR TITLE
APERTA-6254 Not adding author as a participant on every task

### DIFF
--- a/app/services/task_factory.rb
+++ b/app/services/task_factory.rb
@@ -16,6 +16,7 @@ class TaskFactory
 
   def save
     task.save!
+    task
   end
 
   private

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -90,11 +90,6 @@ describe TasksController, redis: true do
       it "creates a task" do
         expect { do_request }.to change(Task, :count).by 1
       end
-
-      it "creates a task, includes the paper creator if is submission task " do
-        do_request
-        expect(Task.last.participants).to include(paper.creator)
-      end
     end
 
     context "when the user does not have access" do

--- a/spec/features/event_streaming_spec.rb
+++ b/spec/features/event_streaming_spec.rb
@@ -75,28 +75,4 @@ feature "Event streaming", js: true, selenium: true, sidekiq: :inline! do
       end
     end
   end
-
-  context "as a regular user" do
-    let!(:user) { FactoryGirl.create :user }
-    let!(:journal) { FactoryGirl.create :journal, :with_roles_and_permissions }
-    let!(:paper) { FactoryGirl.create :paper, :with_tasks, creator: user, journal: journal }
-    let(:task) { paper.tasks_for_type(TahiStandardTasks::UploadManuscriptTask).first }
-
-    before do
-      login_as(user, scope: :user)
-      visit "/"
-    end
-
-    context "on a task" do
-      scenario "comments" do
-        overlay = Page.view_task_overlay(paper, task)
-
-        # comment is added by user
-        task.comments.create!(body: "A new comment by user", commenter: user)
-        expect(overlay.has_last_comment_posted_by?(user)).to eq(true)
-        expect(overlay.has_participants?(user)).to eq(true)
-      end
-    end
-  end
-
 end

--- a/spec/services/paper_factory_spec.rb
+++ b/spec/services/paper_factory_spec.rb
@@ -50,12 +50,6 @@ describe PaperFactory do
       expect(new_paper.tasks.pluck(:type)).to match_array(['TahiStandardTasks::PaperAdminTask', 'TahiStandardTasks::DataAvailabilityTask'])
     end
 
-    it "sets user as a participant on tasks with old_role = author" do
-      new_paper = PaperFactory.create(paper_attrs, user)
-      expect(new_paper.tasks.find_by(type: 'TahiStandardTasks::PaperAdminTask').participants).to be_empty
-      expect(new_paper.tasks.find_by(type: 'TahiStandardTasks::DataAvailabilityTask').participants).to include(user)
-    end
-
     it "adds correct positions to new tasks" do
       new_paper = PaperFactory.create(paper_attrs, user)
       new_paper.phases.each do |phase|

--- a/spec/services/task_factory_spec.rb
+++ b/spec/services/task_factory_spec.rb
@@ -59,20 +59,4 @@ describe TaskFactory do
     task = TaskFactory.create(klass, paper: paper, phase: phase, participants: participants)
     expect(task.participants).to eq(participants)
   end
-
-  it "Add the creator as participant in task if is submission type" do
-    paper.update(journal: FactoryGirl.create(:journal, :with_roles_and_permissions))
-    user = FactoryGirl.create(:user)
-    expect(UserMailer).to receive_message_chain(:delay, :add_participant)
-    task = TaskFactory.create(klass, paper: paper, phase: phase, creator: user)
-    expect(task.participants).to include(user)
-  end
-
-  it 'Add the creator as participant but do not send notification' do
-    paper.update(journal: FactoryGirl.create(:journal, :with_roles_and_permissions))
-    user = FactoryGirl.create(:user)
-    expect(UserMailer).to_not receive(:delay)
-    task = TaskFactory.create(klass, paper: paper, phase: phase, creator: user, notify: false)
-    expect(task.participants).to include(user)
-  end
 end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6254
#### What this PR does:

Removing loop to add authors as participants on all submission tasks.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
