### PR TITLE
bugfix/APERTA-6669 last_doi_issued getting out-of-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 
 ### Fixed
 - Ensure that cards created after paper creation have the correct permissions
+- Ensure new papers receive a properly incremented DOI
 
 ### Security
 

--- a/app/controllers/admin/journals_controller.rb
+++ b/app/controllers/admin/journals_controller.rb
@@ -73,7 +73,7 @@ class Admin::JournalsController < ApplicationController
     params.require(:admin_journal).permit(
       :description, :doi_journal_prefix,
       :doi_publisher_prefix, :epub_cover,
-      :epub_css, :last_doi_issued,
+      :epub_css, :first_doi_number,
       :manuscript_css, :name,
       :pdf_css
     )

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -49,6 +49,7 @@ class Paper < ActiveRecord::Base
 
   serialize :withdrawals, ArrayHashSerializer
 
+  validates :doi, presence: true, uniqueness: true
   validates :paper_type, presence: true
   validates :journal, presence: true
   validates :title, presence: true
@@ -71,7 +72,6 @@ class Paper < ActiveRecord::Base
     doi.split('/').last if doi
   end
 
-  after_create :assign_doi!
   after_create :create_versioned_texts
   after_commit :state_transition_notifications
 
@@ -489,10 +489,6 @@ class Paper < ActiveRecord::Base
   def set_submitting_user_and_touch!(submitting_user) # rubocop:disable Style/AccessorMethodName
     latest_version.update!(submitting_user: submitting_user)
     latest_version.touch
-  end
-
-  def assign_doi!
-    self.update!(doi: DoiService.new(journal: journal).next_doi!) if journal
   end
 
   def create_versioned_texts

--- a/app/serializers/admin_journal_serializer.rb
+++ b/app/serializers/admin_journal_serializer.rb
@@ -11,7 +11,7 @@ class AdminJournalSerializer < ActiveModel::Serializer
              :description,
              :doi_publisher_prefix,
              :doi_journal_prefix,
