### PR TITLE
Hot fix for APERTA-6881 Reset the primary key sequence on the attachments table

### DIFF
--- a/db/migrate/20160804202224_reset_attachment_primary_key_sequence.rb
+++ b/db/migrate/20160804202224_reset_attachment_primary_key_sequence.rb
@@ -1,0 +1,32 @@
+# This updates the primary key sequence for the attachments table. PostgreSQL
+# doesn't automatically set this after INSERTing rows unless nextval() is used.
+# This migration is safe to run forwards and backwards and will work if there
+# are 0 or more records.
+class ResetAttachmentPrimaryKeySequence < ActiveRecord::Migration
+  def up
+    update_attachments_id_seq
+  end
+
+  def down
+    update_attachments_id_seq
+  end
+
+  private
+
+  def update_attachments_id_seq
+    # Use COALESCE in case there are no records in the table, in that case
+    # set the sequence ID to 1. For more information see:
+    #
+    #   https://www.postgresql.org/docs/current/static/functions-conditional.html#FUNCTIONS-COALESCE-NVL-IFNULL
+    #
+    # Pass in false to setval as its second argument to indicate that this
+    # value should be provided the next time nextval() is called. For more
+    # information see:
+    #
+    #   https://www.postgresql.org/docs/9.5/static/functions-sequence.html
+    #
+    execute <<-SQL
+     SELECT setval('attachments_id_seq', coalesce((select max(id)+1 from attachments), 1), false);
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160728142239) do
+ActiveRecord::Schema.define(version: 20160804202224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
JIRA issue: APERTA-6881

This resets the primary key sequence on the attachments table.

This is necessary since postgresql does not do this on its own and all of the attachments/s3-migration work will INSERT a whole bunch of data into the attachments table.

So the attachments table will have IDs up to a high value (like 7001) but the primary key sequence will return a very low number (like 101) for its nextval. This will cause  unnecessary unique violation constraints.

If we end up with a maximum ID of 7001 then this migration ensures the nextval will be 7002.
### Testing locally

Say `17` is the highest `id` you currently have in `attachments`. If you INSERT a new attachment and manually specify the `id` without calling `nextval()`:

```
psql> select last_value from attachments_id_seq;
17
psql> INSERT INTO attachments(id, file) values (18, 'foo.png');
INSERT 0 1
psql> select last_value from attachments_id_seq;
17
```

In the last query above you can see the `attachments_id_seq` sequence didn't get updated.  If you try to INSERT a new attachment letting Postgresql automatically pick the ID then you'll get a unique constraint error:

```
psql> INSERT INTO attachments(file) values ('foo.png');
ERROR:  duplicate key value violates unique constraint "attachments_pkey"
DETAIL:  Key (id)=(18) already exists.
```

This PR makes sure it is updated. After running the migration you should see:

```
psql> select last_value from attachments_id_seq;
18
```

And you should be able to run the line above that failed:

```
psql> INSERT INTO attachments(file) values ('foo.png');
INSERT 0 1
```
