### PR TITLE
Separate feature and non-feature specs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -48,12 +48,19 @@ database:
 ## Customize test commands
 test:
   override:
-    - bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec.xml:
+    # Run feature & non feature specs separately to avoid polluting the database.
+    - bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-non-feature.xml:
         timeout: 1800
         parallel: true
         files:
-          - "spec/**/*_spec.rb"
-          - "engines/*/spec/**/*_spec.rb"
+          - "spec/{[!features]**}/*_spec.rb"
+          - "engines/*/spec/{[!features]**}/*_spec.rb"
+    - bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-feature.xml:
+        timeout: 1800
+        parallel: true
+        files:
+          - "spec/features/**/*_spec.rb"
+          - "engines/*/spec/features/**/*_spec.rb"
     - "set -o pipefail; cd client && ./node_modules/.bin/ember test --silent -r xunit | grep -v ^Warning > $CIRCLE_TEST_REPORTS/qunit.xml"
 
 ## Customize heroku deployment


### PR DESCRIPTION
@slimeate & I figure this out. It seems that it might be a more robust way of handling our tests. @zdennis and @slimeate determined that running the feature/non-feature specs was polluting the feature specs with leftover data from the feature specs.

(Background: while the non-feature (non-capybara) specs use the "transaction" database cleaning strategy, the feature (capybara) specs use the truncation strategy, with the roles/permissions and nested question tables excluded from truncation. So feature specs that touch the nested question and especially roles & permissions tables can leave garbage around for later tests. This seems to be a bigger issue when the feature & non-feature specs run together).
