### PR TITLE
Check if all the figures of the paper are ready, before inserting.

### DIFF
--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -13,7 +13,7 @@ class Figure < ActiveRecord::Base
 
   mount_uploader :attachment, AttachmentUploader
 
-  after_update :insert_figures!, if: :should_insert_figures?
+  after_save :insert_figures!, if: :should_insert_figures?
   after_destroy :insert_figures!
 
   delegate :insert_figures!, to: :paper
@@ -57,7 +57,11 @@ class Figure < ActiveRecord::Base
   end
 
   def should_insert_figures?
-    title_changed? || attachment_changed?
+    (title_changed? || attachment_changed?) && all_figures_done?
+  end
+
+  def all_figures_done?
+    paper.figures.all? { |figure| figure.status == 'done' }
   end
 
   def rank

--- a/spec/models/figure_spec.rb
+++ b/spec/models/figure_spec.rb
@@ -112,6 +112,7 @@ describe Figure, redis: true do
 
     it 'triggers when the figure title is updated' do
       allow(figure).to receive(:paper).and_return(paper_double)
+      allow(figure).to receive(:all_figures_done?).and_return(true)
       expect(paper_double).to receive(:insert_figures!)
 
       figure.update!(title: 'new title')


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6760
#### What this PR does:

Check if all the figures of the paper are ready, before triggering insertion. This ensures that the figures are placed in the right position.
#### Notes

Paired with Jack. Thanks Jack!

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
