### PR TITLE
Strip whitespace before/after email in invites, compare ignoring case

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -12,7 +12,7 @@ class Invitation < ActiveRecord::Base
   before_create :assign_to_latest_decision
 
   scope :where_email_matches,
-        ->(email) { where('email = ? OR email like ?', email, "%<#{email}>") }
+        ->(email) { where('lower(email) = lower(?) OR lower(email) like lower(?)', email, "%<#{email}>") }
 
   before_validation :set_invitee_role
   validates :invitee_role, presence: true

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -224,15 +224,18 @@ describe Invitation do
   end
 
   describe "#where_email_matches" do
-    let(:email) { "turtle@turtles.com" }
-    let!(:invitation_1) { create :invitation, email: email }
-    let!(:invitation_2) { create :invitation, email: "turtle <#{email}>" }
+    let(:emails) { ["turtle@turtles.com", "TURTLE@turtles.com"] }
+    let!(:invitation_1) { create :invitation, email: emails[0] }
+    let!(:invitation_2) { create :invitation, email: "turtle <#{emails[0]}>" }
     let!(:invitation_3) { create :invitation, email: "another@email.com" }
+    let!(:invitation_4) { create :invitation, email: emails[1] }
 
     it "returns invitiations where the email matches the supplied argument" do
-      invitations = Invitation.where_email_matches email
-      expect(Invitation.count).to eq 3
-      expect(invitations.map(&:id)).to match [invitation_1.id, invitation_2.id]
+      emails.each do |email|
+        invitations = Invitation.where_email_matches email
+        expect(Invitation.count).to eq 4
+        expect(invitations.map(&:id)).to contain_exactly(invitation_1.id, invitation_2.id, invitation_4.id)
+      end
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6988
#### What this PR does:
- Strip leading/trailing whitespace from emails set in invitations.
- Do a case-insensitive comparison when matching the user to any pending invitations when the user account is created.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
