### PR TITLE
Include Capybara rspec matchers in page model

### DIFF
--- a/spec/support/pages/page.rb
+++ b/spec/support/pages/page.rb
@@ -11,6 +11,7 @@ class PageFragment
   extend WaitForAjax
   include WaitForAjax
   include Capybara::Select2
+  include Capybara::RSpecMatchers
 
   attr_reader :element
 


### PR DESCRIPTION
This ensures (for reasons which are not clear to us) that:

``` ruby
expect(page).not_to have_css(...)
```

will not wait, but will return immediately if the css is not present.

This will effect `expect`s within methods in `Page` and `PageFragment` instances.
