### PR TITLE
Add heroku-specific sidekiq.yml

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq
+web: bundle exec puma
+worker: bundle exec sidekiq -C config/sidekiq.heroku.yml

--- a/config/sidekiq.heroku.yml
+++ b/config/sidekiq.heroku.yml
@@ -1,0 +1,5 @@
+---
+:queues:
+  - default
+  - mailers
+  - eventstream


### PR DESCRIPTION
heroku does not need a pid file, and the one we have in sidekiq.yml is
in a non-existent directory on heroku, so it was failing.

Also, do not pass in unnecessary -C config/puma.rb (this is the default)
