### PR TITLE
APERTA-6881: S3 Migration tweaks after third staging run

### DIFF
--- a/app/models/s3_migration.rb
+++ b/app/models/s3_migration.rb
@@ -119,6 +119,7 @@ class S3Migration < ActiveRecord::Base
         errored_at: Time.zone.now
       )
       puts "Owner and Paper are nil. Attachment (id=#{attachment.id}) is an orphan. :("
+      failed!
       return
     end
 


### PR DESCRIPTION
This is a one-line change that marks an `S3Migration` record has `failed` in the case where it's owner and paper are both `nil`.
