### PR TITLE
Aperta 6035 —Prevent select2 from going blank

### DIFF
--- a/client/app/pods/components/nested-question-select/component.js
+++ b/client/app/pods/components/nested-question-select/component.js
@@ -6,7 +6,7 @@ export default NestedQuestionComponent.extend({
     'errorPresent:error' // errorPresent defined in NestedQuestionComponent
   ],
 
-  selectedData: Ember.computed('model.answer', function() {
+  selectedData: Ember.computed('model.answer.value', function() {
     const value = this.get('model.answer.value');
     const id = parseInt(value) || value;
     return this.get('source').findBy('id', id);

--- a/engines/plos_billing/client/app/templates/components/billing-task.hbs
+++ b/engines/plos_billing/client/app/templates/components/billing-task.hbs
@@ -142,7 +142,7 @@
                                  placeholder="Select Your Country"
                                  displayQuestionText=false
                                  source=formattedCountries
-                                 enable=(not isNotEditable)}}
+                                 enable=isEditable}}
       {{/if}}
       {{#if countries.loading}}
         {{progress-spinner visible=true size="mini"}}


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6035
#### What this PR does:

The nested-question-select was observing the incorrect property to compute the selected value.

Busted:

![select2-broken](https://cloud.githubusercontent.com/assets/3692/13824153/4238dc3e-eb83-11e5-848a-8e12ecaedf64.gif)

Fixed:

![select2-fixed](https://cloud.githubusercontent.com/assets/3692/13824161/45bf7642-eb83-11e5-9994-da90164680a0.gif)

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature The nested-question-select was observing the wrong property and displaying the wrong answer value
