### PR TITLE
APERTA-6360 Update the welcome reviewer email with the manuscript link

### DIFF
--- a/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
+++ b/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
@@ -34,9 +34,8 @@ module TahiStandardTasks
       mail(to: @assigner.email, subject: "Reviewer invitation was declined on the manuscript, \"#{@paper.display_title}\"")
     end
 
-    def welcome_reviewer(assignee_id:, task_id:)
-      @task = Task.find(task_id)
-      @paper = @task.paper
+    def welcome_reviewer(assignee_id:, paper_id:)
+      @paper = Paper.find(paper_id)
       @journal = @paper.journal
       assignee = User.find_by(id: assignee_id)
       @assignee_name = display_name(assignee)

--- a/engines/tahi_standard_tasks/app/services/reviewer_report_task_creator.rb
+++ b/engines/tahi_standard_tasks/app/services/reviewer_report_task_creator.rb
@@ -34,7 +34,7 @@ class ReviewerReportTaskCreator
       ParticipationFactory.create(task: task, assignee: assignee, notify: false)
       TahiStandardTasks::ReviewerMailer
         .delay.welcome_reviewer(assignee_id: assignee.id,
-                                task_id: task.id)
+                                paper_id: paper.id)
     else
       existing_reviewer_report_task.incomplete!
     end

--- a/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/reviewer_mailer/welcome_reviewer.html.erb
+++ b/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/reviewer_mailer/welcome_reviewer.html.erb
@@ -23,7 +23,7 @@
     </p>
     <div class='paper-abstract'>
       You can access the manuscript and your reviewer report here:
-        <%= link_to client_paper_task_url(@task.paper, @task), client_paper_task_url(@task.paper, @task) %>
+        <%= link_to client_paper_url(@paper), client_paper_url(@paper) %>
     </div>
   </div>
   <hr>

--- a/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/reviewer_report_mailer/notify_academic_editor_email.html.erb
+++ b/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/reviewer_report_mailer/notify_academic_editor_email.html.erb
@@ -17,7 +17,7 @@
       A review of "<%= @paper.display_title(sanitized: false) %>" has been completed.
   </div>
   <div class='footer'>
-    <a class='button' href='<%= client_paper_url(@paper) %>' target='_blank'>
+    <a class='button' href='<%= client_paper_task_url(@paper, @task) %>' target='_blank'>
       View Reviewer Report in <%= app_name %>
     </a>
     <div class='signature'>

--- a/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/reviewer_report_mailer_spec.rb
+++ b/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/reviewer_report_mailer_spec.rb
@@ -58,7 +58,7 @@ describe TahiStandardTasks::ReviewerReportMailer do
     end
 
     it "contains link to the paper" do
-      expect(email.body).to match(%r{\/papers\/#{paper.id}\/})
+      expect(email.body).to match(%r{\/papers\/#{paper.id}\/tasks\/#{task.id}})
     end
 
     it "contains the paper title" do


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6360
#### What this PR does:

This undoes the changes to the mailer that notified the AE of whether a reviewer accepted and updates the correct mailer: welcome_reviewer with the correct link.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
