### PR TITLE
Fix errors in placement when uploading multiple figures

### DIFF
--- a/app/services/figure_inserter.rb
+++ b/app/services/figure_inserter.rb
@@ -22,7 +22,7 @@ class FigureInserter
   end
 
   def sorted_figures
-    @figures.sort_by { |fig| fig.rank || 0 }
+    @figures.select(&:attachment?).sort_by { |f| f.rank || 0 }
   end
 
   def insert_figure(figure)

--- a/spec/models/figure_spec.rb
+++ b/spec/models/figure_spec.rb
@@ -132,4 +132,12 @@ describe Figure, redis: true do
       end
     end
   end
+
+  describe '#attachment_exists?' do
+    context 'when the attachment is present' do
+      it 'returns true' do
+        expect(figure.attachment?).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6760
#### What this PR does:

Fix errors in placement when uploading multiple figures. As a user, if I select and upload multiple figures at once, should all place properly in the manuscript.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature

Paired with jlabarba@plos.org
