### PR TITLE
APERTA-6524 Do not appear to be in editable mode on double click

### DIFF
--- a/client/app/pods/components/supporting-information-file/component.js
+++ b/client/app/pods/components/supporting-information-file/component.js
@@ -62,8 +62,10 @@ export default Component.extend({
       this.set('uiState', 'view');
     },
 
-    enterEditState() {
-      this.set('uiState', 'edit');
+    enterEditStateIfEditable() {
+      if(this.get('isEditable')) {
+        this.set('uiState', 'edit');
+      }
     },
 
     validateTitle() {

--- a/client/app/pods/components/supporting-information-file/template.hbs
+++ b/client/app/pods/components/supporting-information-file/template.hbs
@@ -69,11 +69,11 @@
   </div>
 
 {{else}}
-  <div class="si-file-viewing" {{action "enterEditState" on="doubleClick"}}>
+  <div class="si-file-viewing" {{action "enterEditStateIfEditable" on="doubleClick"}}>
 
     {{#if isEditable}}
       <div class="si-file-control-icons">
-        <i class="fa fa-pencil si-file-edit-icon" {{action "enterEditState" on="click"}}></i>
+        <i class="fa fa-pencil si-file-edit-icon" {{action "enterEditStateIfEditable" on="click"}}></i>
         <i class="fa fa-trash si-file-delete-icon" {{action "enterDeleteState" on="click"}}></i>
       </div>
     {{/if}}


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6524
#### What this PR does:

Though the staff edit PR locked down the permission to edit tasks in certain states on the backend, the supporting info card appeared to be editable on double click.  This syncs the client side with the reality on the server side.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
