### PR TITLE
APERTA-6743 add error metadata to bugsnag report

### DIFF
--- a/client/app/instance-initializers/error-handler.js
+++ b/client/app/instance-initializers/error-handler.js
@@ -18,12 +18,8 @@ export default {
           if (typeof Bugsnag !== 'undefined' && Bugsnag && Bugsnag.notifyException) {
             if (error.errors && error.errors.length) {
               let meta = {
-                metaData: {}
+                errorInfo: {'error.errors': error.errors}
               };
-
-              error.errors.forEach((err, i) => {
-                meta.metaData[`error_info_${i + 1}`] = err;
-              });
 
               Bugsnag.notifyException(error, 'Uncaught Ember Error', meta);
             } else {


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6743

We get a lot of "adapter operation failed" bugs in bugsnag that don't have any further info.
For some errors the error object will have an errors[] array that
bugsnag misses.  We've only seen it have 1 item in our limited survey,
so for now that's what we're extracting.

That data will show up in a tab as per
https://docs.bugsnag.com/platforms/browsers/reporting-handled-errors/#adding-metadata-to-exceptions

After this we can at least see what the response code from the server was.  For instance we'll be able to see that this error was a 401.
![image](https://cloud.githubusercontent.com/assets/2043348/17225872/a52e2ee2-54d4-11e6-83f5-797dc9c470db.png)

For reference here's how we tested on tahi staging. When we post this:
![image](https://cloud.githubusercontent.com/assets/2043348/17590504/00a3652a-5fa8-11e6-9890-b19f24047ff3.png)

We see this on bugsnag:
![image](https://cloud.githubusercontent.com/assets/2043348/17590535/1be96dca-5fa8-11e6-938b-2990497b2021.png)
