### PR TITLE
Optionally pull down rc environment with import_prod

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -4,9 +4,15 @@ Rake::Task["db:load"].clear
 
 namespace :db do
 
-  # rake db:import_prod[rc] will import in the rc environment instead
-  desc "Dumps slightly older prod database from internal network into development environment"
-  task :import_prod, [:env] => :environment do |t, args|
+  desc <<-DESC
+    Dumps slightly older prod database from internal network into development environment
+
+    This also optionally accepts a variable that will pull in different environments if they are hosted on Hector.
+    For example 'rake db:import_remote[rc]' will import in the rc environment instead,
+    while 'rake db:import_remote[dev]' would pull in a 'dev' environment if
+    'dev_dump.tar.gz' exists in bighector.
+  DESC
+  task :import_remote, [:env] => :environment do |t, args|
     return unless Rails.env.development?
     env = args[:env]
     location = "http://bighector.plos.org/aperta/#{env || 'db'}_dump.tar.gz"
@@ -18,7 +24,7 @@ namespace :db do
       if result
         STDERR.puts("Successfully restored #{env || 'prod'} database by running \n #{cmd}")
       else
-        STDERR.puts("Restored #{env || prod} with errors or warnings")
+        STDERR.puts("Restored #{env || 'prod'} with errors or warnings")
       end
     end
   end


### PR DESCRIPTION
Small change to allow for optionally pulling down the rc environment as well from Big Hector.

---
#### Code Review Tasks:

Author tasks:  
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] If I made any UI changes, I've let QA know. 

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
