### PR TITLE
Chore: Intermittent spec failure fix, query parser roles.

### DIFF
--- a/app/services/query_parser.rb
+++ b/app/services/query_parser.rb
@@ -51,7 +51,7 @@ class QueryParser < QueryLanguageParser
   add_two_part_expression('USER', 'HAS ROLE') do |username, role|
     user_id = get_user_id(username)
     role_ids = Role.where('lower(name) = ?', role.downcase)
-                   .pluck(:id)
+                   .pluck(:id).sort
 
     table = join(Assignment, 'assigned_to_id')
     table['user_id'].eq(user_id)


### PR DESCRIPTION
Teeny tiny intermittent spec issue which was due to role_id ordering being different intermittently:

Got this error on CircleCI:

```
1) QueryParser#parse people queries parses across multiple roles of same name for USER x HAS ROLE president
     Failure/Error: expect(parse.to_sql).to eq(<<-SQL.strip)

       expected: "\"assignments_0\".\"user_id\" = 70 AND \"assignments_0\".\"role_id\" IN (219, 220) AND \"assignments_0\".\"assigned_to_type\" = 'Paper'"
            got: "\"assignments_0\".\"user_id\" = 70 AND \"assignments_0\".\"role_id\" IN (220, 219) AND \"assignments_0\".\"assigned_to_type\" = 'Paper'"

       (compared using ==)
```

This ensures that the order for role_id is now always sorted.
