### PR TITLE
APERTA-6669 Don’t allow updating last_doi_issued from the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 
 ### Fixed
 - Ensure that cards created after paper creation have the correct permissions
+- Prevent duplication errors in generating new DOIs.
 
 ### Security
 

--- a/app/services/doi_service.rb
+++ b/app/services/doi_service.rb
@@ -38,9 +38,7 @@ class DoiService
 
   def next_doi!
     if journal_has_doi_prefixes?
-      journal.with_lock do
-        journal.update! last_doi_issued: last_doi_issued.succ
-      end
+      journal.next_doi_number!
       to_s
     end
   end

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -38,6 +38,46 @@ describe Journal do
     end
   end
 
+  describe '#last_doi_issued' do
+    subject(:journal) { FactoryGirl.build(:journal) }
+    context 'and the journal is a new record' do
+      before do
+        expect(journal.new_record?).to be(true)
+      end
+
+      it 'allows last_doi_issued to be set' do
+        expect do
+          journal.last_doi_issued = '12345'
+          journal.save!
+          journal.reload
+        end.to change { journal.last_doi_issued }.to eq('12345')
+      end
+    end
+
+    context 'and the journal is not a new record' do
+      before { journal.save! }
+
+      it 'does not allow last_doi_issued to be set' do
+        expect do
+          journal.update!(last_doi_issued: '98765')
+          journal.reload
+        end.to_not change { journal.last_doi_issued }
+      end
+    end
+  end
+
+  describe "#next_doi_number!" do
+    let(:journal) { FactoryGirl.create(:journal) }
+
+    it "increments last_doi_issued and returns that value" do
+      next_doi = nil
+      expect do
+        next_doi = journal.next_doi_number!
+      end.to change { journal.last_doi_issued.to_i }.by 1
+      expect(next_doi).to eq journal.last_doi_issued
+    end
+  end
+
   describe "DOI" do
     before do
       @journal = build(:journal, :with_doi)


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6669
#### What this PR does:

Prevents our clients from inadvertently updating a `Journal`'s `last_doi_issued` and forcing it to get out-of-sync
#### Notes

This totally removes the ability to update `last_doi_issued` from the client, which seems to be the de facto rule anyways.
#### Major UI changes

Can't update `last_doi_issued` from the client

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature

This should hopefully prevent last_doi_issued from getting out-of-sync
