### PR TITLE
APERTA-6972: Run feature/integration tests separately from unit tests.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -53,7 +53,25 @@ test:
         parallel: true
         files:
           # Only select non-feature specs
-          - "**/spec/*[^features]*/**/*_spec.rb"
+          # WARNING: CircleCI does not appear to use Ruby's Dir.glob under the
+          #       hood so if you test something in irb don't expect to get the
+          #       same CircleCI.
+          #
+          # NOTE ON BELOW GLOB:
+          #       There is no way using standard file globbing to negate
+          #       entire words so we are ignoring all folders inside a spec/
+          #       directory that start with "f".
+          #
+          #       If you try to do [!features] or [^features] it will treat it
+          #       as character set and rather than doing what you hope it will
+          #       end up not matching on any directories that start with any of
+          #       those letters.
+          #
+          #       If you try to split it up as CircleCI's support suggeseted
+          #       like this, [^f][^e][^a], then it will fail on things where then
+          #       second letter was an "e" or the third letter an "a". This
+          #       results in not running all specs.
+          - "**/spec/[!f]*/**/*_spec.rb"
     - bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-features.xml:
         timeout: 1800
         parallel: true

--- a/spec/circleci_spec.rb
+++ b/spec/circleci_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'CircleCI yml configuration' do
+  describe 'Missing file globs?' do
+    it 'ensures we are not missing any directories with specs that start with "f"' do
+      # Grab every ruby spec file that we can find starting in the
+      # ROOT directory of the project
+      all_specs = []
+      Dir.chdir(File.dirname(__FILE__) + '/../') do
+        all_specs = Dir.glob("**/spec/**/*_spec.rb")
+      end
+
+      # find out what the first directory is under "/spec/"
+      top_level_spec_dirs = all_specs.map do |spec_path|
+        spec_path.scan(/\/spec\/([^\/]+)/)
+      end.flatten.uniq
+
+      # if there are more than one first-directories that start with
+      # "f" than the circle.yml file needs to be updated to fix its
+      # file-glob
+      non_feature_spec_dirs = top_level_spec_dirs - %w(features)
+      expect(
+        non_feature_spec_dirs.select { |path| path.start_with?('f') }
+      ).to be_empty
+    end
+  end
+
+end


### PR DESCRIPTION
JIRA issue: [APERTA-6972](https://developer.plos.org/jira/browse/APERTA-6972)
#### What this PR does:

This PR aims to separate out feature specs from non-feature specs because they use different DB cleaning strategies that often interfere.
#### Notes

"Borrowed" from PR #2378, as written by @egh:

> (Background: while the non-feature (non-capybara) specs use the "transaction" database cleaning strategy, the feature (capybara) specs use the truncation strategy, with the roles/permissions and nested question tables excluded from truncation. So feature specs that touch the nested question and especially roles & permissions tables can leave garbage around for later tests. This seems to be a bigger issue when the feature & non-feature specs run together).

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