-             :last_doi_issued,
+             :first_doi_number,
              :paper_count,
              :created_at
   has_many :manuscript_manager_templates, embed: :ids, include: true

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -8,12 +8,8 @@ class DoiService
   SUFFIX_FORMAT           = %r{[^\/]+}
   DOI_FORMAT              = %r{\A(#{PUBLISHER_PREFIX_FORMAT}/#{SUFFIX_FORMAT})\z}
 
-  attr_reader :journal
-
-  delegate :last_doi_issued,
-           :doi_publisher_prefix,
-           :doi_journal_prefix,
-           to: :journal
+  class DoiLengthChanged < StandardError; end
+  class InvalidJournalDoiConfig < StandardError; end
 
   def initialize(journal:)
     fail ArgumentError, "Journal is required" unless journal.present?
@@ -25,45 +21,50 @@ class DoiService
     !!(doi_string =~ DOI_FORMAT)
   end
 
-  def valid?
-    Doi.valid?(to_s)
-  end
-
-  def assign!
-    return unless journal_doi_enabled?
-    journal.with_lock do
-      journal.update! last_doi_issued: last_doi_issued.succ
-    end
-  end
-
-  def next_doi!
-    if journal_has_doi_prefixes?
-      journal.with_lock do
-        journal.update! last_doi_issued: last_doi_issued.succ
-      end
-      to_s
-    end
-  end
-
-  def to_s
-    [doi_publisher_prefix, suffix].join("/")
-  end
-
   def journal_has_doi_prefixes?
-    doi_publisher_prefix.present? && doi_journal_prefix.present?
+    @journal.doi_publisher_prefix.present? &&
+      @journal.doi_journal_prefix.present?
   end
 
   def journal_doi_info_valid?
-    DoiService.valid?(to_s)
+    DoiService.valid?(first_doi)
+  end
+
+  # The DOI we'll set on the journal's very first paper
+  def first_doi
+    [doi_base, @journal.first_doi_number].join
+  end
+
+  # The highest DOI that matches this journal's DOI base pattern
+  def last_doi
+    papers_with_same_doi_base.order(:doi).last.try(:doi)
+  end
+
+  # The next unassigned DOI for this journal.
+  #
+  # this will raise an error if the maximum DOI has been reached. That is, this
+  # will not allow the DOI to contain a different amount of characters than the
+  # DOI before it, so a jump like 10/pone.99 -> 10/pone.100 is not possible.
+  # In addition to keeping our DOIs from unintentionally growing, this will also
+  # fail early if we lose our leading 0's.
+  def next_doi
+    current_last_doi = last_doi
+    return first_doi unless current_last_doi
+    possible_next_doi = current_last_doi.succ
+    fail DoiLengthChanged if possible_next_doi.length != last_doi.length
+    possible_next_doi
   end
 
   private
 
-  def prefix
-    doi_publisher_prefix
+  # All papers which have a DOI which matches the DOI base pattern of this
+  # journal. The scope is not limited to papers which belong to the journal.
+  def papers_with_same_doi_base
+    Paper.where('doi like ?', "#{doi_base}%")
   end
 
-  def suffix
-    [doi_journal_prefix, last_doi_issued].join(".")
+  # The journal's DOI base pattern--a doi without the sequential document number
+  def doi_base
+    "#{@journal.doi_publisher_prefix}/#{@journal.doi_journal_prefix}."
   end
 end

--- a/app/services/paper_factory.rb
+++ b/app/services/paper_factory.rb
@@ -16,6 +16,7 @@ class PaperFactory
   end
 
   def create
+    paper.doi = DoiService.new(journal: paper.journal).next_doi if paper.journal
     Paper.transaction do
       return unless paper.valid?
         if template

--- a/client/app/models/admin-journal.js
+++ b/client/app/models/admin-journal.js
@@ -15,7 +15,7 @@ export default DS.Model.extend({
   epubCoverFileName: DS.attr('string'),
   epubCoverUrl: DS.attr('string'),
   epubCss: DS.attr('string'),
-  lastDoiIssued: DS.attr('number'),
+  firstDoiNumber: DS.attr('string'),
   logoUrl: DS.attr('string'),
   manuscriptCss: DS.attr('string'),
   name: DS.attr('string'),

--- a/client/app/pods/admin/journal/index/controller.js
+++ b/client/app/pods/admin/journal/index/controller.js
@@ -29,27 +29,27 @@ export default Ember.Controller.extend(ValidationErrorsMixin, {
   },
 
   formattedDOI: Ember.computed(
-    'doiPublisherPrefix', 'doiJournalPrefix', 'lastDoiIssued', function() {
+    'doiPublisherPrefix', 'doiJournalPrefix', 'firstDoiNumber', function() {
       if (this.get('doiInvalid')) { return ''; }
 
       const publisher = this.get('doiPublisherPrefix');
       const journal = this.get('doiJournalPrefix');
-      const start = this.get('lastDoiIssued');
+      const start = this.get('firstDoiNumber');
       const dot = Ember.isEmpty(journal) ? '' : '.';
       return publisher + '/' + journal + dot + start;
     }
   ),
 
-  doiInvalid: Ember.computed('doiPublisherPrefix', 'lastDoiIssued', function() {
+  doiInvalid: Ember.computed('doiPublisherPrefix', 'firstDoiNumber', function() {
     const noPubPrefix = Ember.isEmpty(this.get('doiPublisherPrefix'));
-    const noLastDoi = Ember.isEmpty(this.get('lastDoiIssued'));
+    const noLastDoi = Ember.isEmpty(this.get('firstDoiNumber'));
     const invalid = this.get('doiStartNumberInvalid');
 
     return noPubPrefix || noLastDoi || invalid;
   }),
 
-  doiStartNumberInvalid: Ember.computed('lastDoiIssued', function() {
-    return !$.isNumeric(this.get('lastDoiIssued')) &&
+  doiStartNumberInvalid: Ember.computed('firstDoiNumber', function() {
+    return !$.isNumeric(this.get('firstDoiNumber')) &&
            !Ember.isEmpty(this.get('doiStartNumber'));
   }),
 

--- a/client/app/pods/admin/journal/index/route.js
+++ b/client/app/pods/admin/journal/index/route.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
     this._super(controller, model);
     controller.set(
       'doiStartNumberEditable',
-      Ember.isEmpty(model.get('lastDoiIssued'))
+      Ember.isEmpty(model.get('firstDoiNumber'))
     );
     this.fetchAdminJournalUsers(model.get('id'));
   },

--- a/client/app/pods/admin/journal/index/template.hbs
+++ b/client/app/pods/admin/journal/index/template.hbs
@@ -122,20 +122,20 @@
         <div class="admin-doi-settings-title">Article</div>
         {{#if doiEditState}}
           {{input type="text"
-                  class="last_doi_issued"
-                  value=lastDoiIssued
+                  class="first_doi_number"
+                  value=firstDoiNumber
                   placeholder="Article Starting Number"}}
           {{#if doiStartNumberInvalid}}
             <div class="error-message">The Article Start Number must be an integer</div>
           {{/if}}
         {{else}}
-          <span class="article">{{lastDoiIssued}}</span>
+          <span class="article">{{firstDoiNumber}}</span>
         {{/if}}
       </label>
     {{else}}
       <div class="col-md-3">
         <div class="admin-doi-settings-title">Article</div>
-        <span class="article">{{lastDoiIssued}}</span>
+        <span class="article">{{firstDoiNumber}}</span>
       </div>
     {{/if}}
 

--- a/client/tests/helpers/factory.coffee
+++ b/client/tests/helpers/factory.coffee
@@ -247,7 +247,7 @@ FactoryAttributes.Journal =
   manuscript_css: null
   doi_publisher_prefix: null
   doi_journal_prefix: null
-  last_doi_issued: null
+  first_doi_number: null
 
 FactoryAttributes.AdminJournal =
   _rootKey: 'admin_journal'
@@ -261,7 +261,7 @@ FactoryAttributes.AdminJournal =
   manuscript_css: null
   doi_publisher_prefix: null
   doi_journal_prefix: null
-  last_doi_issued: null
+  first_doi_number: null
 
 FactoryAttributes.OldRole =
   _rootKey: 'old_role'

--- a/client/tests/integration/admin-journal-test.js
+++ b/client/tests/integration/admin-journal-test.js
@@ -67,7 +67,7 @@ test('saving doi info will send a put request to the admin journal controller', 
     click('.admin-doi-settings-edit-button');
     fillIn('.admin-doi-setting-section .doi_publisher_prefix', 'PPREFIX');
     fillIn('.admin-doi-setting-section .doi_journal_prefix', 'JPREFIX');
-    fillIn('.admin-doi-setting-section .last_doi_issued', '10000');
+    fillIn('.admin-doi-setting-section .first_doi_number', '00001');
     click('.admin-doi-setting-section button');
   });
 
@@ -95,7 +95,7 @@ test('saving invalid doi info will display an error', function(assert) {
     click('.admin-doi-settings-edit-button');
     fillIn('.admin-doi-setting-section .doi_publisher_prefix', 'PPREFIX');
     fillIn('.admin-doi-setting-section .doi_journal_prefix', 'a/b');
-    fillIn('.admin-doi-setting-section .last_doi_issued', '10000');
+    fillIn('.admin-doi-setting-section .first_doi_number', '00001');
     return click('.admin-doi-setting-section button');
   });
 

--- a/db/data.yml
+++ b/db/data.yml
@@ -3534,7 +3534,7 @@ journals:
   - description
   - doi_publisher_prefix
   - doi_journal_prefix
-  - last_doi_issued
+  - first_doi_number
   records: 
   - - '1'
     - PLOS Yeti
@@ -3549,7 +3549,7 @@ journals:
       for publication.
     - yetipub
     - yetijour
-    - '1000002'
+    - '0000001'
 
 ---
 manuscript_manager_templates:

--- a/db/migrate/20160420220958_remove_last_doi_issued_from_journal.rb
+++ b/db/migrate/20160420220958_remove_last_doi_issued_from_journal.rb
@@ -1,0 +1,22 @@
+##
+# Stop using last_doi_issued
+#
+# Instead we'll search through the DB for the actual last DOI issued. This
+# should hopefully put to bed any issues we have with this value getting out
+# of sync at a slight cost to performance.
+#
+# initial_doi_number serves to handle the assignment of a journal's very first
+# DOI but is afterwards totally ignored.
+#
+# using the word "number" in a column that is actually a string is odd, but is
+# not a mistake. We use a string here to allow numbers with left padding
+# (eg "0001")
+class RemoveLastDoiIssuedFromJournal < ActiveRecord::Migration
+  def change
+    remove_column :journals, :last_doi_issued, :string, default: '0'
+    add_column :journals,
+               :first_doi_number,
+               :string,
+               default: '0000001'
+  end
+end

--- a/db/migrate/20160426015547_add_not_null_contstraint_to_doi.rb
+++ b/db/migrate/20160426015547_add_not_null_contstraint_to_doi.rb
@@ -1,0 +1,14 @@
+# Don't let papers exist without DOIs.
+class AddNotNullContstraintToDoi < ActiveRecord::Migration
+  def up
+    Paper.where(doi: nil).includes(:journal).find_each do |paper|
+      paper.update! doi: DoiService.new(journal: paper.journal).next_doi
+    end
+
+    change_column :papers, :doi, :text, null: false
+  end
+
+  def down
+    change_column :papers, :doi, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160413002420) do
+ActiveRecord::Schema.define(version: 20160426015547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -266,7 +266,7 @@ ActiveRecord::Schema.define(version: 20160413002420) do
     t.text     "description"
     t.string   "doi_publisher_prefix"
     t.string   "doi_journal_prefix"
-    t.string   "last_doi_issued",      default: "0"
+    t.string   "first_doi_number",     default: "0000001"
   end
 
   create_table "manuscript_manager_templates", force: :cascade do |t|
@@ -373,7 +373,7 @@ ActiveRecord::Schema.define(version: 20160413002420) do
     t.datetime "published_at"
     t.integer  "striking_image_id"
     t.boolean  "editable",                             default: true
-    t.text     "doi"
+    t.text     "doi",                                      null: false
     t.string   "publishing_state"
     t.datetime "submitted_at"
     t.string   "salesforce_manuscript_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,11 @@ class ManualSeeds # Use this class to run seeds the old way
   def self.run
     Rake::Task['db:schema:load'].invoke
     # Create Journal
-    plos_journal = Journal.first_or_create!(name: 'PLOS Biology', logo: '', doi_publisher_prefix: "10.1371", doi_journal_prefix: "pbio", last_doi_issued: "0000001")
+    plos_journal = Journal.first_or_create! name: 'PLOS Biology',
+                                            logo: '',
+                                            doi_publisher_prefix: "10.1371",
+                                            doi_journal_prefix: "pbio",
+                                            first_doi_number: "0000001"
 
     Rake::Task['roles-and-permissions:seed'].invoke
     Rake::Task['data:update_journal_task_types'].invoke

--- a/engines/plos_billing/spec/plos_services/billing_log_manager_spec.rb
+++ b/engines/plos_billing/spec/plos_services/billing_log_manager_spec.rb
@@ -99,7 +99,7 @@ describe PlosServices::BillingLogManager do
     journal = FactoryGirl.create(
       :journal,
       :with_roles_and_permissions,
-      :with_doi, { name: 'journal name' }
+      name: 'journal name'
     )
     paper = FactoryGirl.create :paper_with_task, {
       creator: FactoryGirl.create(:user, { first_name: 'lou', last_name: 'prima', email: 'pfa@pfa.com' }),

--- a/spec/factories/journal_factory.rb
+++ b/spec/factories/journal_factory.rb
@@ -1,13 +1,11 @@
 FactoryGirl.define do
   factory :journal do
+    doi_journal_prefix
+    doi_publisher_prefix
+    first_doi_number "10001"
+
     sequence :name do |n|
       "Journal #{n}"
-    end
-
-    trait :with_doi do
-      doi_journal_prefix
-      doi_publisher_prefix
-      last_doi_issued "10000"
     end
 
     trait(:with_paper) do

--- a/spec/factories/paper_factory.rb
+++ b/spec/factories/paper_factory.rb
@@ -3,6 +3,7 @@ require 'securerandom'
 FactoryGirl.define do
   factory :paper do
     journal
+    doi { DoiService.new(journal: journal).next_doi if journal }
 
     trait :with_integration_journal do
       association :journal, factory: :journal_with_roles_and_permissions

--- a/spec/features/doi_paper_spec.rb
+++ b/spec/features/doi_paper_spec.rb
@@ -10,39 +10,12 @@ feature "Paper DOI Generation", selenium: true, js: true do
       visit "/"
     end
 
-    context "on a journal without a doi prefix set" do
-      let(:journal) do
-        FactoryGirl.create(
-          :journal,
-          :with_roles_and_permissions,
-          doi_publisher_prefix: nil,
-          doi_journal_prefix: nil,
-          last_doi_issued: nil
-        )
-      end
-
-      let(:paper_type) {
-        journal.manuscript_manager_templates.pluck(:paper_type).first
-      }
-
-      let(:paper) {
-        FactoryGirl.create(:paper, journal: journal, paper_type: paper_type)
-      }
-
-      scenario "it doesn't contain any doi artifacts" do
-        visit "/papers/#{paper.id}"
-        within "#paper-container" do
-          expect(page).to_not have_text("Manuscript ID")
-        end
-      end
-    end
-
     context "on a journal with a doi prefix set" do
       let(:journal) {
         FactoryGirl.create :journal, :with_roles_and_permissions,
         doi_publisher_prefix: 'vicious',
         doi_journal_prefix: 'robots',
-        last_doi_issued: '8887'
+        first_doi_number: '8888'
       }
 
       let(:paper_type) {

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -12,9 +12,6 @@ describe Journal do
     end
 
     it "still valid" do
-      expect(@journal.doi_publisher_prefix).to eq nil
-      expect(@journal.doi_journal_prefix).to eq nil
-      expect(@journal.last_doi_issued).to eq "0"
       expect(@journal.save!).to eq true
     end
   end
@@ -40,14 +37,14 @@ describe Journal do
 
   describe "DOI" do
     before do
-      @journal = build(:journal, :with_doi)
+      @journal = build(:journal)
       @journal.save!
     end
 
     it "can be created" do
       expect(@journal.doi_publisher_prefix).to be_truthy
-      expect(@journal.doi_journal_prefix).to   be_truthy
-      expect(@journal.last_doi_issued).to      be_truthy
+      expect(@journal.doi_journal_prefix).to be_truthy
+      expect(@journal.first_doi_number).to be_truthy
     end
 
     it "will not save invalid DOI publisher prefix" do

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -24,23 +24,6 @@ describe Paper do
       expect(paper.decisions.length).to eq 1
       expect(paper.decisions.first.class).to eq Decision
     end
-
-    describe "after_create doi callback" do
-      it "the doi is not set coming from factory girl before create" do
-        unsaved_paper_from_factory_girl = FactoryGirl.build :paper
-        expect(unsaved_paper_from_factory_girl.doi).to eq(nil)
-      end
-
-      it "sets a doi in after_create callback" do
-        journal                 = FactoryGirl.create :journal, :with_doi
-        last_doi_initial        = journal.last_doi_issued
-        paper                   = FactoryGirl.create :paper, journal: journal
-
-        expect(paper.doi).to be_truthy
-        expect(last_doi_initial.succ).to eq(journal.last_doi_issued) #is incremented in journal
-        expect(journal.last_doi_issued).to eq(paper.doi.split('.')[1])
-      end
-    end
   end
 
   describe '#body' do

--- a/spec/services/paper_factory_spec.rb
+++ b/spec/services/paper_factory_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PaperFactory do
-  let(:journal) { FactoryGirl.create(:journal, :with_roles_and_permissions, :with_doi) }
+  let(:journal) { FactoryGirl.create(:journal, :with_roles_and_permissions) }
   let(:mmt) do
     FactoryGirl.create(:manuscript_manager_template, paper_type: "Science!").tap do |mmt|
       phase = mmt.phase_templates.create!(name: "First Phase")

--- a/spec/services/salesforce_services/object_translations_spec.rb
+++ b/spec/services/salesforce_services/object_translations_spec.rb
@@ -108,7 +108,6 @@ describe SalesforceServices::ObjectTranslations do
     let(:journal) do
       FactoryGirl.create(
         :journal,
-        :with_doi,
         name: 'journal name'
       )
     end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6669
#### What this PR does:

We had a problem where `last_doi_issued` got out of sync with the DOIs that actually existed in aperta. So this PR gets rid of `last_doi_issued`. Instead we just look up the highest, actually extant DOI and determine the next DOI from that.
#### Notes

`last_doi_issued` is gone. Instead we now have `first_doi_number` on journal which determines the first DOI issued it that journal. After a journal's first DOI, DOI numbers are based of the last actual DOI issued and `first_doi_number` is essentially useless. Note that `first_doi_number` is actually the first number that should be issued and not one less than the first number that should be issued as was the case with `last_doi_issued`.

DOI assignment previously happened in an `after_create` hook on `Paper`. I've gotten rid of the `after_create` and am now relying on the paper_factories to set the DOI. In order to ensure that we still have a DOI, I've added a presence constraint on `doi`. Glenn confirmed that we don't currently have a product use case for allowing papers without DOIs.
#### Major UI changes

All papers should now have DOIs. No real UI changes.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
