### PR TITLE
APERTA-6932 Allow full paths for FTP_DIR

### DIFF
--- a/app/services/ftp_uploader_service.rb
+++ b/app/services/ftp_uploader_service.rb
@@ -66,8 +66,10 @@ class FtpUploaderService
   end
 
   def enter_packages_directory
-    remote_directories = @ftp.nlst
-    @ftp.mkdir(@directory) unless remote_directories.index(@directory)
+    @ftp.chdir(@directory)
+  rescue Net::FTPPermError
+    Rails.logger.info "Attempting to create ftp directory: #{@directory}"
+    @ftp.mkdir(@directory)
     @ftp.chdir(@directory)
   end
 


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6932
#### What this PR does:

Previously we were only able to specify FTP_DIR as a single word like ‘packages’. This caused errors when we’d want to set it to ‘/‘ or ‘/aperta2apex’ (which is the current production config). This PR should fix that. It should now be possible to specify the FTP_DIR by its full path.

This does not however create any missing directory parents. Specifying something like FTP_DIR=’/foo/bar/‘ will error if /foo does not exist.
#### Notes

I would have added some test coverage of this, but FakeFTP seems to be a little too fake to implement filesystem methods. Things like `chdir` and `mkdir` seem to just no-op with FakeFTP.

I've updated the env vars for this heroku review app so that it's uploading to the production ftp in a directory next to the real one. I figured this was warranted since this is a bug that appears most often on that FTP server and we've had a hard time reproducing it elsewhere. Check out the heroku app config if you want to log into the ftp server for verification. This paper is set up for exporting to apex: https://tahi-staging-pr-2362.herokuapp.com/papers/4/tasks/192
#### Major UI changes

none

---
#### Code Review Tasks:

Author tasks:  
- ~~[ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)~~
- ~~[ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`~~
- ~~[ ] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)~~
- ~~[ ] If I made any UI changes, I've let QA know.~~

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
