### PR TITLE
APERTA-7160 remove numeral

### DIFF
--- a/client/app/pods/paper-tracker/row/template.hbs
+++ b/client/app/pods/paper-tracker/row/template.hbs
@@ -21,7 +21,7 @@
   <td class="paper-tracker-members-column">
     {{#each paper.simplifiedRelatedUsers as |role|}}
     <div class="paper-tracker-users-group">
-      <span>{{role.users.length}} {{pluralize-string string=role.name count=role.users.length}}:</span>
+      <span>{{pluralize-string string=role.name count=role.users.length}}:</span>
       {{comma-separated-user-list users=role.users}}
     </div>
     {{/each}}


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7160
#### What this PR does:

Removes leading numerals from 'Member' categories on paper tracker.  '1 Reviewer' becomes 'Reviewer'

![image](https://cloud.githubusercontent.com/assets/2043348/16504606/d89d5c2a-3ee6-11e6-97f2-5950fa16ea04.png)

---
#### After the Code Review:
- [ ] The Product Team has reviewed and approved this feature
