### PR TITLE
APERTA-6466 Store data that is sent to putUpdate so that it stores wi…

### DIFF
--- a/client/app/services/restless.js
+++ b/client/app/services/restless.js
@@ -50,7 +50,7 @@ export default Ember.Service.extend({
   },
 
   putUpdate(model, path, data) {
-    return this.putModel(model, path).then(function(response) {
+    return this.putModel(model, path, data).then(function(response) {
       return model.get('store').pushPayload(response);
     }, function(xhr) {
       let errors, modelErrors;


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6446
#### What this PR does:

We used to store the withdrawal reason but somehow it disappeared.  This PR brings it back.
#### Notes

This just restores the behavior that was pre-existing. I think it may be a greater question how to deal with `restless` in general that is sprinkled throughout our app. Maybe after Ember data is upgraded?

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
  …thdrawal reason
