### PR TITLE
BUGFIX: fix flaky user spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -227,8 +227,10 @@ describe User do
 
   describe "#create" do
     let(:user) { User.create! attributes_for(:user) }
+    let!(:user_role) { Role.where(name: 'User').first_or_create! }
 
     it "should create a user record with the User role assigned" do
+      expect(user_role).to be_present
       expect(user).to have_role_name 'User'
     end
   end


### PR DESCRIPTION
JIRA issue: N/A
#### What this PR does:

A `user_spec.rb` spec was dependent on a 'User' role record being present in the DB, but it appears it was getting nuked by `authorizations/interface_spec.rb`. When that spec ran before `user_spec.rb`, `user_spec.rb` would fail.

This PR ensures that the user role exists.
#### Notes

This was the first time I used `rspec --bisect` and it was awesome! This is what it found:

```
The minimal reproduction command is:
  rspec './spec/authorizations/interface_spec.rb[1:1:4]' './spec/models/user_spec.rb[1:12:1]' --format documentation --seed 25240
```
#### Major UI changes

None

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
