### PR TITLE
FLAKY TEST FIX - Apply order to combined permission states

### DIFF
--- a/app/models/authorizations/query.rb
+++ b/app/models/authorizations/query.rb
@@ -254,7 +254,7 @@ module Authorizations
           # only the last set of permission sets seen will be kept in
           # this ResultSet
           @object_permission_map[object].merge!(with_permissions) do |key, v1, v2|
-            { states: (v1[:states] + v2[:states]).uniq }
+            { states: (v1[:states] + v2[:states]).uniq.sort }
           end
         end
       end

--- a/spec/authorizations/client_side_permission_data_spec.rb
+++ b/spec/authorizations/client_side_permission_data_spec.rb
@@ -152,7 +152,7 @@ DESC
                 states: %w(*)
               },
               edit: {
-                states: %w(unsubmitted *)
+                states: %w(* unsubmitted)
               }
             }
           }


### PR DESCRIPTION
JIRA issue: none (for shame)
#### What this PR does:

Fixes a flaky spec that was making my PRs sad: spec/authorizations/client_side_permission_data_spec.rb:135

Seems like it was failing because it was expecting a certain order in the permission states list which was being violated half the time. I figured that the order of this list was otherwise insignificant so I just sorted it alphabetically so it would have a dependable order for testing purposes.

@zdennis, you're probably the best qualified to say if this is safe or not since I think you're the author of most of the surrounding code.

---
#### Code Review Tasks:

Author tasks:  

~~\- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)~~
~~\- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`~~
~~\- [ ] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page]~~(https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
~~\- [ ] If I made any UI changes, I've let QA know.~~

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature

This was done in order to fix a test that was failing because. Besides
that, there's no meaning behind the ordering.
