### PR TITLE
Filter out anonymous descendants of Task

### DIFF
--- a/spec/services/journal_services/create_default_task_types_spec.rb
+++ b/spec/services/journal_services/create_default_task_types_spec.rb
@@ -3,6 +3,14 @@ require 'rails_helper'
 describe JournalServices::CreateDefaultTaskTypes do
   let(:journal) { FactoryGirl.create(:journal) }
 
+  before do
+    # Filter out anonymous classes.
+    # This allows us to create test descendants of Task without polluting this.
+    allow(Task).to receive(:all_task_types).and_wrap_original do |m|
+      m.call.reject { |klass| klass.name.nil? }
+    end
+  end
+
   it 'Creates missing task types for an existing journal' do
     journal.journal_task_types.first.destroy
     expect {


### PR DESCRIPTION
Prevent tests that extend Task from polluting the return value of the
`Task#all_task_types` method.

Fixes: https://circleci.com/gh/Tahi-project/tahi/12549
