### PR TITLE
APERTA-7080 Reverse default order of paper types

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -74,7 +74,9 @@ class Journal < ActiveRecord::Base
   end
 
   def paper_types
-    self.manuscript_manager_templates.pluck(:paper_type)
+    # We ordering by the oldest articles first to have 'Research Article'
+    # to float to the top of the article drop down list
+    manuscript_manager_templates.unscoped.order('id asc').pluck(:paper_type)
   end
 
   def valid_old_roles

--- a/app/serializers/journal_serializer.rb
+++ b/app/serializers/journal_serializer.rb
@@ -1,10 +1,4 @@
 class JournalSerializer < ActiveModel::Serializer
   attributes :id, :name, :logo_url, :paper_types, :manuscript_css
 
-  # We want to reverse the order of paper_types here so that the oldest paper
-  # types appear first so users do not need to dig through tons of types
-  # that may not be relevant
-  def paper_types
-    object.paper_types.reverse
-  end
 end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7080
#### What this PR does:

Users have been selecting "Unsolved Mystery" and all the latest, but wrong, article types because they appear at the top of the dropdown while "Research Article" is at the very bottom.

This PR reverses the order that journal paper_types are presented as a quick win so as to avoid this confusion.

Note that the QA test case for this is captured in https://developer.plos.org/jira/browse/APERTA-7083 as we want this PR in for the RC ASAP.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
