### PR TITLE
APERTA-7080 Remove unscoped from paper types that was pulling in all …

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -76,7 +76,7 @@ class Journal < ActiveRecord::Base
   def paper_types
     # We ordering by the oldest articles first to have 'Research Article'
     # to float to the top of the article drop down list
-    manuscript_manager_templates.unscoped.order('id asc').pluck(:paper_type)
+    manuscript_manager_templates.order('id asc').pluck(:paper_type)
   end
 
   def valid_old_roles

--- a/app/serializers/journal_serializer.rb
+++ b/app/serializers/journal_serializer.rb
@@ -1,4 +1,3 @@
 class JournalSerializer < ActiveModel::Serializer
   attributes :id, :name, :logo_url, :paper_types, :manuscript_css
-
 end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7080
#### What this PR does:

This PR fixes the dropdown so that it only has articles for that particular journal instead of all journals.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature

…journals
