### PR TITLE
Making the default .env valid

### DIFF
--- a/.env
+++ b/.env
@@ -43,7 +43,7 @@ PASSWORD_AUTH_ENABLED=false
 # }}} Devise Database Authenticable
 
 # {{{ CAS-NED Integration
-CAS_ENABLED=true
+CAS_ENABLED=false
 CAS_CALLBACK_URL=
 CAS_SSL_VERIFY=false
 CAS_HOST=


### PR DESCRIPTION
JIRA issue: [APERTA-6697](https://developer.plos.org/jira/browse/APERTA-6697)
#### What this PR does:

CAS was enabled locally, but two required CAS fields were missing from the default config (CAS_HOST and CAS_SIGNUP_URL) This makes things consistent.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
