### PR TITLE
APERTA-6961 Fix flaky journal creation feature spec

### DIFF
--- a/spec/support/pages/admin_dashboard_page.rb
+++ b/spec/support/pages/admin_dashboard_page.rb
@@ -137,7 +137,7 @@ class EditJournalFragment < PageFragment
 
   def save
     click_on "Save"
-    wait_for_ajax
+    wait_for_ajax timeout: 20
     session.has_content? @name
   end
 

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -6,10 +6,10 @@ class Capybara::Session
     wait_for_ajax
   end
 
-  def wait_for_ajax
+  def wait_for_ajax(timeout: Capybara.default_max_wait_time)
     return unless jquery_present?
 
-    Timeout.timeout(Capybara.default_max_wait_time) do
+    Timeout.timeout(timeout) do
       loop until finished_all_ajax_requests? && finished_ember_requests?
     end
   end
@@ -34,8 +34,8 @@ class Capybara::Session
 end
 
 module WaitForAjax
-  def wait_for_ajax(session = Capybara.current_session)
-    session.wait_for_ajax
+  def wait_for_ajax(session = Capybara.current_session, **opts)
+    session.wait_for_ajax **opts
   end
 end
 


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6961
#### What this PR does:

Increases the timeout on a wait_for_ajax for the journal creation feature spec. Creating a journal takes a pretty long time, apparently longer than our 10 second default timeout.
#### Notes

I toyed with the idea of mocking out the journal factory so it didn't need to create a million R&P records, but then decided against it because mocking in an integration test seems a little counter-productive.
#### Major UI changes

None.

---
#### Code Review Tasks:

Author tasks:  
- ~~[ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)~~
- ~~[ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`~~
- ~~[ ] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page]~~(https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- ~~[ ] If I made any UI changes, I've let QA know.~~ 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
