### PR TITLE
Add lines to apex export

### DIFF
--- a/app/serializers/typesetter/metadata_serializer.rb
+++ b/app/serializers/typesetter/metadata_serializer.rb
@@ -3,7 +3,7 @@ module Typesetter
   # Expects a paper as its object to serialize.
   class MetadataSerializer < Typesetter::TaskAnswerSerializer
     attributes :short_title, :doi, :manuscript_id, :paper_type, :journal_title,
-               :publication_date
+               :publication_date, :provenance, :special_handling_instructions
     attribute :first_submitted_at, key: :received_date
     attribute :accepted_at, key: :accepted_date
     attribute :title, key: :paper_title
@@ -29,6 +29,16 @@ module Typesetter
       pub_date = production_metadata.publication_date
       return unless pub_date
       Date.strptime(pub_date, '%m/%d/%Y')
+    end
+
+    def provenance
+      production_metadata = task('TahiStandardTasks::ProductionMetadataTask')
+      production_metadata.provenance || ''
+    end
+
+    def special_handling_instructions
+      production_metadata = task('TahiStandardTasks::ProductionMetadataTask')
+      production_metadata.special_handling_instructions || ''
     end
 
     def supporting_information_files

--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/production_metadata_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/production_metadata_task.rb
@@ -22,6 +22,15 @@ module TahiStandardTasks
       answer_for("production_metadata--publication_date").try(:value)
     end
 
+    def provenance
+      answer_for("production_metadata--provenance").try(:value)
+    end
+
+    def special_handling_instructions
+      answer_for("production_metadata--special_handling_instructions")
+        .try(:value)
+    end
+
     def volume_number
       answer_for("production_metadata--volume_number").try(:value)
     end


### PR DESCRIPTION
#### What this PR does:

add-lines-to-apex-export

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
