### PR TITLE
APERTA-6601 Update data availability policy and add another question

### DIFF
--- a/db/data.yml
+++ b/db/data.yml
@@ -6159,7 +6159,7 @@ nested_questions:
     - '128'
     - '28'
     - '2015-10-29 20:16:38.519496'
-    - '2016-03-29 20:28:06.951832'
+    - '2016-04-18 23:09:30.406641'
     - PlosBilling::BillingTask
     - 
   - - '90'
@@ -7627,9 +7627,9 @@ nested_questions:
     - 
     - '199'
     - '200'
-    - '4'
+    - '3'
     - '2015-10-30 19:51:03.473215'
-    - '2016-03-10 19:55:38.108421'
+    - '2016-04-18 23:09:30.454792'
     - TahiStandardTasks::ProductionMetadataTask
     - 
   - - '235'
@@ -7639,10 +7639,37 @@ nested_questions:
     - 
     - '199'
     - '200'
-    - '4'
+    - '5'
     - '2015-10-30 19:51:03.473215'
-    - '2016-03-10 19:55:38.108421'
+    - '2016-04-18 23:09:30.476549'
     - TahiStandardTasks::ProductionMetadataTask
+    - 
+  - - '236'
+    - Tick here if the URLs/accession numbers/DOIs will be available only after acceptance
+      of the manuscript for publication so that we can ensure their inclusion before
+      publication.
+    - boolean
+    - data_availability--additional_information_doi
+    - 
+    - '363'
+    - '364'
+    - '3'
+    - '2016-04-18 23:09:30.193042'
+    - '2016-04-18 23:09:30.193042'
+    - TahiStandardTasks::DataAvailabilityTask
+    - 
+  - - '237'
+    - Tick here if your circumstances are not covered by the questions above and you
+      need the journal’s help to make your data available.
+    - boolean
+    - data_availability--additional_information_other
+    - 
+    - '365'
+    - '366'
+    - '4'
+    - '2016-04-18 23:09:30.20367'
+    - '2016-04-18 23:09:30.20367'
+    - TahiStandardTasks::DataAvailabilityTask
     - 
 
 ---

--- a/engines/tahi_standard_tasks/client/app/templates/components/data-availability-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/data-availability-task.hbs
@@ -1,6 +1,13 @@
 {{partial "task-completed-section"}}
 
 <div class="task-main-content">
+  <p>
+ PLOS journals require authors to make all data underlying the findings described in their manuscript fully available, without restriction and from the time of publication, with only rare exceptions to address legal and ethical concerns (see the PLOS Data Policy and FAQ for further details). When submitting a manuscript, authors must provide a Data Availability Statement that describes where the data underlying their manuscript can be found.
+  </p>
+  <p>
+  Your answers to the following constitute your statement about data availability and will be included with the article in the event of publication. Please note that simply stating ‘data available on request from the author’ is not acceptable. If, however, your data are only available upon request from the author(s), you must answer “No” to the first question below, and explain your exceptional situation in the text box provided.
+  </p>
+
   <ol class="question-list">
     <li class="question">
       {{nested-question-radio
@@ -12,7 +19,6 @@
 
     <li class="question">
       <div class="question-text">
-        {{dataLocationQuestion.text}}
         Your answers should be entered into the box below and will be published in the form you provide them, if your manuscript is accepted. If you are copying our sample text below, please ensure you replace any instances of XXX with the appropriate details.</div>
       <ul class="question-help">
         <li class="item">
@@ -39,6 +45,19 @@
             displayQuestionText=false
             disabled=isNotEditable}}
       </div>
+    </li>
+    <li class="question">
+      <div class="question-text">
+        Additional Data Availability information
+      </div>
+    {{nested-question-check ident="data_availability--additional_information_doi"
+                            owner=task
+                            disabled=isNotEditable
+    }}
+    {{nested-question-check ident="data_availability--additional_information_other"
+                            owner=task
+                            disabled=isNotEditable
+    }}
     </li>
   </ol>
 </div>

--- a/lib/tasks/nested-questions/data_availability_task.rake
+++ b/lib/tasks/nested-questions/data_availability_task.rake
@@ -17,6 +17,22 @@ namespace 'nested-questions:seed' do
       text: "Please describe where your data may be found, writing in full sentences.",
       position: 2
     }
+    questions << {
+      owner_id: nil,
+      owner_type: TahiStandardTasks::DataAvailabilityTask.name,
+      ident: "data_availability--additional_information_doi",
+      value_type: "boolean",
+      text: "Tick here if the URLs/accession numbers/DOIs will be available only after acceptance of the manuscript for publication so that we can ensure their inclusion before publication.",
+      position: 3
+    }
+    questions << {
+      owner_id: nil,
+      owner_type: TahiStandardTasks::DataAvailabilityTask.name,
+      ident: "data_availability--additional_information_other",
+      value_type: "boolean",
+      text: "Tick here if your circumstances are not covered by the questions above and you need the journal’s help to make your data available.",
+      position: 4
+    }
 
     NestedQuestion.where(
       owner_type: TahiStandardTasks::DataAvailabilityTask.name


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6601
#### What this PR does:

This updates the Data Availability Policy per the critical Jira ticket 6601. It also adds some checkboxes for the card.
#### Major UI changes

@jgray-PLOS This adds two checkboxes for the Data Availability Card per the Jira ACs.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
