### PR TITLE
APERTA-6601 Indent bullet points for data-availability

### DIFF
--- a/app/assets/stylesheets/overlays/_base.scss
+++ b/app/assets/stylesheets/overlays/_base.scss
@@ -2,6 +2,7 @@
 @import 'ad-hoc-task-overlay';
 @import 'card-delete-overlay';
 @import 'collaborators_overlay';
+@import 'data_availability_overlay';
 @import 'edit_task_types_overlay';
 @import 'feedback_overlay';
 @import 'invite_reviewers_overlay';

--- a/app/assets/stylesheets/overlays/_data_availability_overlay.scss
+++ b/app/assets/stylesheets/overlays/_data_availability_overlay.scss
@@ -1,0 +1,3 @@
+.left-indent {
+  margin-left: 20px;
+}

--- a/engines/tahi_standard_tasks/client/app/templates/components/data-availability-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/data-availability-task.hbs
@@ -25,16 +25,16 @@
           If your data are all contained within the paper and/or Supporting Information files, please state this in your answer below. For example, "All relevant data are within the paper and its Supporting Information files."
         </li>
 
-        <li class="item">
+        <li class="item left-indent">
           If your data are held or will be held in a public repository, include URLs, accession numbers or DOIs. For example, "All XXX files are available from the XXX database (accession number(s) XXX, XXX)." If this information will only be available after acceptance, please indicate this by ticking the box below.
         </li>
 
-        <li class="item">
+        <li class="item left-indent">
            If neither of these applies but you are able to provide details of access elsewhere, with or without limitations, please do so in the box below. For example:
            <br />
           "Data are available from the XXX Institutional Data Access / Ethics Committee for researchers who meet the criteria for access to confidential data."
         </li>
-        <li class="item">
+        <li class="item left-indent">
           "Data are from the XXX study whose authors may be contacted at XXX."
         </li>
       </ul>


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6601
#### What this PR does:

Moves the indentation right a little bit.
<img width="644" alt="screen shot 2016-04-19 at 2 33 59 pm" src="https://cloud.githubusercontent.com/assets/4078758/14656328/d1357032-063b-11e6-88cf-c98f1ea90f0f.png">

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
