### PR TITLE
APERTA-6826 Remove footer from reviewer invite email

### DIFF
--- a/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/paper_reviewer_mailer/notify_invited.html.erb
+++ b/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/paper_reviewer_mailer/notify_invited.html.erb
@@ -20,13 +20,4 @@
       </a>
     </p>
   </div>
-  <hr>
-  <div class="footer">
-    <div class="paper-title">
-      "<%= @paper.display_title(sanitized: false) %>"
-    </div>
-    <div class="paper-abstract">
-      <%= raw @paper.abstract %>
-    </div>
-  </div>
 </div>

--- a/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/paper_reviewer_mailer_spec.rb
+++ b/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/paper_reviewer_mailer_spec.rb
@@ -11,7 +11,6 @@ shared_examples_for 'an invitation notification email' do |email_identifier_word
     expect(email.to.first).to eq invitation.email
   end
 
-  specify { expect(email.body).to match(/#{task.paper.display_title(sanitized: false)}/) }
   specify { expect(email.body).to match(/#{email_identifier_word}/) }
 end
 
@@ -62,6 +61,11 @@ describe TahiStandardTasks::PaperReviewerMailer do
     end
 
     it_behaves_like 'an invitation notification email', email_identifier_word: 'rescinded'
+
+    specify do
+      title = task.paper.display_title(sanitized: false)
+      expect(email.body).to match(/#{title}/)
+    end
 
     describe "email content and formatting" do
       it "has correct subject line" do


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6826
#### What this PR does:

Removes the title and abstract from the footer in the reviewer invite email. Since these were the only two things in the footer, this PR removes the whole footer as well.
#### Notes

none
#### Major UI changes

nope

---
#### Code Review Tasks:

Author tasks:  
- ~~[ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)~~
- ~~[ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`~~
- ~~[ ] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page]~~(https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- ~~[ ] If I made any UI changes, I've let QA know.~~ 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
