### PR TITLE
APERTA-6881: Tweaks to S3 migration based on first staging run

### DIFF
--- a/app/models/s3_migration.rb
+++ b/app/models/s3_migration.rb
@@ -39,8 +39,10 @@ class S3Migration < ActiveRecord::Base
 
   def self.migrate!
     ready.all.each do |migration|
-      puts "Performing migration: #{migration.inspect}"
-      migration.migrate!
+      transaction do
+        puts "Performing migration: #{migration.inspect}"
+        migration.migrate!
+      end
     end
   end
 
@@ -188,8 +190,10 @@ class S3Migration < ActiveRecord::Base
       if child
         # update snapshot to use new_file_hash instead of the previous_file_hash
         child['value'] = new_file_hash
-        child.save!
-        snapshot
+
+        # we're updating the internals contents of the snaphot above so
+        # be sure to save the snapshot
+        snapshot.save!
       end
     end
   end

--- a/lib/tasks/data-migrations/s3_attachments.rake
+++ b/lib/tasks/data-migrations/s3_attachments.rake
@@ -9,6 +9,10 @@ namespace :data do
       task prepare: :environment do
         Attachment.transaction do
           Attachment.all.each do |attachment|
+            # if there are attachment(s) that failed during processing
+            # then they won't have a file path, so skip them
+            next unless attachment.file.path
+
             if attachment.s3_dir
               S3Migration.create!(
                 source_url: attachment.file.path,
@@ -73,7 +77,7 @@ namespace :data do
       task perform: :environment do
         ::AttachmentUploader.include S3Migration::UploaderOverrides
 
-        S3Migration.transaction { S3Migration.migrate! }
+        S3Migration.migrate!
       end
     end
   end


### PR DESCRIPTION
Looking over the S3 Migration logs, I made the following tweaks:
- Ignore borked attachment files. There were 4 files on staging that did not point to actual files. It looks like they may have been TIFFs that could not be processed. 
- Make sure snapshots that are updated are saving.
- Wrap each individual file migration in a transaction rather than everything. My network connection died earlier and it everything got rolled back. The migrations are smart enough to pick up where they left off, but the transaction was too broadly applied.
