### PR TITLE
APERTA-7030: Do not update reviewer report titles on deploy.

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -62,6 +62,17 @@ class Task < ActiveRecord::Base
   validates :title, length: { maximum: 255 }
 
   class << self
+    # Public: Restores the task defaults to all of its instances/models
+    #
+    # * restores title to DEFAULT_TITLE
+    # * restores old_role to DEFAULT_ROLE
+    #
+    # Note: this will not restore the +title+ or +old_role+ on ad-hoc tasks.
+    def restore_defaults
+      return if self == Task
+      update_all(old_role: self::DEFAULT_ROLE, title: self::DEFAULT_TITLE)
+    end
+
     # Public: Scopes the tasks with a given old_role
     #
     # old_role  - The String of old_role name.

--- a/app/services/journal_services/update_default_tasks.rb
+++ b/app/services/journal_services/update_default_tasks.rb
@@ -4,9 +4,7 @@ module JournalServices
   class UpdateDefaultTasks < BaseService
     def self.call
       Task.all_task_types.each do |klass|
-        next if klass == Task
-        klass.update_all old_role: klass::DEFAULT_ROLE,
-                         title: klass::DEFAULT_TITLE
+        klass.restore_defaults
       end
     end
   end

--- a/engines/plos_billing/spec/models/billing/billing_task_spec.rb
+++ b/engines/plos_billing/spec/models/billing/billing_task_spec.rb
@@ -13,6 +13,11 @@ module PlosBilling
       )
     end
 
+    describe '.restore_defaults' do
+      include_examples '<Task class>.restore_defaults update title to the default'
+      include_examples '<Task class>.restore_defaults update old_role to the default'
+    end
+
     describe '.create' do
       it "creates it" do
         expect(billing_task).to_not be_nil

--- a/engines/plos_bio_tech_check/spec/models/changes_for_author_task_spec.rb
+++ b/engines/plos_bio_tech_check/spec/models/changes_for_author_task_spec.rb
@@ -12,6 +12,11 @@ describe PlosBioTechCheck::ChangesForAuthorTask do
     task.save!
   end
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe "#notify_changes_for_author" do
     it "queues an email to send" do
       expect { task.notify_changes_for_author }

--- a/engines/plos_bio_tech_check/spec/models/initial_tech_check_task_spec.rb
+++ b/engines/plos_bio_tech_check/spec/models/initial_tech_check_task_spec.rb
@@ -14,6 +14,12 @@ describe PlosBioTechCheck::InitialTechCheckTask do
   let(:phase) { FactoryGirl.create :phase, paper: paper }
   let(:task) { FactoryGirl.create :initial_tech_check_task, paper: paper, phase: phase }
   let(:subject) { described_class.new(paper: paper, phase: phase, title: "new task", old_role: PaperRole::COLLABORATOR) }
+
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe '#round' do
     it 'initializes with the round 1' do
       expect(task.round).to eq 1

--- a/engines/tahi-assign_team/spec/models/tahi/assign_team/assign_team_task_spec.rb
+++ b/engines/tahi-assign_team/spec/models/tahi/assign_team/assign_team_task_spec.rb
@@ -5,6 +5,11 @@ describe Tahi::AssignTeam::AssignTeamTask do
   let(:paper) { FactoryGirl.create(:paper, journal: journal) }
   let(:journal) { FactoryGirl.create(:journal) }
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe '#assignable_roles' do
     let(:academic_editor_role) { FactoryGirl.build_stubbed(:role) }
     let(:cover_editor_role) { FactoryGirl.build_stubbed(:role) }

--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/reviewer_report_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/reviewer_report_task.rb
@@ -6,6 +6,13 @@ module TahiStandardTasks
     before_create :assign_to_latest_decision
     has_many :decisions, -> { uniq }, through: :paper
 
+    # Overrides Task#restore_defaults to be only restore +old_role+. This
+    # will never update +title+ as that is dynamically determined. If you
+    # need to change the reviewer report title write a data migration.
+    def self.restore_defaults
+      update_all(old_role: self::DEFAULT_ROLE)
+    end
+
     # find_or_build_answer_for(...) will return the associated answer for this
     # task given :nested_question. For ReviewerReportTask this enforces the
     # lookup to be scoped to this task's current decision. Answers associated

--- a/engines/tahi_standard_tasks/spec/models/authors_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/authors_task_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe TahiStandardTasks::AuthorsTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe "#validate_authors" do
     let!(:valid_author) do
       author = FactoryGirl.create(:author, paper: task.paper)

--- a/engines/tahi_standard_tasks/spec/models/competing_interests_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/competing_interests_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::CompetingInterestsTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/cover_letter_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/cover_letter_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::CoverLetterTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/data_availability_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/data_availability_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::DataAvailabilityTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/ethics_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/ethics_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::EthicsTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/figure_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/figure_task_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe TahiStandardTasks::FigureTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe "#figure_access_details" do
     let(:paper) { FactoryGirl.create(:paper) }
     let!(:task) { FactoryGirl.create(:figure_task, paper: paper) }

