### PR TITLE
Fix 3 migrations to allow migrating from new db

### DIFF
--- a/db/migrate/20131210232316_add_journal_id_to_papers.rb
+++ b/db/migrate/20131210232316_add_journal_id_to_papers.rb
@@ -4,16 +4,11 @@ class AddJournalIdToPapers < ActiveRecord::Migration
 
     reversible do |dir|
       dir.up do
-        execute <<-SQL
-          INSERT INTO "journals" ("name") VALUES ('PLOS Yeti');
-          UPDATE "papers" SET "journal_id" = (SELECT "journals".id FROM "journals" WHERE "journals"."name" = 'PLOS Yeti' LIMIT 1);
-        SQL
+        # NB: This migration previously did something very wrong. It inserted
+        # data into the db. Now it does nothing, which is better.
       end
 
       dir.down do
-        execute <<-SQL
-          DELETE FROM "journals" WHERE "journals"."name" = 'PLOS Yeti';
-        SQL
       end
     end
   end

--- a/db/migrate/20140619184231_add_status_to_manuscript.rb
+++ b/db/migrate/20140619184231_add_status_to_manuscript.rb
@@ -1,7 +1,9 @@
 class AddStatusToManuscript < ActiveRecord::Migration
   def up
     add_column :manuscripts, :status, :string, default: "processing"
-    Manuscript.update_all status: "done"
+    execute <<-SQL
+      UPDATE manuscripts SET status = 'done';
+    SQL
   end
 
   def down

--- a/db/migrate/20141204214215_map_old_queries_to_new_flow_queries.rb
+++ b/db/migrate/20141204214215_map_old_queries_to_new_flow_queries.rb
@@ -1,9 +1,11 @@
 class MapOldQueriesToNewFlowQueries < ActiveRecord::Migration
   def up
-    Flow.where("role_id IS NOT ?", nil).destroy_all
+    execute <<-SQL
+      DELETE FROM flows WHERE flows.role_id IS NOT null;
+    SQL
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20141208152459_use_default_flows.rb
+++ b/db/migrate/20141208152459_use_default_flows.rb
@@ -4,11 +4,13 @@ class UseDefaultFlows < ActiveRecord::Migration
     # since they are not associted with the default flows.
     # The default flows will be included to the users choices when they
     # visit their flow manager.
-    UserFlow.destroy_all
-    Flow.destroy_all
+    execute <<-SQL
+      DELETE FROM user_flows;
+      DELETE FROM flows;
+    SQL
   end
 
   def down
-    raise ActiveRecord::IrreversibleMigration
+    fail ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20160525152903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "unaccent"
 
@@ -311,8 +310,6 @@ ActiveRecord::Schema.define(version: 20160525152903) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "logo"
-    t.string   "epub_cover"
-    t.text     "epub_css"
     t.text     "pdf_css"
     t.text     "manuscript_css"
     t.text     "description"
@@ -723,8 +720,8 @@ ActiveRecord::Schema.define(version: 20160525152903) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "username"
+    t.boolean  "site_admin",             default: false, null: false
     t.string   "avatar"
-    t.boolean  "site_admin",                         default: false
     t.string   "em_guid"
   end
 


### PR DESCRIPTION
Three of our migrations were broken because they relied on classes that no
longer exists. Use raw SQL to work around this issue.

Also correct two places where our db/schema.rb had diverged from what
the schema would be if a user ran all the migrations from the beginning
of the app.

To test:

`rake db:drop db:create db:migrate`
