### PR TITLE
Chore: Adds two new article types for development seeds

### DIFF
--- a/db/data.yml
+++ b/db/data.yml
@@ -4385,6 +4385,14 @@ manuscript_manager_templates:
     - Non-Research
     - '1'
     - false
+  - - '3'
+    - No Author Tasks (Gradual Engagement)
+    - '1'
+    - false
+  - - '4'
+    - No Author Tasks
+    - '1'
+    - false
 
 ---
 nested_question_answers:
@@ -14720,6 +14728,18 @@ phase_templates:
     - '2016-06-02 13:40:41.582947'
     - '2016-06-02 13:40:41.582947'
     - '5'
+  - - '74'
+    - Phase 1
+    - '3'
+    - '2016-08-16 14:10:21.595802'
+    - '2016-08-16 14:10:21.595802'
+    - '1'
+  - - '75'
+    - Phase 1
+    - '4'
+    - '2016-08-16 14:10:56.046532'
+    - '2016-08-16 14:10:56.046532'
+    - '1'
 
 ---
 phases:
@@ -16677,6 +16697,132 @@ task_templates:
     - Register Decision
     - "[]"
     - '1'
+  - - '230'
+    - '14'
+    - '74'
+    - Register Decision
+    - "[]"
+    - '1'
+  - - '231'
+    - '9'
+    - '74'
+    - Assign Admin
+    - "[]"
+    - '2'
+  - - '232'
+    - '28'
+    - '74'
+    - Assign Team
+    - "[]"
+    - '3'
+  - - '233'
+    - '23'
+    - '74'
+    - Final Tech Check
+    - "[]"
+    - '4'
+  - - '234'
+    - '30'
+    - '74'
+    - Initial Decision
+    - "[]"
+    - '5'
+  - - '235'
+    - '24'
+    - '74'
+    - Initial Tech Check
+    - "[]"
+    - '6'
+  - - '236'
+    - '25'
+    - '74'
+    - Revision Tech Check
+    - "[]"
+    - '7'
+  - - '237'
+    - '31'
+    - '74'
+    - Send to Apex
+    - "[]"
+    - '8'
+  - - '238'
+    - '33'
+    - '74'
+    - Title And Abstract
+    - "[]"
+    - '9'
+  - - '239'
+    - '10'
+    - '74'
+    - Invite Academic Editor
+    - "[]"
+    - '10'
+  - - '240'
+    - '11'
+    - '74'
+    - Invite Reviewers
+    - "[]"
+    - '11'
+  - - '241'
+    - '14'
+    - '75'
+    - Register Decision
+    - "[]"
+    - '1'
+  - - '242'
+    - '9'
+    - '75'
+    - Assign Admin
+    - "[]"
+    - '2'
+  - - '243'
+    - '28'
+    - '75'
+    - Assign Team
+    - "[]"
+    - '3'
+  - - '244'
+    - '23'
+    - '75'
+    - Final Tech Check
+    - "[]"
+    - '4'
+  - - '245'
+    - '24'
+    - '75'
+    - Initial Tech Check
+    - "[]"
+    - '5'
+  - - '246'
+    - '10'
+    - '75'
+    - Invite Academic Editor
+    - "[]"
+    - '6'
+  - - '247'
+    - '11'
+    - '75'
+    - Invite Reviewers
+    - "[]"
+    - '7'
+  - - '248'
+    - '25'
+    - '75'
+    - Revision Tech Check
+    - "[]"
+    - '8'
+  - - '249'
+    - '33'
+    - '75'
+    - Title And Abstract
+    - "[]"
+    - '9'
+  - - '250'
+    - '31'
+    - '75'
+    - Send to Apex
+    - "[]"
+    - '10'
 
 ---
 tasks:


### PR DESCRIPTION
This adds two new Article Types to the PLOS Yeti journal in DB seeds to make it easier to submit papers during development.

It adds the following article types:
- No Author Tasks (Gradual Engagement)
- No Authors Tasks

This makes the papers for these journal types submittable by defaults.

_Note: There are no code changes._
