### PR TITLE
APERTA-6344 Revert "Updating the Assign Team card to not show the trash icon if t…

### DIFF
--- a/engines/tahi-assign_team/client/app/templates/components/assign-team-task.hbs
+++ b/engines/tahi-assign_team/client/app/templates/components/assign-team-task.hbs
@@ -43,9 +43,7 @@
             <td><span class="assignee-full-name">{{assignment.user.name}}</span> has been assigned as {{assignment.role.name}}</td>
             <td><span class="assignment-updated-at">{{format-date assignment.createdAt format="LLL"}}</span></td>
             <td><span class="assignment-state">Assigned</span></td>
-            {{#if isEditable}}
-              <td><span class="fa fa-trash assignment-remove" {{action "destroyAssignment" assignment}}></span></td>
-            {{/if}}
+            <td><span class="fa fa-trash assignment-remove" {{action "destroyAssignment" assignment}}></span></td>
           </tr>
         {{/each}}
       </tbody>


### PR DESCRIPTION
JIRA issue: [APERTA-6344](https://developer.plos.org/jira/browse/APERTA-6344)
#### What this PR does:

This removes the removal of the remove icon for assignments on the Assign Team card
#### Notes

This is based on conversation during triage with James and Glenn. The editability of the paper or task should not affect the ability to remove assignments.
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
  …he task is not editable."
