### PR TITLE
APERTA-6761 Restore back app name from the dashboard

### DIFF
--- a/client/app/pods/application/controller.js
+++ b/client/app/pods/application/controller.js
@@ -12,6 +12,11 @@ export default Ember.Controller.extend({
   journals: null,
   canViewPaperTracker: false,
 
+  init() {
+    this._super(...arguments);
+    Ember.assert('Application name is required for proper display', window.appName);
+  },
+
   setCanViewPaperTracker: function() {
     if (this.journals === null) {
       return false;


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6761
#### What this PR does:
- Add back app name

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
