### PR TITLE
Shrinkwrap npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ follow these instructions:
 
 For more information check http://mailcatcher.me/
 
+## Upgrading node packages
+
+To upgrade a node package, e.g., to version 1.0.1, use:
+```
+cd client
+npm install my-package@1.0.1 --save
+npm shrinkwrap
+```
+
+This should update both the `client/package.json` and
+`client/npm-shrinkwrap.json` files. Commit changes to both these files.
+
 # Tests
 
 ## Running specs
@@ -135,7 +147,7 @@ You can run the javascript specs via the command line with `rake ember:test`.
 You can also run the javascript specs from the browser. To do this run
 `ember test --serve` from `client/` to see the results in the
 browser.
-You can run a particular test with '--module'. For example, running: 
+You can run a particular test with '--module'. For example, running:
 `ember test --serve --module="Integration:Discussions"
 will run the Ember test that starts with `module('Integration:Discussions', {`
 

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -1,0 +1,13112 @@
+{
+  "name": "tahi",
+  "version": "0.0.0",
+  "dependencies": {
+    "broccoli-asset-rev": {
+      "version": "2.4.2",
+      "from": "https://registry.npmjs.org/broccoli-asset-rev/-/broccoli-asset-rev-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/broccoli-asset-rev/-/broccoli-asset-rev-2.4.2.tgz",
+      "dependencies": {
+        "broccoli-asset-rewrite": {
+          "version": "1.0.11",
+          "from": "https://registry.npmjs.org/broccoli-asset-rewrite/-/broccoli-asset-rewrite-1.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-asset-rewrite/-/broccoli-asset-rewrite-1.0.11.tgz"
+        },
+        "broccoli-filter": {
+          "version": "1.2.3",
+          "from": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-1.2.3.tgz",
+          "dependencies": {
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.9",
+              "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-plugin": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "dependencies": {
+                "quick-temp": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "promise-map-series": {
+              "version": "0.2.2",
+              "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz"
+            },
+            "walk-sync": {
+              "version": "0.2.6",
+              "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            }
+          }
+        },
+        "matcher-collection": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.0.21",
+          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.21.tgz",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.21.tgz"
+        }
+      }
+    },
+    "broccoli-funnel": {
+      "version": "0.2.3",
+      "from": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-0.2.3.tgz",
+      "dependencies": {
+        "broccoli-read-compat": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/broccoli-read-compat/-/broccoli-read-compat-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-read-compat/-/broccoli-read-compat-0.1.3.tgz",
+          "dependencies": {
+            "promise-map-series": {
+              "version": "0.2.2",
+              "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+            },
+            "quick-temp": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.2.1",
+              "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+            }
+          }
+        },
+        "core-object": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
+          "dependencies": {
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "symlink-or-copy": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+          "dependencies": {
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            }
+          }
+        },
+        "walk-sync": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+        }
+      }
+    },
+    "broccoli-merge-trees": {
+      "version": "0.2.1",
+      "from": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-0.2.1.tgz",
+      "dependencies": {
+        "promise-map-series": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+          "dependencies": {
+            "rsvp": {
+              "version": "3.2.1",
+              "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+            }
+          }
+        },
+        "broccoli-writer": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+          "dependencies": {
+            "quick-temp": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.2.1",
+              "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+            }
+          }
+        },
+        "symlink-or-copy": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+          "dependencies": {
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-cli": {
+      "version": "1.13.13",
+      "from": "https://registry.npmjs.org/ember-cli/-/ember-cli-1.13.13.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-1.13.13.tgz",
+      "dependencies": {
+        "amd-name-resolver": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.2.tgz"
+        },
+        "bower": {
+          "version": "1.7.7",
+          "from": "https://registry.npmjs.org/bower/-/bower-1.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.7.tgz"
+        },
+        "bower-config": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+        },
+        "broccoli": {
+          "version": "0.16.8",
+          "from": "https://registry.npmjs.org/broccoli/-/broccoli-0.16.8.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli/-/broccoli-0.16.8.tgz",
+          "dependencies": {
+            "broccoli-slow-trees": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz"
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "connect": {
+              "version": "3.4.1",
+              "from": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
+              "dependencies": {
+                "finalhandler": {
+                  "version": "0.4.1",
+                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+                  "dependencies": {
+                    "escape-html": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.3.0",
+                      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "unpipe": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                    }
+                  }
+                },
+                "parseurl": {
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            },
+            "handlebars": {
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "5.5.0",
+          "from": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.5.0.tgz",
+          "dependencies": {
+            "babel-core": {
+              "version": "5.8.38",
+              "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                },
+                "babylon": {
+                  "version": "5.8.38",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
+                },
+                "bluebird": {
+                  "version": "2.10.2",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                },
+                "convert-source-map": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
+                },
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                },
+                "output-file-sync": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "regenerator": {
+                  "version": "0.8.40",
+                  "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.4",
+                      "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "2.9.0",
+                          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "detective": {
+                          "version": "4.3.1",
+                          "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                            },
+                            "defined": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.3",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.4.1",
+                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.3",
+                                      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.4",
+                              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                            },
+                            "y18n": {
+                              "version": "3.2.1",
+                              "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.7.2",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.43",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "dependencies": {
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "ast-types": {
+                          "version": "0.8.15",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                }
+              }
+            },
+            "broccoli-persistent-filter": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "dependencies": {
+                "async-disk-cache": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "blank-object": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                },
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz"
+                },
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                },
+                "fs-tree-diff": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "dependencies": {
+                    "fast-ordered-set": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+                    }
+                  }
+                },
+                "hash-for-dep": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "dependencies": {
+                    "broccoli-kitchen-sink-helpers": {
+                      "version": "0.2.9",
+                      "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz"
+                    }
+                  }
+                },
+                "md5-hex": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "dependencies": {
+                    "md5-o-matic": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "clone": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-config-loader": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-config-loader/-/broccoli-config-loader-1.0.0.tgz",
+          "dependencies": {
+            "broccoli-caching-writer": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "dependencies": {
+                "broccoli-plugin": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz"
+                },
+                "lodash.assign": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.8",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "broccoli-config-replace": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/broccoli-config-replace/-/broccoli-config-replace-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-config-replace/-/broccoli-config-replace-1.1.1.tgz",
+          "dependencies": {
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fs-extra": {
+              "version": "0.24.0",
+              "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.3",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                },
+                "jsonfile": {
+                  "version": "2.2.3",
+                  "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz",
+          "dependencies": {
+            "array-equal": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
+            },
+            "blank-object": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+            },
+            "fast-ordered-set": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+            },
+            "fs-tree-diff": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "path-posix": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "walk-sync": {
+              "version": "0.2.6",
+              "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+              "dependencies": {
+                "matcher-collection": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-kitchen-sink-helpers": {
+          "version": "0.2.9",
+          "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz",
+          "dependencies": {
+            "can-symlink": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+              "dependencies": {
+                "tmp": {
+                  "version": "0.0.28",
+                  "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+                  "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fast-ordered-set": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+              "dependencies": {
+                "blank-object": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                }
+              }
+            },
+            "fs-tree-diff": {
+              "version": "0.4.4",
+              "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "broccoli-plugin": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "broccoli-sane-watcher": {
+          "version": "1.1.4",
+          "from": "https://registry.npmjs.org/broccoli-sane-watcher/-/broccoli-sane-watcher-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-sane-watcher/-/broccoli-sane-watcher-1.1.4.tgz",
+          "dependencies": {
+            "broccoli-slow-trees": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz"
+            }
+          }
+        },
+        "broccoli-source": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz"
+        },
+        "broccoli-sourcemap-concat": {
+          "version": "2.0.2",
+          "from": "https://registry.npmjs.org/broccoli-sourcemap-concat/-/broccoli-sourcemap-concat-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-sourcemap-concat/-/broccoli-sourcemap-concat-2.0.2.tgz",
+          "dependencies": {
+            "broccoli-caching-writer": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "dependencies": {
+                "broccoli-plugin": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz"
+                },
+                "lodash.assign": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.8",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fast-sourcemap-concat": {
+              "version": "0.2.7",
+              "from": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-0.2.7.tgz",
+              "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-0.2.7.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map-url": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            },
+            "lodash.uniq": {
+              "version": "3.2.2",
+              "from": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
+              "dependencies": {
+                "lodash._basecallback": {
+                  "version": "3.3.1",
+                  "from": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+                  "dependencies": {
+                    "lodash._baseisequal": {
+                      "version": "3.0.7",
+                      "from": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+                      "dependencies": {
+                        "lodash.istypedarray": {
+                          "version": "3.0.5",
+                          "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz"
+                        },
+                        "lodash.keys": {
+                          "version": "3.1.2",
+                          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "dependencies": {
+                            "lodash.isarguments": {
+                              "version": "3.0.8",
+                              "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash.pairs": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+                      "dependencies": {
+                        "lodash.keys": {
+                          "version": "3.1.2",
+                          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "dependencies": {
+                            "lodash.isarguments": {
+                              "version": "3.0.8",
+                              "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._baseuniq": {
+                  "version": "3.0.3",
+                  "from": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
+                  "dependencies": {
+                    "lodash._baseindexof": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                    },
+                    "lodash._cacheindexof": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                    },
+                    "lodash._createcache": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz"
+                    }
+                  }
+                },
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-viz": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/broccoli-viz/-/broccoli-viz-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-viz/-/broccoli-viz-2.0.1.tgz"
+        },
+        "chalk": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "clean-base-url": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/clean-base-url/-/clean-base-url-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/clean-base-url/-/clean-base-url-1.0.0.tgz"
+        },
+        "compression": {
+          "version": "1.6.1",
+          "from": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.10",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.22.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+            },
+            "compressible": {
+              "version": "2.0.7",
+              "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+            },
+            "vary": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+            }
+          }
+        },
+        "configstore": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/configstore/-/configstore-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.2.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+            },
+            "os-tmpdir": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                }
+              }
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+            },
+            "write-file-atomic": {
+              "version": "1.1.4",
+              "from": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+              "dependencies": {
+                "imurmurhash": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+                },
+                "slide": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+                }
+              }
+            },
+            "xdg-basedir": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "core-object": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
+          "dependencies": {
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            }
+          }
+        },
+        "cpr": {
+          "version": "0.4.2",
+          "from": "https://registry.npmjs.org/cpr/-/cpr-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/cpr/-/cpr-0.4.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.4.5",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "6.0.4",
+                  "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+        },
+        "ember-cli-copy-dereference": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ember-cli-copy-dereference/-/ember-cli-copy-dereference-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-copy-dereference/-/ember-cli-copy-dereference-1.0.0.tgz"
+        },
+        "ember-cli-get-dependency-depth": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz"
+        },
+        "ember-cli-is-package-missing": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ember-cli-is-package-missing/-/ember-cli-is-package-missing-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-is-package-missing/-/ember-cli-is-package-missing-1.0.0.tgz"
+        },
+        "ember-cli-normalize-entity-name": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz"
+        },
+        "ember-cli-path-utils": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ember-cli-path-utils/-/ember-cli-path-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-path-utils/-/ember-cli-path-utils-1.0.0.tgz"
+        },
+        "ember-cli-preprocess-registry": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-1.1.0.tgz",
+          "dependencies": {
+            "broccoli-clean-css": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-0.2.0.tgz",
+              "dependencies": {
+                "clean-css": {
+                  "version": "2.2.23",
+                  "from": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.2.0",
+                      "from": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
+                    }
+                  }
+                },
+                "broccoli-filter": {
+                  "version": "0.1.14",
+                  "from": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
+                  "dependencies": {
+                    "broccoli-writer": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.3.5",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "process-relative-require": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/process-relative-require/-/process-relative-require-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/process-relative-require/-/process-relative-require-1.0.0.tgz"
+            }
+          }
+        },
+        "ember-cli-string-utils": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.0.0.tgz"
+        },
+        "ember-cli-test-info": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz"
+        },
+        "ember-router-generator": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.0.tgz",
+          "dependencies": {
+            "recast": {
+              "version": "0.9.18",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
+              "dependencies": {
+                "esprima-fb": {
+                  "version": "10001.1.0-dev-harmony-fb",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "ast-types": {
+                  "version": "0.6.16",
+                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz"
+                }
+              }
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+        },
+        "exists-sync": {
+          "version": "0.0.3",
+          "from": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz"
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "findup": {
+          "version": "0.1.5",
+          "from": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+            },
+            "commander": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "0.22.1",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.22.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.22.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+            },
+            "jsonfile": {
+              "version": "2.2.3",
+              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fs-monitor-stack": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/fs-monitor-stack/-/fs-monitor-stack-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs-monitor-stack/-/fs-monitor-stack-1.1.0.tgz"
+        },
+        "git-repo-info": {
+          "version": "1.1.2",
+          "from": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.1.2.tgz"
+        },
+        "glob": {
+          "version": "5.0.13",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.13.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.3",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "1.13.2",
+          "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz",
+          "dependencies": {
+            "eventemitter3": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+            },
+            "requires-port": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+            }
+          }
+        },
+        "inflection": {
+          "version": "1.8.0",
+          "from": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz"
+        },
+        "inquirer": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.5.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.8.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz"
+            },
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.11",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.9",
+                  "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.4",
+                      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.4",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-git-url": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/is-git-url/-/is-git-url-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-0.2.3.tgz"
+        },
+        "isbinaryfile": {
+          "version": "2.0.4",
+          "from": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-2.0.4.tgz"
+        },
+        "leek": {
+          "version": "0.0.18",
+          "from": "https://registry.npmjs.org/leek/-/leek-0.0.18.tgz",
+          "resolved": "https://registry.npmjs.org/leek/-/leek-0.0.18.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.1.1",
+              "from": "debug@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "lodash-node@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            },
+            "request": {
+              "version": "2.53.0",
+              "from": "request@>=2.27.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.9",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "from": "mime-db@>=1.7.0 <1.8.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.11.1",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
+                    },
+                    "boom": {
+                      "version": "2.6.1",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.17",
+              "from": "rsvp@>=3.0.6 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.17.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "markdown-it": {
+          "version": "4.3.0",
+          "from": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.3.0.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+            },
+            "linkify-it": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.0.tgz"
+            },
+            "mdurl": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
+            },
+            "uc.micro": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.0.tgz"
+            }
+          }
+        },
+        "markdown-it-terminal": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/markdown-it-terminal/-/markdown-it-terminal-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/markdown-it-terminal/-/markdown-it-terminal-0.0.2.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "cardinal": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
+              "dependencies": {
+                "redeyed": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "12001.1.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
+                    }
+                  }
+                },
+                "ansicolors": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+                }
+              }
+            },
+            "cli-table": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "dependencies": {
+                "colors": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "3.10.2",
+              "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-3.10.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-3.10.2.tgz"
+            }
+          }
+        },
+        "merge-defaults": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.2.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "morgan": {
+          "version": "1.7.0",
+          "from": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
+          "dependencies": {
+            "basic-auth": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+            },
+            "depd": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+            }
+          }
+        },
+        "node-modules-path": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.1.tgz"
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "npm": {
+          "version": "2.14.10",
+          "from": "https://registry.npmjs.org/npm/-/npm-2.14.10.tgz",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.14.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.7 <1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            },
+            "ansi": {
+              "version": "0.3.0",
+              "from": "ansi@latest",
+              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+            },
+            "ansicolors": {
+              "version": "0.3.2",
+              "from": "ansicolors@latest"
+            },
+            "ansistyles": {
+              "version": "0.1.3",
+              "from": "ansistyles@0.1.3",
+              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz"
+            },
+            "archy": {
+              "version": "1.0.0",
+              "from": "archy@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+            },
+            "async-some": {
+              "version": "1.0.2",
+              "from": "async-some@>=1.0.2 <1.1.0"
+            },
+            "block-stream": {
+              "version": "0.0.8",
+              "from": "block-stream@0.0.8",
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+            },
+            "char-spinner": {
+              "version": "1.0.1",
+              "from": "char-spinner@latest",
+              "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
+            },
+            "chmodr": {
+              "version": "1.0.2",
+              "from": "chmodr@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "from": "chownr@1.0.1",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz"
+            },
+            "cmd-shim": {
+              "version": "2.0.1",
+              "from": "cmd-shim@>=2.0.1-0 <3.0.0-0",
+              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.1.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>3.0.1 <4.0.0-0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                }
+              }
+            },
+            "columnify": {
+              "version": "1.5.2",
+              "from": "columnify@1.5.2",
+              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.2.tgz",
+              "dependencies": {
+                "wcwidth": {
+                  "version": "1.0.0",
+                  "from": "wcwidth@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
+                  "dependencies": {
+                    "defaults": {
+                      "version": "1.0.2",
+                      "from": "defaults@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.2.tgz",
+                      "dependencies": {
+                        "clone": {
+                          "version": "0.1.19",
+                          "from": "clone@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "config-chain": {
+              "version": "1.1.9",
+              "from": "config-chain@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.4",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                }
+              }
+            },
+            "dezalgo": {
+              "version": "1.0.3",
+              "from": "dezalgo@>=1.0.3 <1.1.0",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.3",
+                  "from": "asap@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                }
+              }
+            },
+            "editor": {
+              "version": "1.0.0",
+              "from": "editor@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz"
+            },
+            "fs-vacuum": {
+              "version": "1.2.7",
+              "from": "fs-vacuum@1.2.7"
+            },
+            "fs-write-stream-atomic": {
+              "version": "1.0.4",
+              "from": "fs-write-stream-atomic@1.0.4"
+            },
+            "fstream": {
+              "version": "1.0.8",
+              "from": "fstream@1.0.8"
+            },
+            "fstream-npm": {
+              "version": "1.0.7",
+              "from": "fstream-npm@>=1.0.7 <1.1.0",
+              "dependencies": {
+                "fstream-ignore": {
+                  "version": "1.0.3",
+                  "from": "fstream-ignore@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz"
+                }
+              }
+            },
+            "github-url-from-git": {
+              "version": "1.4.0",
+              "from": "github-url-from-git@>=1.4.0-0 <2.0.0-0",
+              "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
+            },
+            "github-url-from-username-repo": {
+              "version": "1.0.2",
+              "from": "github-url-from-username-repo@>=1.0.2-0 <2.0.0-0"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.2",
+              "from": "graceful-fs@>=3.0.8 <3.1.0"
+            },
+            "hosted-git-info": {
+              "version": "2.1.4",
+              "from": "hosted-git-info@>=2.1.2 <2.2.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+            },
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <1.1.0"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@latest",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "ini": {
+              "version": "1.3.4",
+              "from": "ini@latest",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+            },
+            "init-package-json": {
+              "version": "1.9.1",
+              "from": "init-package-json@1.9.1",
+              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.1.tgz",
+              "dependencies": {
+                "promzard": {
+                  "version": "0.3.0",
+                  "from": "promzard@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz"
+                }
+              }
+            },
+            "lockfile": {
+              "version": "1.0.1",
+              "from": "lockfile@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
+            },
+            "lru-cache": {
+              "version": "2.7.0",
+              "from": "lru-cache@2.7.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "from": "minimatch@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.1",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "node-gyp": {
+              "version": "3.0.3",
+              "from": "node-gyp@3.0.3",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.0.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.1",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.1",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "1.2.1",
+                  "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "dependencies": {
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0",
+                          "from": "delegates@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.1",
+                          "from": "has-unicode@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "from": "lodash.pad@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padleft": {
+                          "version": "3.1.1",
+                          "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padright": {
+                          "version": "3.1.1",
+                          "from": "lodash.padright@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-array": {
+                  "version": "1.0.0",
+                  "from": "path-array@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.0.tgz",
+                  "dependencies": {
+                    "array-index": {
+                      "version": "0.1.1",
+                      "from": "array-index@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/array-index/-/array-index-0.1.1.tgz",
+                      "dependencies": {
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@*",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "tar": {
+                  "version": "1.0.3",
+                  "from": "tar@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.4",
+              "from": "nopt@3.0.4"
+            },
+            "normalize-git-url": {
+              "version": "3.0.1",
+              "from": "normalize-git-url@latest"
+            },
+            "normalize-package-data": {
+              "version": "2.3.5",
+              "from": "normalize-package-data@>=2.3.5 <2.4.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "dependencies": {
+                "is-builtin-module": {
+                  "version": "1.0.0",
+                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "dependencies": {
+                    "builtin-modules": {
+                      "version": "1.1.0",
+                      "from": "builtin-modules@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "npm-cache-filename": {
+              "version": "1.0.2",
+              "from": "npm-cache-filename@1.0.2",
+              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz"
+            },
+            "npm-install-checks": {
+              "version": "1.0.6",
+              "from": "npm-install-checks@1.0.6",
+              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.6.tgz",
+              "dependencies": {
+                "npmlog": {
+                  "version": "1.2.1",
+                  "from": "npmlog@>=0.1.0 <0.2.0||>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "dependencies": {
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0",
+                          "from": "delegates@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.1",
+                          "from": "has-unicode@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "from": "lodash.pad@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padleft": {
+                          "version": "3.1.1",
+                          "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padright": {
+                          "version": "3.1.1",
+                          "from": "lodash.padright@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-package-arg": {
+              "version": "4.0.2",
+              "from": "npm-package-arg@>=4.0.2 <4.1.0"
+            },
+            "npm-registry-client": {
+              "version": "7.0.7",
+              "from": "npm-registry-client@7.0.7",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.5.0",
+                  "from": "concat-stream@>=1.4.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.2",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.3",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-user-validate": {
+              "version": "0.1.2",
+              "from": "npm-user-validate@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.2.tgz"
+            },
+            "npmlog": {
+              "version": "2.0.0",
+              "from": "npmlog@>=2.0.0 <2.1.0",
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.0.4",
+                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    }
+                  }
+                },
+                "gauge": {
+                  "version": "1.2.2",
+                  "from": "gauge@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                  "dependencies": {
+                    "has-unicode": {
+                      "version": "1.0.1",
+                      "from": "has-unicode@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "3.1.1",
+                      "from": "lodash.pad@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._basetostring": {
+                          "version": "3.0.1",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                        },
+                        "lodash._createpadding": {
+                          "version": "3.6.1",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                          "dependencies": {
+                            "lodash.repeat": {
+                              "version": "3.0.1",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.padleft": {
+                      "version": "3.1.1",
+                      "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._basetostring": {
+                          "version": "3.0.1",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                        },
+                        "lodash._createpadding": {
+                          "version": "3.6.1",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                          "dependencies": {
+                            "lodash.repeat": {
+                              "version": "3.0.1",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.padright": {
+                      "version": "3.1.1",
+                      "from": "lodash.padright@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._basetostring": {
+                          "version": "3.0.1",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                        },
+                        "lodash._createpadding": {
+                          "version": "3.6.1",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                          "dependencies": {
+                            "lodash.repeat": {
+                              "version": "3.0.1",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.2 <1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
+            },
+            "opener": {
+              "version": "1.4.1",
+              "from": "opener@>=1.4.1 <1.5.0",
+              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz"
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "from": "osenv@0.1.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.0",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
+            },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "from": "path-is-inside@1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+            },
+            "read": {
+              "version": "1.0.7",
+              "from": "read@1.0.7",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "from": "mute-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "read-installed": {
+              "version": "4.0.3",
+              "from": "read-installed@4.0.3",
+              "dependencies": {
+                "debuglog": {
+                  "version": "1.0.1",
+                  "from": "debuglog@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz"
+                },
+                "readdir-scoped-modules": {
+                  "version": "1.0.2",
+                  "from": "readdir-scoped-modules@>=1.0.0 <2.0.0"
+                },
+                "util-extend": {
+                  "version": "1.0.1",
+                  "from": "util-extend@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz"
+                }
+              }
+            },
+            "read-package-json": {
+              "version": "2.0.2",
+              "from": "read-package-json@>=2.0.2 <2.1.0",
+              "dependencies": {
+                "json-parse-helpfulerror": {
+                  "version": "1.0.3",
+                  "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "dependencies": {
+                    "jju": {
+                      "version": "1.2.1",
+                      "from": "jju@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            },
+            "realize-package-specifier": {
+              "version": "3.0.1",
+              "from": "realize-package-specifier@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz"
+            },
+            "request": {
+              "version": "2.65.0",
+              "from": "request@>=2.65.0 <2.66.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "bl@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.3",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.3.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.3",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "from": "form-data@>=1.0.0-rc3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.0",
+                      "from": "async@>=1.4.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "from": "mime-types@>=2.1.7 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "mime-db@>=1.19.0 <1.20.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.3 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "qs@>=5.2.0 <5.3.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0",
+                  "from": "tough-cookie@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "from": "hawk@>=3.1.0 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.0",
+                      "from": "boom@>=2.8.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.0.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@>=1.0.5 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "2.0.2",
+                  "from": "har-validator@>=2.0.2 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@>=2.8.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.2",
+                      "from": "is-my-json-valid@>=2.12.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0",
+                          "from": "jsonpointer@2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "1.0.0",
+                      "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "1.0.0",
+                          "from": "pinkie@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "retry": {
+              "version": "0.8.0",
+              "from": "retry@0.8.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.4.3",
+              "from": "rimraf@2.4.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+            },
+            "semver": {
+              "version": "5.0.3",
+              "from": "semver@5.0.3",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+            },
+            "sha": {
+              "version": "2.0.1",
+              "from": "sha@2.0.1",
+              "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "slide": {
+              "version": "1.1.6",
+              "from": "slide@>=1.1.6 <1.2.0",
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+            },
+            "sorted-object": {
+              "version": "1.0.0",
+              "from": "sorted-object@"
+            },
+            "spdx": {
+              "version": "0.4.1",
+              "from": "spdx@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/spdx/-/spdx-0.4.1.tgz"
+            },
+            "tar": {
+              "version": "2.2.1",
+              "from": "tar@2.2.1"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@~0.2.0"
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "from": "uid-number@>=0.0.6 <0.1.0",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+            },
+            "umask": {
+              "version": "1.1.0",
+              "from": "umask@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz"
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.1",
+              "from": "validate-npm-package-license@3.0.1",
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+              "dependencies": {
+                "spdx-correct": {
+                  "version": "1.0.1",
+                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.1.tgz"
+                },
+                "spdx-expression-parse": {
+                  "version": "1.0.0",
+                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.0.tgz",
+                  "dependencies": {
+                    "spdx-exceptions": {
+                      "version": "1.0.2",
+                      "from": "spdx-exceptions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "validate-npm-package-name": {
+              "version": "2.2.2",
+              "from": "validate-npm-package-name@2.2.2",
+              "dependencies": {
+                "builtins": {
+                  "version": "0.0.7",
+                  "from": "builtins@0.0.7"
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.0",
+              "from": "which@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+              "dependencies": {
+                "is-absolute": {
+                  "version": "0.1.7",
+                  "from": "is-absolute@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                  "dependencies": {
+                    "is-relative": {
+                      "version": "0.1.3",
+                      "from": "is-relative@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@1.0.1",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            },
+            "write-file-atomic": {
+              "version": "1.1.3",
+              "from": "write-file-atomic@1.1.3",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.3.tgz"
+            },
+            "ansi-regex": {
+              "version": "2.0.0",
+              "from": "ansi-regex@2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+            },
+            "spdx-license-ids": {
+              "version": "1.1.0",
+              "from": "spdx-license-ids@1.1.0",
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+            }
+          }
+        },
+        "pleasant-progress": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/pleasant-progress/-/pleasant-progress-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/pleasant-progress/-/pleasant-progress-1.1.0.tgz"
+        },
+        "portfinder": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "promise-map-series": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+        },
+        "quick-temp": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "mktemp": {
+              "version": "0.3.5",
+              "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        },
+        "rsvp": {
+          "version": "3.2.1",
+          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+        },
+        "sane": {
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/sane/-/sane-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-1.3.3.tgz",
+          "dependencies": {
+            "exec-sh": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
+              "dependencies": {
+                "merge": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+                }
+              }
+            },
+            "fb-watchman": {
+              "version": "1.9.0",
+              "from": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz",
+              "dependencies": {
+                "bser": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+                  "dependencies": {
+                    "node-int64": {
+                      "version": "0.4.0",
+                      "from": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "walker": {
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+              "dependencies": {
+                "makeerror": {
+                  "version": "1.0.11",
+                  "from": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+                  "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+                  "dependencies": {
+                    "tmpl": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "watch": {
+              "version": "0.10.0",
+              "from": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
+            }
+          }
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        },
+        "silent-error": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/silent-error/-/silent-error-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.0.0.tgz"
+        },
+        "symlink-or-copy": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+          "dependencies": {
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            }
+          }
+        },
+        "temp": {
+          "version": "0.8.1",
+          "from": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        },
+        "testem": {
+          "version": "0.9.11",
+          "from": "https://registry.npmjs.org/testem/-/testem-0.9.11.tgz",
+          "resolved": "https://registry.npmjs.org/testem/-/testem-0.9.11.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+            },
+            "backbone": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/backbone/-/backbone-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.2.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.8.3",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+                }
+              }
+            },
+            "charm": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/charm/-/charm-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.0.tgz"
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "consolidate": {
+              "version": "0.13.1",
+              "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.13.1.tgz",
+              "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.13.1.tgz",
+              "dependencies": {
+                "bluebird": {
+                  "version": "2.10.2",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                }
+              }
+            },
+            "cross-spawn-async": {
+              "version": "2.1.9",
+              "from": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.9.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                    },
+                    "yallist": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.2.4",
+                  "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+                  "dependencies": {
+                    "is-absolute": {
+                      "version": "0.1.7",
+                      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                      "dependencies": {
+                        "is-relative": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                        }
+                      }
+                    },
+                    "isexe": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "did_it_work": {
+              "version": "0.0.6",
+              "from": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz"
+            },
+            "fileset": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz"
+            },
+            "fireworm": {
+              "version": "0.6.6",
+              "from": "https://registry.npmjs.org/fireworm/-/fireworm-0.6.6.tgz",
+              "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.6.6.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "lodash": {
+                  "version": "2.3.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.3.0.tgz"
+                },
+                "is-type": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "growl": {
+              "version": "1.9.2",
+              "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+            },
+            "js-yaml": {
+              "version": "3.5.5",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.7.2",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "mustache": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz"
+            },
+            "npmlog": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+              "dependencies": {
+                "ansi": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
+                },
+                "are-we-there-yet": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "gauge": {
+                  "version": "1.2.7",
+                  "from": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+                  "dependencies": {
+                    "has-unicode": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "4.1.0",
+                      "from": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.1.0.tgz",
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "from": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                        }
+                      }
+                    },
+                    "lodash.padend": {
+                      "version": "4.2.0",
+                      "from": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.2.0.tgz",
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "from": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                        }
+                      }
+                    },
+                    "lodash.padstart": {
+                      "version": "4.2.0",
+                      "from": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz",
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2",
+                          "from": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "printf": {
+              "version": "0.2.3",
+              "from": "https://registry.npmjs.org/printf/-/printf-0.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/printf/-/printf-0.2.3.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "socket.io-pure": {
+              "version": "1.3.12",
+              "from": "https://registry.npmjs.org/socket.io-pure/-/socket.io-pure-1.3.12.tgz",
+              "resolved": "https://registry.npmjs.org/socket.io-pure/-/socket.io-pure-1.3.12.tgz",
+              "dependencies": {
+                "engine.io-pure": {
+                  "version": "1.5.9",
+                  "from": "https://registry.npmjs.org/engine.io-pure/-/engine.io-pure-1.5.9.tgz",
+                  "resolved": "https://registry.npmjs.org/engine.io-pure/-/engine.io-pure-1.5.9.tgz",
+                  "dependencies": {
+                    "base64id": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                    },
+                    "debug": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                      }
+                    },
+                    "engine.io-parser": {
+                      "version": "1.2.2",
+                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.2.tgz",
+                      "dependencies": {
+                        "after": {
+                          "version": "0.8.1",
+                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                        },
+                        "arraybuffer.slice": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                        },
+                        "base64-arraybuffer": {
+                          "version": "0.1.2",
+                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                        },
+                        "blob": {
+                          "version": "0.0.4",
+                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
+                        },
+                        "has-binary": {
+                          "version": "0.1.6",
+                          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                          "dependencies": {
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            }
+                          }
+                        },
+                        "utf8": {
+                          "version": "2.1.0",
+                          "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
+                        }
+                      }
+                    },
+                    "ws-pure": {
+                      "version": "0.8.0",
+                      "from": "https://registry.npmjs.org/ws-pure/-/ws-pure-0.8.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ws-pure/-/ws-pure-0.8.0.tgz",
+                      "dependencies": {
+                        "options": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                        },
+                        "ultron": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "socket.io-parser": {
+                  "version": "2.2.4",
+                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "benchmark": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                    }
+                  }
+                },
+                "socket.io-client-pure": {
+                  "version": "1.3.12",
+                  "from": "https://registry.npmjs.org/socket.io-client-pure/-/socket.io-client-pure-1.3.12.tgz",
+                  "resolved": "https://registry.npmjs.org/socket.io-client-pure/-/socket.io-client-pure-1.3.12.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "engine.io-client-pure": {
+                      "version": "1.5.9",
+                      "from": "https://registry.npmjs.org/engine.io-client-pure/-/engine.io-client-pure-1.5.9.tgz",
+                      "resolved": "https://registry.npmjs.org/engine.io-client-pure/-/engine.io-client-pure-1.5.9.tgz",
+                      "dependencies": {
+                        "component-inherit": {
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                        },
+                        "debug": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.6.2",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                            }
+                          }
+                        },
+                        "engine.io-parser": {
+                          "version": "1.2.2",
+                          "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.2.tgz",
+                          "dependencies": {
+                            "after": {
+                              "version": "0.8.1",
+                              "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+                              "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                            },
+                            "arraybuffer.slice": {
+                              "version": "0.0.6",
+                              "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+                              "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                            },
+                            "base64-arraybuffer": {
+                              "version": "0.1.2",
+                              "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
+                              "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                            },
+                            "blob": {
+                              "version": "0.0.4",
+                              "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
+                            },
+                            "utf8": {
+                              "version": "2.1.0",
+                              "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
+                            }
+                          }
+                        },
+                        "has-cors": {
+                          "version": "1.1.0",
+                          "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
+                        },
+                        "parsejson": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                          "dependencies": {
+                            "better-assert": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "dependencies": {
+                                "callsite": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "parseqs": {
+                          "version": "0.0.2",
+                          "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                          "dependencies": {
+                            "better-assert": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "dependencies": {
+                                "callsite": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "parseuri": {
+                          "version": "0.0.4",
+                          "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                          "dependencies": {
+                            "better-assert": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "dependencies": {
+                                "callsite": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "ws-pure": {
+                          "version": "0.8.0",
+                          "from": "https://registry.npmjs.org/ws-pure/-/ws-pure-0.8.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ws-pure/-/ws-pure-0.8.0.tgz",
+                          "dependencies": {
+                            "options": {
+                              "version": "0.0.6",
+                              "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                            },
+                            "ultron": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "xmlhttprequest-ssl": {
+                          "version": "1.5.1",
+                          "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
+                          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
+                        }
+                      }
+                    },
+                    "component-bind": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "object-component": {
+                      "version": "0.0.3",
+                      "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+                    },
+                    "has-binary": {
+                      "version": "0.1.6",
+                      "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    },
+                    "parseuri": {
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-array": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+                    },
+                    "backo2": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+                    }
+                  }
+                },
+                "socket.io-adapter": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                      }
+                    },
+                    "socket.io-parser": {
+                      "version": "2.2.2",
+                      "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                      "dependencies": {
+                        "debug": {
+                          "version": "0.7.4",
+                          "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                        },
+                        "json3": {
+                          "version": "3.2.6",
+                          "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+                          "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                        },
+                        "component-emitter": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "benchmark": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "object-keys": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
+                    }
+                  }
+                },
+                "has-binary-data": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "styled_string": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz"
+            },
+            "tap-parser": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.2.2.tgz",
+              "dependencies": {
+                "events-to-array": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "xmldom": {
+              "version": "0.1.22",
+              "from": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz"
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        },
+        "tiny-lr": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.0.tgz",
+          "dependencies": {
+            "body-parser": {
+              "version": "1.14.2",
+              "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+              "dependencies": {
+                "bytes": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+                },
+                "content-type": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+                },
+                "depd": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                },
+                "http-errors": {
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                    }
+                  }
+                },
+                "iconv-lite": {
+                  "version": "0.4.13",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                    }
+                  }
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                },
+                "raw-body": {
+                  "version": "2.1.6",
+                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+                  "dependencies": {
+                    "bytes": {
+                      "version": "2.3.0",
+                      "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+                    },
+                    "unpipe": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                    }
+                  }
+                },
+                "type-is": {
+                  "version": "1.6.12",
+                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+                  "dependencies": {
+                    "media-typer": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.10",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.22.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.10.0",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.4",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "livereload-js": {
+              "version": "2.2.2",
+              "from": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            },
+            "qs": {
+              "version": "5.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+            }
+          }
+        },
+        "walk-sync": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+        },
+        "yam": {
+          "version": "0.0.18",
+          "from": "https://registry.npmjs.org/yam/-/yam-0.0.18.tgz",
+          "resolved": "https://registry.npmjs.org/yam/-/yam-0.0.18.tgz",
+          "dependencies": {
+            "fs-extra": {
+              "version": "0.16.5",
+              "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                },
+                "jsonfile": {
+                  "version": "2.2.3",
+                  "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.merge": {
+              "version": "3.3.2",
+              "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.8",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                },
+                "lodash.isplainobject": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basefor": {
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                    }
+                  }
+                },
+                "lodash.istypedarray": {
+                  "version": "3.0.5",
+                  "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+                },
+                "lodash.toplainobject": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-app-version": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-1.0.0.tgz",
+      "dependencies": {
+        "git-repo-version": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/git-repo-version/-/git-repo-version-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/git-repo-version/-/git-repo-version-0.3.0.tgz",
+          "dependencies": {
+            "git-repo-info": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.1.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-babel": {
+      "version": "5.1.6",
+      "from": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.1.6.tgz",
+      "dependencies": {
+        "broccoli-babel-transpiler": {
+          "version": "5.5.0",
+          "from": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.5.0.tgz",
+          "dependencies": {
+            "babel-core": {
+              "version": "5.8.38",
+              "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                },
+                "babylon": {
+                  "version": "5.8.38",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
+                },
+                "bluebird": {
+                  "version": "2.10.2",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
+                },
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "output-file-sync": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "regenerator": {
+                  "version": "0.8.40",
+                  "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.4",
+                      "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "2.9.0",
+                          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "detective": {
+                          "version": "4.3.1",
+                          "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                            },
+                            "defined": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.3",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.4.1",
+                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.3",
+                                      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.4",
+                              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                            },
+                            "y18n": {
+                              "version": "3.2.1",
+                              "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.7.2",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.43",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "dependencies": {
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "ast-types": {
+                          "version": "0.8.15",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                }
+              }
+            },
+            "broccoli-persistent-filter": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "dependencies": {
+                "async-disk-cache": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "blank-object": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                },
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "broccoli-plugin": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "dependencies": {
+                    "quick-temp": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        },
+                        "mktemp": {
+                          "version": "0.3.5",
+                          "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "fs-tree-diff": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "dependencies": {
+                    "fast-ordered-set": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+                    }
+                  }
+                },
+                "hash-for-dep": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "dependencies": {
+                    "broccoli-kitchen-sink-helpers": {
+                      "version": "0.2.9",
+                      "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "md5-hex": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "dependencies": {
+                    "md5-o-matic": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "promise-map-series": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+                },
+                "rsvp": {
+                  "version": "3.2.1",
+                  "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz"
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-merge-trees": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz",
+              "dependencies": {
+                "broccoli-plugin": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "dependencies": {
+                    "promise-map-series": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                      "dependencies": {
+                        "rsvp": {
+                          "version": "3.2.1",
+                          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                        }
+                      }
+                    },
+                    "quick-temp": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        },
+                        "mktemp": {
+                          "version": "0.3.5",
+                          "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "can-symlink": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+                  "dependencies": {
+                    "tmp": {
+                      "version": "0.0.28",
+                      "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+                      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+                      "dependencies": {
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "fast-ordered-set": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                  "dependencies": {
+                    "blank-object": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                    }
+                  }
+                },
+                "fs-tree-diff": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz"
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "dependencies": {
+                    "copy-dereference": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "clone": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz",
+          "dependencies": {
+            "array-equal": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
+            },
+            "blank-object": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+            },
+            "broccoli-plugin": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "dependencies": {
+                "promise-map-series": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "dependencies": {
+                    "rsvp": {
+                      "version": "3.2.1",
+                      "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                    }
+                  }
+                },
+                "quick-temp": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "fast-ordered-set": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+            },
+            "fs-tree-diff": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "path-posix": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "dependencies": {
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                }
+              }
+            },
+            "walk-sync": {
+              "version": "0.2.6",
+              "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+              "dependencies": {
+                "matcher-collection": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
+        "ember-cli-version-checker": {
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        }
+      }
+    },
+    "ember-cli-coffeescript": {
+      "version": "1.13.0",
+      "from": "https://registry.npmjs.org/ember-cli-coffeescript/-/ember-cli-coffeescript-1.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-coffeescript/-/ember-cli-coffeescript-1.13.0.tgz",
+      "dependencies": {
+        "broccoli-coffee": {
+          "version": "0.4.1",
+          "from": "https://registry.npmjs.org/broccoli-coffee/-/broccoli-coffee-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-coffee/-/broccoli-coffee-0.4.1.tgz",
+          "dependencies": {
+            "coffee-script": {
+              "version": "1.9.3",
+              "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.3.tgz",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.3.tgz"
+            }
+          }
+        },
+        "broccoli-filter": {
+          "version": "0.1.14",
+          "from": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
+          "dependencies": {
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.9",
+              "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-writer": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "promise-map-series": {
+              "version": "0.2.2",
+              "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+            },
+            "quick-temp": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.2.1",
+              "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "dependencies": {
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                }
+              }
+            },
+            "walk-sync": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "coffeelint": {
+          "version": "1.15.0",
+          "from": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.15.0.tgz",
+          "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.15.0.tgz",
+          "dependencies": {
+            "coffee-script": {
+              "version": "1.10.0",
+              "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "resolve": {
+              "version": "0.6.3",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "0.11.1",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.11.1.tgz",
+          "dependencies": {
+            "ncp": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "jsonfile": {
+              "version": "2.2.3",
+              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ignore": {
+          "version": "2.2.19",
+          "from": "https://registry.npmjs.org/ignore/-/ignore-2.2.19.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-2.2.19.tgz"
+        },
+        "inflection": {
+          "version": "1.8.0",
+          "from": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz"
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        }
+      }
+    },
+    "ember-cli-content-security-policy": {
+      "version": "0.4.0",
+      "from": "https://registry.npmjs.org/ember-cli-content-security-policy/-/ember-cli-content-security-policy-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-content-security-policy/-/ember-cli-content-security-policy-0.4.0.tgz",
+      "dependencies": {
+        "body-parser": {
+          "version": "1.15.0",
+          "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
+          "dependencies": {
+            "bytes": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+            },
+            "content-type": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+            },
+            "http-errors": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                }
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.13",
+              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "6.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
+            },
+            "raw-body": {
+              "version": "2.1.6",
+              "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz",
+              "dependencies": {
+                "bytes": {
+                  "version": "2.3.0",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+                },
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.6.12",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.10",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.22.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-dependency-checker": {
+      "version": "1.2.0",
+      "from": "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-1.2.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "is-git-url": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/is-git-url/-/is-git-url-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-0.2.0.tgz"
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        }
+      }
+    },
+    "ember-cli-deprecation-workflow": {
+      "version": "0.1.4",
+      "from": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-0.1.4.tgz",
+      "dependencies": {
+        "ember-debug-handlers-polyfill": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.0.3.tgz"
+        },
+        "exists-sync": {
+          "version": "0.0.3",
+          "from": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz"
+        }
+      }
+    },
+    "ember-cli-font-awesome": {
+      "version": "0.0.9",
+      "from": "https://registry.npmjs.org/ember-cli-font-awesome/-/ember-cli-font-awesome-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-font-awesome/-/ember-cli-font-awesome-0.0.9.tgz",
+      "dependencies": {
+        "font-awesome": {
+          "version": "4.3.0",
+          "from": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.3.0.tgz"
+        }
+      }
+    },
+    "ember-cli-htmlbars": {
+      "version": "1.0.3",
+      "from": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-1.0.3.tgz",
+      "dependencies": {
+        "broccoli-persistent-filter": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+          "dependencies": {
+            "async-disk-cache": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "blank-object": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+            },
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-plugin": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "dependencies": {
+                "quick-temp": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "fs-tree-diff": {
+              "version": "0.4.4",
+              "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+              "dependencies": {
+                "fast-ordered-set": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+                }
+              }
+            },
+            "hash-for-dep": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+              "dependencies": {
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.2.9",
+                  "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.7",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+                }
+              }
+            },
+            "md5-hex": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+              "dependencies": {
+                "md5-o-matic": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "promise-map-series": {
+              "version": "0.2.2",
+              "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+            },
+            "rsvp": {
+              "version": "3.2.1",
+              "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz"
+            },
+            "walk-sync": {
+              "version": "0.2.6",
+              "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+              "dependencies": {
+                "matcher-collection": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "dependencies": {
+            "is-utf8": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-htmlbars-inline-precompile": {
+      "version": "0.3.1",
+      "from": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.3.1.tgz",
+      "dependencies": {
+        "babel-plugin-htmlbars-inline-precompile": {
+          "version": "0.0.5",
+          "from": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.0.5.tgz"
+        }
+      }
+    },
+    "ember-cli-ic-ajax": {
+      "version": "0.2.4",
+      "from": "https://registry.npmjs.org/ember-cli-ic-ajax/-/ember-cli-ic-ajax-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-ic-ajax/-/ember-cli-ic-ajax-0.2.4.tgz",
+      "dependencies": {
+        "ic-ajax": {
+          "version": "2.0.1",
+          "from": "ic-ajax@"
+        }
+      }
+    },
+    "ember-cli-inject-live-reload": {
+      "version": "1.4.0",
+      "from": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.4.0.tgz"
+    },
+    "ember-cli-lazyloader": {
+      "version": "0.0.0",
+      "from": "git+https://ea548e3d06f18f2c5287468e46ae5fe262d3f5ac:x-oauth-basic@github.com/Tahi-project/ember-cli-lazyloader.git#06c55594e352c936c4ea072cbfecdeea2f5157de",
+      "resolved": "git+https://ea548e3d06f18f2c5287468e46ae5fe262d3f5ac:x-oauth-basic@github.com/Tahi-project/ember-cli-lazyloader.git#06c55594e352c936c4ea072cbfecdeea2f5157de"
+    },
+    "ember-cli-qunit": {
+      "version": "1.4.0",
+      "from": "https://registry.npmjs.org/ember-cli-qunit/-/ember-cli-qunit-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-qunit/-/ember-cli-qunit-1.4.0.tgz",
+      "dependencies": {
+        "broccoli-babel-transpiler": {
+          "version": "5.5.0",
+          "from": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.5.0.tgz",
+          "dependencies": {
+            "babel-core": {
+              "version": "5.8.38",
+              "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                },
+                "babylon": {
+                  "version": "5.8.38",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz"
+                },
+                "bluebird": {
+                  "version": "2.10.2",
+                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.2.0.tgz"
+                },
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "output-file-sync": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "regenerator": {
+                  "version": "0.8.40",
+                  "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.4",
+                      "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "2.9.0",
+                          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "detective": {
+                          "version": "4.3.1",
+                          "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                            },
+                            "defined": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.3",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.4.1",
+                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+                          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.3",
+                                      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.3",
+                                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.4",
+                              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                            },
+                            "y18n": {
+                              "version": "3.2.1",
+                              "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.7.2",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.43",
+                      "from": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                      "dependencies": {
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "ast-types": {
+                          "version": "0.8.15",
+                          "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                }
+              }
+            },
+            "broccoli-persistent-filter": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "dependencies": {
+                "async-disk-cache": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "blank-object": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                },
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "broccoli-plugin": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "dependencies": {
+                    "quick-temp": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        },
+                        "mktemp": {
+                          "version": "0.3.5",
+                          "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "fs-tree-diff": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "dependencies": {
+                    "fast-ordered-set": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+                    }
+                  }
+                },
+                "hash-for-dep": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "dependencies": {
+                    "broccoli-kitchen-sink-helpers": {
+                      "version": "0.2.9",
+                      "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "md5-hex": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "dependencies": {
+                    "md5-o-matic": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "promise-map-series": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+                },
+                "rsvp": {
+                  "version": "3.2.1",
+                  "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz"
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-funnel": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.1.tgz",
+              "dependencies": {
+                "array-equal": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
+                },
+                "blank-object": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                },
+                "broccoli-plugin": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "dependencies": {
+                    "promise-map-series": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                      "dependencies": {
+                        "rsvp": {
+                          "version": "3.2.1",
+                          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                        }
+                      }
+                    },
+                    "quick-temp": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        },
+                        "mktemp": {
+                          "version": "0.3.5",
+                          "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "fast-ordered-set": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+                },
+                "fs-tree-diff": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.3.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "path-posix": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz"
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "dependencies": {
+                    "copy-dereference": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                    }
+                  }
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "clone": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-jshint": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/broccoli-jshint/-/broccoli-jshint-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-jshint/-/broccoli-jshint-1.2.0.tgz",
+          "dependencies": {
+            "broccoli-persistent-filter": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.2.0.tgz",
+              "dependencies": {
+                "async-disk-cache": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.0.3.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "blank-object": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                },
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "broccoli-plugin": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+                  "dependencies": {
+                    "quick-temp": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        },
+                        "mktemp": {
+                          "version": "0.3.5",
+                          "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "fs-tree-diff": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+                  "dependencies": {
+                    "fast-ordered-set": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz"
+                    }
+                  }
+                },
+                "hash-for-dep": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.0.2.tgz",
+                  "dependencies": {
+                    "broccoli-kitchen-sink-helpers": {
+                      "version": "0.2.9",
+                      "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "md5-hex": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.1.tgz",
+                  "dependencies": {
+                    "md5-o-matic": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "promise-map-series": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+                },
+                "rsvp": {
+                  "version": "3.2.1",
+                  "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz"
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "findup-sync": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "jshint": {
+              "version": "2.9.1",
+              "from": "https://registry.npmjs.org/jshint/-/jshint-2.9.1.tgz",
+              "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.1.tgz",
+              "dependencies": {
+                "cli": {
+                  "version": "0.6.6",
+                  "from": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                },
+                "htmlparser2": {
+                  "version": "3.8.3",
+                  "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                  "dependencies": {
+                    "domhandler": {
+                      "version": "2.3.0",
+                      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                    },
+                    "domutils": {
+                      "version": "1.5.1",
+                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "dependencies": {
+                        "dom-serializer": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                            },
+                            "entities": {
+                              "version": "1.1.1",
+                              "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shelljs": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                },
+                "lodash": {
+                  "version": "3.7.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+                }
+              }
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.4.2",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.4.2.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz",
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.2.1.tgz",
+              "dependencies": {
+                "promise-map-series": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "dependencies": {
+                    "rsvp": {
+                      "version": "3.2.1",
+                      "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                    }
+                  }
+                },
+                "quick-temp": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "can-symlink": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+              "dependencies": {
+                "tmp": {
+                  "version": "0.0.28",
+                  "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+                  "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "fast-ordered-set": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.2.tgz",
+              "dependencies": {
+                "blank-object": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.1.tgz"
+                }
+              }
+            },
+            "fs-tree-diff": {
+              "version": "0.4.4",
+              "from": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "dependencies": {
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-concat": {
+          "version": "2.2.0",
+          "from": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-2.2.0.tgz",
+          "dependencies": {
+            "broccoli-caching-writer": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "dependencies": {
+                "broccoli-plugin": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
+                  "dependencies": {
+                    "promise-map-series": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+                    },
+                    "quick-temp": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        },
+                        "mktemp": {
+                          "version": "0.3.5",
+                          "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "lodash.assign": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.8",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rsvp": {
+                  "version": "3.2.1",
+                  "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "dependencies": {
+                    "copy-dereference": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                    }
+                  }
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.9",
+              "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fast-sourcemap-concat": {
+              "version": "0.2.7",
+              "from": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-0.2.7.tgz",
+              "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-0.2.7.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "rsvp": {
+                  "version": "3.2.1",
+                  "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "source-map-url": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+                }
+              }
+            },
+            "lodash.merge": {
+              "version": "4.3.2",
+              "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.3.2.tgz",
+              "dependencies": {
+                "lodash._baseclone": {
+                  "version": "4.5.3",
+                  "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-4.5.3.tgz"
+                },
+                "lodash._stack": {
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/lodash._stack/-/lodash._stack-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._stack/-/lodash._stack-4.1.1.tgz"
+                },
+                "lodash.isplainobject": {
+                  "version": "4.0.3",
+                  "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.3.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "4.1.3",
+                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-4.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-4.1.3.tgz"
+                },
+                "lodash.rest": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz"
+                }
+              }
+            },
+            "lodash.omit": {
+              "version": "4.1.0",
+              "from": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.1.0.tgz",
+              "dependencies": {
+                "lodash._basedifference": {
+                  "version": "4.4.0",
+                  "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-4.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-4.4.0.tgz",
+                  "dependencies": {
+                    "lodash._setcache": {
+                      "version": "4.1.1",
+                      "from": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.1.tgz"
+                    }
+                  }
+                },
+                "lodash._baseflatten": {
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-4.1.1.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "4.1.3",
+                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-4.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-4.1.3.tgz"
+                },
+                "lodash.rest": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.rest/-/lodash.rest-4.0.1.tgz"
+                }
+              }
+            },
+            "lodash.uniq": {
+              "version": "4.2.0",
+              "from": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.2.0.tgz",
+              "dependencies": {
+                "lodash._baseuniq": {
+                  "version": "4.5.0",
+                  "from": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.5.0.tgz",
+                  "dependencies": {
+                    "lodash._createset": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.1.tgz"
+                    },
+                    "lodash._setcache": {
+                      "version": "4.1.1",
+                      "from": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._setcache/-/lodash._setcache-4.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            }
+          }
+        },
+        "ember-qunit": {
+          "version": "0.4.20",
+          "from": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-0.4.20.tgz",
+          "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-0.4.20.tgz",
+          "dependencies": {
+            "ember-test-helpers": {
+              "version": "0.5.22",
+              "from": "https://registry.npmjs.org/ember-test-helpers/-/ember-test-helpers-0.5.22.tgz",
+              "resolved": "https://registry.npmjs.org/ember-test-helpers/-/ember-test-helpers-0.5.22.tgz",
+              "dependencies": {
+                "klassy": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/klassy/-/klassy-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/klassy/-/klassy-0.1.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "qunitjs": {
+          "version": "1.22.0",
+          "from": "https://registry.npmjs.org/qunitjs/-/qunitjs-1.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-1.22.0.tgz"
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        }
+      }
+    },
+    "ember-cli-rails-addon": {
+      "version": "0.7.0",
+      "from": "https://registry.npmjs.org/ember-cli-rails-addon/-/ember-cli-rails-addon-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-rails-addon/-/ember-cli-rails-addon-0.7.0.tgz"
+    },
+    "ember-cli-release": {
+      "version": "0.2.8",
+      "from": "https://registry.npmjs.org/ember-cli-release/-/ember-cli-release-0.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-release/-/ember-cli-release-0.2.8.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "git-tools": {
+          "version": "0.1.4",
+          "from": "https://registry.npmjs.org/git-tools/-/git-tools-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/git-tools/-/git-tools-0.1.4.tgz",
+          "dependencies": {
+            "spawnback": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/spawnback/-/spawnback-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/spawnback/-/spawnback-1.0.0.tgz"
+            }
+          }
+        },
+        "make-array": {
+          "version": "0.1.2",
+          "from": "https://registry.npmjs.org/make-array/-/make-array-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/make-array/-/make-array-0.1.2.tgz"
+        },
+        "merge": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+        },
+        "moment-timezone": {
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.3.1.tgz",
+          "dependencies": {
+            "moment": {
+              "version": "2.12.0",
+              "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.2.1",
+          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+        },
+        "semver": {
+          "version": "4.3.6",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        },
+        "silent-error": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/silent-error/-/silent-error-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.0.0.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-sri": {
+      "version": "1.2.1",
+      "from": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-1.2.1.tgz",
+      "dependencies": {
+        "broccoli-sri-hash": {
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-sri-hash/-/broccoli-sri-hash-1.2.2.tgz",
+          "dependencies": {
+            "broccoli-caching-writer": {
+              "version": "2.2.1",
+              "from": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.2.1.tgz",
+              "dependencies": {
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.2.9",
+                  "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "broccoli-plugin": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
+                  "dependencies": {
+                    "promise-map-series": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+                    },
+                    "quick-temp": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        },
+                        "mktemp": {
+                          "version": "0.3.5",
+                          "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                        },
+                        "underscore.string": {
+                          "version": "2.3.3",
+                          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "lodash.assign": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.8",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "walk-sync": {
+                  "version": "0.2.6",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.6.tgz",
+                  "dependencies": {
+                    "matcher-collection": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.1.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.2.1",
+              "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+            },
+            "sri-toolbox": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/sri-toolbox/-/sri-toolbox-0.2.0.tgz"
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "dependencies": {
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-concurrency": {
+      "version": "0.5.17",
+      "from": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-0.5.17.tgz",
+      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-0.5.17.tgz"
+    },
+    "ember-data": {
+      "version": "1.0.0-beta.18",
+      "from": "https://registry.npmjs.org/ember-data/-/ember-data-1.0.0-beta.18.tgz",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-1.0.0-beta.18.tgz",
+      "dependencies": {
+        "github": {
+          "version": "0.2.4",
+          "from": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+          "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+          "dependencies": {
+            "mime": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.2.1",
+          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+        }
+      }
+    },
+    "ember-data-factory-guy": {
+      "version": "1.0.7",
+      "from": "https://registry.npmjs.org/ember-data-factory-guy/-/ember-data-factory-guy-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/ember-data-factory-guy/-/ember-data-factory-guy-1.0.7.tgz"
+    },
+    "ember-disable-proxy-controllers": {
+      "version": "1.0.1",
+      "from": "https://registry.npmjs.org/ember-disable-proxy-controllers/-/ember-disable-proxy-controllers-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ember-disable-proxy-controllers/-/ember-disable-proxy-controllers-1.0.1.tgz"
+    },
+    "ember-export-application-global": {
+      "version": "1.0.5",
+      "from": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-1.0.5.tgz"
+    },
+    "ember-getowner-polyfill": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-1.0.0.tgz"
+    },
+    "ember-hash-helper-polyfill": {
+      "version": "0.1.0",
+      "from": "https://registry.npmjs.org/ember-hash-helper-polyfill/-/ember-hash-helper-polyfill-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-hash-helper-polyfill/-/ember-hash-helper-polyfill-0.1.0.tgz",
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-power-select": {
+      "version": "0.7.2",
+      "from": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-0.7.2.tgz",
+      "dependencies": {
+        "ember-basic-dropdown": {
+          "version": "0.7.3",
+          "from": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-0.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-0.7.3.tgz"
+        }
+      }
+    },
+    "ember-truth-helpers": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-1.0.0.tgz"
+    },
+    "ember-wormhole": {
+      "version": "0.3.4",
+      "from": "https://registry.npmjs.org/ember-wormhole/-/ember-wormhole-0.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/ember-wormhole/-/ember-wormhole-0.3.4.tgz"
+    },
+    "express": {
+      "version": "4.13.4",
+      "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+      "dependencies": {
+        "accepts": {
+          "version": "1.2.13",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.1.10",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                }
+              }
+            },
+            "negotiator": {
+              "version": "0.5.3",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+            }
+          }
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+        },
+        "content-type": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+        },
+        "cookie": {
+          "version": "0.1.5",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+        },
+        "etag": {
+          "version": "1.7.0",
+          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+        },
+        "finalhandler": {
+          "version": "0.4.1",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+          "dependencies": {
+            "unpipe": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+            }
+          }
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+        },
+        "methods": {
+          "version": "1.1.2",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+            }
+          }
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+        },
+        "proxy-addr": {
+          "version": "1.0.10",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+          "dependencies": {
+            "forwarded": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+            },
+            "ipaddr.js": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "4.0.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+        },
+        "range-parser": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+        },
+        "send": {
+          "version": "0.13.1",
+          "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+          "dependencies": {
+            "destroy": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "ms": {
+              "version": "0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            },
+            "statuses": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.10.2",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+        },
+        "type-is": {
+          "version": "1.6.12",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.10",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        },
+        "vary": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+        }
+      }
+    },
+    "glob": {
+      "version": "4.5.3",
+      "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "dependencies": {
+        "inflight": {
+          "version": "1.0.4",
+          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "liquid-fire": {
+      "version": "0.21.2",
+      "from": "https://registry.npmjs.org/liquid-fire/-/liquid-fire-0.21.2.tgz",
+      "resolved": "https://registry.npmjs.org/liquid-fire/-/liquid-fire-0.21.2.tgz",
+      "dependencies": {
+        "broccoli-static-compiler": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/broccoli-static-compiler/-/broccoli-static-compiler-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/broccoli-static-compiler/-/broccoli-static-compiler-0.2.2.tgz",
+          "dependencies": {
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.9",
+              "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-writer": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+              "dependencies": {
+                "quick-temp": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "rsvp": {
+                  "version": "3.2.1",
+                  "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "dependencies": {
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ember-cli-htmlbars": {
+          "version": "0.7.6",
+          "from": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-0.7.6.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-0.7.6.tgz",
+          "dependencies": {
+            "broccoli-filter": {
+              "version": "0.1.14",
+              "from": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
+              "dependencies": {
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.2.9",
+                  "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "broccoli-writer": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "promise-map-series": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.2.tgz"
+                },
+                "quick-temp": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.5.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "rsvp": {
+                  "version": "3.2.1",
+                  "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz"
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "dependencies": {
+                    "copy-dereference": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                    }
+                  }
+                },
+                "walk-sync": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.1.6.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            }
+          }
+        },
+        "velocity-animate": {
+          "version": "1.2.3",
+          "from": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.2.3.tgz",
+          "dependencies": {
+            "jquery": {
+              "version": "2.2.2",
+              "from": "https://registry.npmjs.org/jquery/-/jquery-2.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.2.tgz"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
For production, we should use npm shrinkwrap to lock down our node dependencies.

npm shrinkwrap is like the `Gemfile.lock`, except bolted on, so more trouble.

To generated this, I ran `npm run clean` and then ran `npm shrinkwrap` in the `client/` directory and checked in the generated file. This means we should have the most up-to-date dependencies.

I believe that this should "just work" going forward for `npm install`. That is, `npm install` should install the exact versions locked down in the `npm-shrinkwrap.json` file.

Things get trickier if you want to add or upgrade an npm package. It should be possible to run:

```
ember install --save package@version
npm shrinkwrap
```

but, this being node, I can't guarantee that will actually work.

@slimeate I know you have dealt with this before. Are we on the right track here? Also @nummi @Bestra 
