### PR TITLE
Fix yet another flaky spec

### DIFF
--- a/client/app/pods/admin/journals/index/controller.js
+++ b/client/app/pods/admin/journals/index/controller.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.ArrayController.extend(Ember.SortableMixin, {
-  sortProperties: ['isNew', 'name'],
+  sortProperties: ['isNew', 'id'],
   sortAscending: false,
 
   newJournalPresent: Ember.computed('arrangedContent.[]', function() {


### PR DESCRIPTION
Journals on the admin page were being sorted by name. When you changed
the name, it would sort as you typed. This caused the capybara tests to
lose focus.

Instead, let’s sort by id so the newest ones come first and the journals
do not move around as you change the name.
