### PR TITLE
CHORE: up data_migration rails generator template

### DIFF
--- a/lib/generators/data_migration/templates/migration.rb
+++ b/lib/generators/data_migration/templates/migration.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < DataMigration
   RAKE_TASK_UP = place_rake_task_as_string_here
   # RAKE_TASK_DOWN = 'fill_me_in or delete me if unnecessary'
 end

--- a/spec/generators/data_migration_generator_spec.rb
+++ b/spec/generators/data_migration_generator_spec.rb
@@ -26,7 +26,7 @@ describe DataMigrationGenerator, type: :generator do
 
   it 'provides a default migration skeleton' do
     expect(File.read(migration)).to eq <<-FILE.strip_heredoc
-      class PaintTheSkyBlue < ActiveRecord::Migration
+      class PaintTheSkyBlue < DataMigration
         RAKE_TASK_UP = place_rake_task_as_string_here
         # RAKE_TASK_DOWN = 'fill_me_in or delete me if unnecessary'
       end


### PR DESCRIPTION
JIRA issue: none
#### What this PR does:

Running `rails generate data_migration MySweetChanges` will now generate a skeleton migration that subclasses `DataMigration`. This was an oversight on my part when introducing the generator.
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I have found the tests to be sufficient
