### PR TITLE
Fix version sorting when deploying to RC

### DIFF
--- a/config/deploy/rc.rb
+++ b/config/deploy/rc.rb
@@ -5,7 +5,8 @@ ask :branch, proc {
   `git ls-remote --heads`.lines
     .map { |l| l.split(' ').last.strip }
     .select { |b| b =~ %r{^refs/heads/release/[0-9\.]+$} }
-    .sort.last
+    .sort_by { |b| Gem::Version.new(b.split(%r{/}).last) }
+    .last
 }
 
 server 'tahi-worker-201.sfo.plos.org', user: 'aperta', roles: %w(cron db worker)


### PR DESCRIPTION
We want to default to deploying the latest version to RC. Previously, we
were using alphabetic sort, which does not support version numbers
properly.

Instead, extract the version and wrap in Gem::Version. This will
properly support semantic versioning.
