### PR TITLE
Preserve line breaks in discussion notification emails

### DIFF
--- a/app/views/user_mailer/notify_mention_in_discussion.html.erb
+++ b/app/views/user_mailer/notify_mention_in_discussion.html.erb
@@ -13,7 +13,7 @@
     </p>
     <p>
     <%= if @reply
-          @reply.body
+          simple_format(@reply.body)
         end %>
     </p>
     <p>


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6782
#### What this PR does:

Email notifications from the discussion forum now preserve all the line breaks in the body of the message.
#### Major UI changes

Line breaks are now preserved:
![screenshot](https://cloud.githubusercontent.com/assets/167700/15412403/cdd0dfd0-1dec-11e6-914d-11da33b89cc5.png)

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
