### PR TITLE
Fix issue that allowed users to access a discussion from one document in another document

### DIFF
--- a/client/app/mixins/discussions/show/route.js
+++ b/client/app/mixins/discussions/show/route.js
@@ -9,6 +9,14 @@ export default Ember.Mixin.create(DiscussionsRoutePathsMixin, {
     return this.store.find('discussion-topic', params.topic_id);
   },
 
+  redirect(model, transition) {
+    var paperId = this.modelFor('paper').get('id');
+
+    if (model.get('paperId') !== paperId) {
+      this.transitionTo('paper.index.discussions');
+    }
+  },
+
   afterModel(model) {
     this.setModelChannel(model);
   },


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6748
#### What this PR does:

With the discussion sidebar open, a staff user then attempting to quickly move from one manuscript to another by modifying the paper id in the URL.
When a user does this, they see the following message: "You're attempting to access a discussion that doesn't belong to the current paper."
#### Major UI changes

New message:
![screenshot from 2016-05-25 14-18-14](https://cloud.githubusercontent.com/assets/167700/15553235/c862f808-2283-11e6-9c7e-c3dbb329eacb.png)

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
