### PR TITLE
Allow NULL values for user.ned_id

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ActiveRecord::Base
   validates :first_name, length: { maximum: 255 }
   validates :last_name, length: { maximum: 255 }
 
-  validates :ned_id, uniqueness: true
+  validates :ned_id, uniqueness: true, allow_nil: true
   validates_with NedValidator
 
   mount_uploader :avatar, AvatarUploader


### PR DESCRIPTION
Do not fail validation when there are 2 users with a NULL ned_id.

Without this change, we would not be able to per-populate more than 1 new user.