--- a/engines/tahi_standard_tasks/spec/models/financial_disclosure_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/financial_disclosure_task_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe TahiStandardTasks::FinancialDisclosureTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe '#funders association' do
     let!(:task) do
       FactoryGirl.create(:financial_disclosure_task, funders: [funder])

--- a/engines/tahi_standard_tasks/spec/models/front_matter_reviewer_report_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/front_matter_reviewer_report_task_spec.rb
@@ -12,4 +12,9 @@ describe TahiStandardTasks::FrontMatterReviewerReportTask do
     subject { TahiStandardTasks::FrontMatterReviewerReportTask::DEFAULT_ROLE }
     it { is_expected.to eq('reviewer') }
   end
+
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults does not update title'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
 end

--- a/engines/tahi_standard_tasks/spec/models/initial_decision_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/initial_decision_task_spec.rb
@@ -4,6 +4,11 @@ describe TahiStandardTasks::InitialDecisionTask do
   let(:paper) { FactoryGirl.create :paper, :with_tasks }
   let(:task) { FactoryGirl.create :initial_decision_task }
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe '#initial_decision' do
     it 'gets initial decision' do
       expect(task.initial_decision).to eq(task.paper.decisions.last)

--- a/engines/tahi_standard_tasks/spec/models/paper_admin_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/paper_admin_task_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe TahiStandardTasks::PaperAdminTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe "updating paper admin" do
     let(:sally) { create :user }
     let(:bob) { create :user }

--- a/engines/tahi_standard_tasks/spec/models/paper_editor_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/paper_editor_task_spec.rb
@@ -5,6 +5,11 @@ describe TahiStandardTasks::PaperEditorTask do
   let(:paper) { FactoryGirl.create(:paper_with_phases, journal: journal) }
   let!(:author) { FactoryGirl.create(:author, paper: paper) }
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe "#invitation_invited" do
     let!(:task) do
       TahiStandardTasks::PaperEditorTask.create!({

--- a/engines/tahi_standard_tasks/spec/models/paper_reviewer_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/paper_reviewer_task_spec.rb
@@ -10,6 +10,11 @@ describe TahiStandardTasks::PaperReviewerTask do
   end
   let(:journal) { FactoryGirl.create(:journal, :with_academic_editor_role) }
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe "#invitation_invited" do
     let(:invitation) { FactoryGirl.create(:invitation, :invited, task: task) }
 

--- a/engines/tahi_standard_tasks/spec/models/production_metadata_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/production_metadata_task_spec.rb
@@ -15,6 +15,11 @@ describe TahiStandardTasks::ProductionMetadataTask do
     )
   end
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   context "validations" do
     context "task not just marked complete" do
       let(:task) { FactoryGirl.build(:production_metadata_task) }

--- a/engines/tahi_standard_tasks/spec/models/publishing_related_questions_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/publishing_related_questions_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::PublishingRelatedQuestionsTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/register_decision_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/register_decision_task_spec.rb
@@ -27,6 +27,11 @@ describe TahiStandardTasks::RegisterDecisionTask do
     )
   end
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   context "letters" do
     before do
       user = double(:last_name, last_name: 'Mazur')

