### PR TITLE
Chore/speedup dashboard test

### DIFF
--- a/spec/support/pages/fragments/pending_invitation_fragment.rb
+++ b/spec/support/pages/fragments/pending_invitation_fragment.rb
@@ -2,12 +2,11 @@ class PendingInvitationFragment < PageFragment
   def accept(button_text='Accept')
     element_text = element.text
     click_button button_text
-    session.has_content? element_text
+    expect(session).to have_content element_text
   end
 
   def reject(button_text='Decline')
-    element_text = element.text
     click_button button_text
-    session.has_content? element_text
+    expect(session).to have_content("You've successfully declined this invitation")
   end
 end


### PR DESCRIPTION
- remove bogus non-passing non-assertion

In testing the other capybara-related PR, we noticed that the dashboard spec was waiting after rejecting an invite for what seemed like no good reason.  In this case it was calling `session.has_content?` with some text that didn't exist on the page.  
The has_content check was never actually passing.  Since it wasn't
an assertion, it would simply time out and return false.
