### PR TITLE
Fix/update database import

### DIFF
--- a/lib/tasks/database_import.rake
+++ b/lib/tasks/database_import.rake
@@ -7,8 +7,11 @@ namespace :db do
     fail "This can only be run in a development environment" unless Rails.env.development?
     source_db = args[:source_db_name].present? ? args[:source_db_name] : 'tahi-staging'
     Rake::Task['db:drop'].invoke
-    system(" `heroku pg:pull DATABASE_URL tahi_development --app #{source_db}`")
+    system("`(heroku pg:pull DATABASE_URL tahi_development --app #{source_db}) && rake db:reset_passwords`")
+  end
 
+  task :reset_passwords => [:environment] do |t, args|
+    fail "This can only be run in a development environment" unless Rails.env.development?
     Journal.update_all(logo: nil)
     User.update_all(avatar: nil)
     User.all.each do |u|


### PR DESCRIPTION
#### What this PR does:

 This reworks the database_import.rake file so it doesn't break all the time. It achieves this by:
- using `pg:pull` so there is no need to download a local copy of the database before restoring
- it fixes the issue with Journal's not existing by tying both commands together in the command line. The `heroku pg:pull` was incorrectly sending a success status code midway through the restore.

---
#### Code Review Tasks:

Author tasks:  
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
