### PR TITLE
Spike to run data migrations in schema migrations

### DIFF
--- a/db/migrate/20160613163632_run_set_registered_flag.rb
+++ b/db/migrate/20160613163632_run_set_registered_flag.rb
@@ -1,0 +1,3 @@
+class RunSetRegisteredFlag < DataMigration
+  RAKE_TASK = 'data:migrate:decisions:set_registered_flag'
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160608144550) do
+ActiveRecord::Schema.define(version: 20160613163632) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/data_migration.rb
+++ b/lib/data_migration.rb
@@ -1,0 +1,29 @@
+# Extend this class to make a migration that calls a rake task, e.g.
+#
+# ```
+# class RunDoSomething < DataMigration
+#   RAKE_TASK = 'data:migrate:do_something'
+# end
+# ```
+#
+# This will run the specified rake task on a migrate `up` if and only if that
+# task exists. If the task no longer exists, it will run nothing. The migration
+# will fail on `down`.
+#
+# This allows data migrations that satisfy the following:
+# 1. Automatically run once and only once in a defined order on deploy.
+# 2. Can be run again if necessary.
+# 3. Can be removed if the code is no longer active/valid (by removing the rake
+#    task), while still allowing the migration to succeed (it will be a noop).
+class DataMigration < ActiveRecord::Migration
+  def up
+    fail StandardError, "#{self.class} did not define RAKE_TASK" \
+      unless defined? self.class::RAKE_TASK
+    return unless Rake::Task.task_defined?(self.class::RAKE_TASK)
+    Rake::Task[self.class::RAKE_TASK].invoke
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/lib/data_migration_spec.rb
+++ b/spec/lib/data_migration_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+require 'data_migration'
+
+describe DataMigration, rake: true do
+  let(:klass) { Class.new(DataMigration) }
+
+  it 'should fail on down' do
+    expect { klass.new.down }.to raise_exception(ActiveRecord::IrreversibleMigration)
+  end
+
+  context 'when `RAKE_TASK` is not defined' do
+    it 'should fail on up' do
+      expect { klass.new.up }.to raise_exception(/did not define RAKE_TASK/)
+    end
+  end
+
+  context 'when `RAKE_TASK` is defined' do
+    let(:klass) { Class.new(DataMigration) }
+
+    before do
+      klass::RAKE_TASK = 'my-rake-task'
+    end
+
+    context 'but the task does not exist' do
+      it 'should return nil' do
+        expect(klass.new.up).to be(nil)
+      end
+    end
+
+    context 'and the task exists' do
+      let(:underlying_code) { double }
+      before do
+        Rake::Task.define_task('my-rake-task') do
+          underlying_code.call
+        end
+      end
+
+      it 'should be called' do
+        expect(underlying_code).to receive(:call)
+        klass.new.up
+      end
+    end
+  end
+end


### PR DESCRIPTION
Can be used to run rake-based data migrations into the schema migration.

This allows data migrations that satisfy the following:
1. Automatically run once and only once in a defined order on deploy.
2. Can be run again if necessary.
3. Can be removed if the code is no longer active/valid (by removing the rake
   task), while still allowing the migration to succeed (it will be a noop).

Also include a migration for the set_registered_flag rake task.
