### PR TITLE
Add billing values to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,12 @@
     "BASIC_HTTP_USERNAME": {
       "required": true
     },
+    "BILLING_FTP_ENABLED": {
+      "required": true
+    },
+    "BILLING_FTP_URL": {
+      "required": true
+    },
     "BUGSNAG_API_KEY": {
       "required": true
     },


### PR DESCRIPTION
I missed these in https://github.com/Tahi-project/tahi/pull/2476/files#diff-7240be7a02d8789cae2c0970f0260dfeR33, and right now the review apps are all borked as a result.

See https://dashboard.heroku.com/pipelines/37eb5120-a142-4c82-8b0c-d82a33f891aa/review-app/5ea78498-33ef-4e43-b9be-3e2e855ea8b8 as an example.

The env vars are configured on ciagent-stage, but since the app.json doesn't have the values set those vars aren't propagating down.
For reference here are the values on ciagent-stage:
![image](https://cloud.githubusercontent.com/assets/2043348/17517848/48b388cc-5e13-11e6-9e9b-ff31cfb84023.png)

In reality I think both ftp_url vars could be `required: false` but I didn't want to break precedent at this point
