### PR TITLE
APERTA-6697 addition: Make sure the FTP_USER is inherited in Heroku review apps.

### DIFF
--- a/app.json
+++ b/app.json
@@ -103,6 +103,9 @@
     "FTP_ENABLED": {
       "required": true
     },
+    "FTP_USER": {
+      "required": true
+    },
     "FTP_HOST": {
       "required": true
     },


### PR DESCRIPTION
JIRA issue: [APERTA-6697](https://developer.plos.org/jira/browse/APERTA-6697)
#### What this PR does:

@MMercieca  found that the FTP_USER isn't being inherited in the Heroku review apps. This causes review apps created after 33d65d872bfa91cf5ec120a06a8b6b5a1b7c071c to no boot without manually setting the FTP_USER.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