--- a/engines/tahi_standard_tasks/spec/models/related_articles_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/related_articles_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::RelatedArticlesTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/reporting_guidelines_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/reporting_guidelines_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::ReportingGuidelinesTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/reviewer_recommendations_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/reviewer_recommendations_task_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 describe TahiStandardTasks::ReviewerRecommendationsTask do
   subject(:task) { FactoryGirl.create(:reviewer_recommendations_task) }
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+
   describe '#reviewer_recommendations association' do
     let!(:recommendation) do
       FactoryGirl.create(

--- a/engines/tahi_standard_tasks/spec/models/reviewer_report_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/reviewer_report_task_spec.rb
@@ -12,4 +12,9 @@ describe TahiStandardTasks::ReviewerReportTask do
     subject { TahiStandardTasks::ReviewerReportTask::DEFAULT_ROLE }
     it { is_expected.to eq('reviewer') }
   end
+
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults does not update title'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
 end

--- a/engines/tahi_standard_tasks/spec/models/revise_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/revise_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::ReviseTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/send_to_apex_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/send_to_apex_task_spec.rb
@@ -5,11 +5,12 @@ describe TahiStandardTasks::SendToApexTask do
     FactoryGirl.create :paper, :with_tasks
   end
   let!(:task) do
-    TahiStandardTasks::SendToApexTask.create!(
-      paper: paper,
-      old_role: 'editor',
-      phase: paper.phases.first
-    )
+    FactoryGirl.create(:send_to_apex_task, paper: paper)
+  end
+
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
   end
 
   describe '#apex_deliveries association' do

--- a/engines/tahi_standard_tasks/spec/models/supporting_information_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/supporting_information_task_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 module TahiStandardTasks
   describe SupportingInformationTask do
+    describe '.restore_defaults' do
+      include_examples '<Task class>.restore_defaults update title to the default'
+      include_examples '<Task class>.restore_defaults update old_role to the default'
+    end
+
     describe "#file_access_details" do
       let(:paper) { FactoryGirl.create(:paper, :with_tasks) }
 

--- a/engines/tahi_standard_tasks/spec/models/taxon_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/taxon_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::TaxonTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/engines/tahi_standard_tasks/spec/models/upload_manuscript_task_spec.rb
+++ b/engines/tahi_standard_tasks/spec/models/upload_manuscript_task_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe TahiStandardTasks::UploadManuscriptTask do
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults update title to the default'
+    include_examples '<Task class>.restore_defaults update old_role to the default'
+  end
+end

--- a/spec/factories/task_factory.rb
+++ b/spec/factories/task_factory.rb
@@ -17,6 +17,13 @@ FactoryGirl.define do
     old_role "admin"
   end
 
+  factory :cover_letter_task, class: 'TahiStandardTasks::CoverLetterTask' do
+    phase
+    paper
+    title "Cover Letter"
+    old_role "author"
+  end
+
   factory :competing_interests_task, class: 'TahiStandardTasks::CompetingInterestsTask' do
     phase
     paper
@@ -135,13 +142,6 @@ FactoryGirl.define do
     paper
     title "Invitable Task"
     old_role "user"
-  end
-
-  factory :cover_letter_task, class: "TahiStandardTasks::CoverLetterTask" do
-    phase
-    paper
-    title "Cover Letter"
-    old_role "author"
   end
 
   factory :metadata_task, class: 'MockMetadataTask' do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 describe Task do
   let(:paper) { FactoryGirl.create :paper, :with_tasks }
 
+  describe '.restore_defaults' do
+    include_examples '<Task class>.restore_defaults does not update title'
+    include_examples '<Task class>.restore_defaults does not update old_role'
+  end
+
   describe ".without" do
     let!(:tasks) do
       2.times.map do

--- a/spec/support/shared_examples/task_shared_examples.rb
+++ b/spec/support/shared_examples/task_shared_examples.rb
@@ -1,0 +1,75 @@
+shared_examples '<Task class>.restore_defaults does not update title' do
+  let!(:task_class) do
+    described_class.name.demodulize.underscore.to_sym
+  end
+  let!(:task_1) do
+    FactoryGirl.create(task_class, title: 'Foo bar', old_role: 'admin')
+  end
+  let!(:task_2) do
+    FactoryGirl.create(task_class, title: 'Baz foo', old_role: 'somebody')
+  end
+
+  it 'does not restore the title of any of its instances' do
+    expect do
+      described_class.restore_defaults
+    end.to_not change { [task_1.reload.title, task_2.reload.title] }
+  end
+end
+
+shared_examples '<Task class>.restore_defaults does not update old_role' do
+  let!(:task_class) do
+    described_class.name.demodulize.underscore.to_sym
+  end
+  let!(:task_1) do
+    FactoryGirl.create(task_class, title: 'Foo bar', old_role: 'admin')
+  end
+  let!(:task_2) do
+    FactoryGirl.create(task_class, title: 'Baz foo', old_role: 'somebody')
+  end
+
+  it 'does not restore the old_role of any of its instances' do
+    expect do
+      described_class.restore_defaults
+    end.to_not change { [task_1.reload.old_role, task_2.reload.old_role] }
+  end
+end
+
+shared_examples '<Task class>.restore_defaults update title to the default' do
+  let!(:task_class) do
+    described_class.name.demodulize.underscore.to_sym
+  end
+  let!(:task_1) do
+    FactoryGirl.create(task_class, title: 'Foo bar', old_role: 'admin')
+  end
+  let!(:task_2) do
+    FactoryGirl.create(task_class, title: 'Baz foo', old_role: 'somebody')
+  end
+
+  it 'does not restore the title of any of its instances' do
+    expect do
+      described_class.restore_defaults
+    end.to change { [task_1.reload.title, task_2.reload.title] }.to(
+      [described_class::DEFAULT_TITLE, described_class::DEFAULT_TITLE]
+    )
+  end
+end
+
+shared_examples '<Task class>.restore_defaults update old_role to the default' do
+  let!(:task_class) do
+    described_class.name.demodulize.underscore.to_sym
+  end
+  let!(:task_1) do
+    FactoryGirl.create(task_class, title: 'Foo bar', old_role: 'admin')
+  end
+  let!(:task_2) do
+    FactoryGirl.create(task_class, title: 'Baz foo', old_role: 'somebody')
+  end
+
+  it 'does not restore the old_role of any of its instances' do
+    expect do
+      described_class.restore_defaults
+    end.to change { [task_1.reload.old_role, task_2.reload.old_role] }.to(
+      [described_class::DEFAULT_ROLE, described_class::DEFAULT_ROLE]
+    )
+  end
+end


### PR DESCRIPTION
JIRA issue: [APERTA-7030](https://developer.plos.org/jira/browse/APERTA-7030)

Paired with Ben Beckwith (@bnbeckwith)
#### What this PR does:

This makes it so reviewer report titles are not overwritten on deploy.
#### Notes
- Push logic for blindly updating task titles and old_roles column into the Task class
- This lets each task class own the behavior that makes sense.
- This resolves the issue where dynamically updated titles for reviewer reports were being overwritten on deploy
- etching in skeleton specs for tasks that had none

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
