### PR TITLE
APERTA-6708 Update email subjects to use journal name

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -66,7 +66,7 @@ class UserMailer < ActionMailer::Base
 
     mail(
       to: @commentee.try(:email),
-      subject: "You've been mentioned on the manuscript, #{app_name}")
+      subject: "You've been mentioned on the manuscript, \"#{@paper.display_title}\"")
   end
 
   def notify_creator_of_paper_submission(paper_id)
@@ -76,7 +76,7 @@ class UserMailer < ActionMailer::Base
 
     mail(
       to: @author.try(:email),
-      subject: "Thank you for submitting your manuscript to PLOS #{app_name}")
+      subject: "Thank you for submitting your manuscript to #{@journal.name}")
   end
 
   def notify_admin_of_paper_submission(paper_id, user_id)

--- a/engines/plos_bio_tech_check/app/mailers/plos_bio_tech_check/changes_for_author_mailer.rb
+++ b/engines/plos_bio_tech_check/app/mailers/plos_bio_tech_check/changes_for_author_mailer.rb
@@ -14,7 +14,7 @@ module PlosBioTechCheck
       @journal = @paper.journal
 
       mail(to: @author.email,
-           subject: "Changes needed on your Manuscript in #{app_name}")
+           subject: "Changes needed on your Manuscript in #{@journal.name}")
     end
 
     def notify_paper_tech_fixed admin_id:, paper_id:

--- a/engines/plos_bio_tech_check/app/views/plos_bio_tech_check/changes_for_author_mailer/notify_changes_for_author.html.erb
+++ b/engines/plos_bio_tech_check/app/views/plos_bio_tech_check/changes_for_author_mailer/notify_changes_for_author.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="greeting">
     <p class="message">
-      Changes are needed on your Manuscript in Aperta
+      Changes are needed on your Manuscript in <%= @journal.name %>
     </p>
   </div>
   <hr>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -128,7 +128,7 @@ describe UserMailer, redis: true do
     it_behaves_like "recipient without email address"
 
     it 'has correct subject line' do
-      expect(email.subject).to eq "You've been mentioned on the manuscript, #{app_name}"
+      expect(email.subject).to eq "You've been mentioned on the manuscript, \"#{task.paper.display_title}\""
     end
 
     it 'sends the email to the mentioned user' do
@@ -152,7 +152,7 @@ describe UserMailer, redis: true do
     let(:email) { UserMailer.notify_creator_of_paper_submission(paper.id) }
 
     it 'has correct subject line' do
-      expect(email.subject).to eq "Thank you for submitting your manuscript to PLOS #{app_name}"
+      expect(email.subject).to eq "Thank you for submitting your manuscript to #{paper.journal.name}"
     end
 
     it "sends the email to the paper's creator" do
@@ -160,7 +160,7 @@ describe UserMailer, redis: true do
     end
 
     it "emails the creator user they have been mentioned" do
-      expect(email.subject).to eq "Thank you for submitting your manuscript to PLOS #{app_name}"
+      expect(email.subject).to eq "Thank you for submitting your manuscript to #{paper.journal.name}"
       expect(email.body).to include "Thank you for submitting your manuscript"
       expect(email.body).to include paper.title
       expect(email.body).to include paper.journal.name


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6708
#### What this PR does:

Email subject lines shouldn't refer to PLOS Aperta, it ought to be plus biology instead.
can we change the message to the author at submission
"Thank you for submitting your manuscript to PLOS Aperta" to "Thank you for submitting your manuscript to PLOS Biology"
and
"Changes needed on your Manuscript in Aperta" to "Changes needed on your Manuscript in PLOS Biology" . Make sure this covers, ITC, RTC, FTC
using journal name variable would be best.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
