### PR TITLE
APERTA-6882 Remove npm files after deploy

### DIFF
--- a/lib/capistrano/tasks/shared.rake
+++ b/lib/capistrano/tasks/shared.rake
@@ -101,6 +101,15 @@ namespace :nginx do
   end
 end
 
+namespace :cleanup do
+  desc "Cleanup node temp files" # Prevents running out of inodes
+  task :tmp do
+    on release_roles(fetch(:assets_roles)) do
+      execute :rm, '-rf', '/tmp/npm-*'
+    end
+  end
+end
+
 # Hack to fake a puma.rb config, which we do not have on a worker
 before 'deploy:check:linked_files', :remove_junk do
   on roles(:db, :worker) do
@@ -112,3 +121,5 @@ after 'deploy:finished', 'puma:restart'
 
 after 'deploy:finished', 'sidekiq:restart'
 after 'deploy:finished', 'nginx:start'
+
+after 'deploy:finished', 'cleanup:tmp'


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6882
#### What this PR does:

ACs:
attempting to deploy Aperta 1.4.8, we ran into an issue where the system was out of inodes. Looking at /tmp, we had many leftover npm-\* directories with a gazillion tiny files.
Manually clearing these directories allowed us to proceed past this failure in to the next one 
Please to update the deploy jobs to clean up after themselves.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
