### PR TITLE
APERTA-7469 Remove all traces of segment.io

### DIFF
--- a/app.json
+++ b/app.json
@@ -192,9 +192,6 @@
     "S3_URL": {
       "required": true
     },
-    "SEGMENT_IO_WRITE_KEY": {
-      "required": true
-    },
     "USE_NED_INSTITUTIONS": {
       "required": true
     }

--- a/app/views/ember_cli/ember/index.html.erb
+++ b/app/views/ember_cli/ember/index.html.erb
@@ -10,7 +10,6 @@
     <%= csrf_meta_tags %>
 
     <% if !(Rails.env.test? || Rails.env.development?) %>
-      <%= render "shared/segment_io" %>
       <%= render "shared/bugsnag_javascript" %>
     <% end %>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
     <% end %>
     <%= csrf_meta_tags %>
     <% if !(Rails.env.test? || Rails.env.development?) %>
-      <%= render "shared/segment_io" %>
       <%= render "shared/bugsnag_javascript" %>
     <% end %>
   </head>

--- a/app/views/shared/_segment_io.html.erb
+++ b/app/views/shared/_segment_io.html.erb
@@ -1,7 +1,0 @@
-<% if ENV['SEGMENT_IO_WRITE_KEY'] %>
-  <script type="text/javascript">
-    window.analytics=window.analytics||[],window.analytics.methods=["identify","group","track","page","pageview","alias","ready","on","once","off","trackLink","trackForm","trackClick","trackSubmit"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var key=window.analytics.methods[i];window.analytics[key]=window.analytics.factory(key)}window.analytics.load=function(t){if(!document.getElementById("analytics-js")){var a=document.createElement("script");a.type="text/javascript",a.id="analytics-js",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.io/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)}},window.analytics.SNIPPET_VERSION="2.0.9",
-    window.analytics.load("<%= ENV['SEGMENT_IO_WRITE_KEY'] %>");
-    window.analytics.page();
-  </script>
-<% end %>

--- a/lib/tahi_env.rb
+++ b/lib/tahi_env.rb
@@ -157,9 +157,6 @@ class TahiEnv
   required :DATABASEDOTCOM_USERNAME, if: :salesforce_enabled?
   required :DATABASEDOTCOM_PASSWORD, if: :salesforce_enabled?
 
-  # Segment IO
-  optional :SEGMENT_IO_WRITE_KEY
-
   # Sendgrid
   required :SENDGRID_USERNAME
   required :SENDGRID_PASSWORD

--- a/spec/lib/tahi_env_spec.rb
+++ b/spec/lib/tahi_env_spec.rb
@@ -158,9 +158,6 @@ describe TahiEnv do
   it_behaves_like 'dependent required env var', var: 'DATABASEDOTCOM_USERNAME', dependent_key: 'SALESFORCE_ENABLED'
   it_behaves_like 'dependent required env var', var: 'DATABASEDOTCOM_PASSWORD', dependent_key: 'SALESFORCE_ENABLED'
 
-  # Segment IO
-  it_behaves_like 'optional env var', var: 'SEGMENT_IO_WRITE_KEY'
-
   # Sendgrid
   it_behaves_like 'required env var', var: 'SENDGRID_USERNAME'
   it_behaves_like 'required env var', var: 'SENDGRID_PASSWORD'


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7469
#### What this PR does:

Removes our integration with segment.io
#### Major UI changes

None
#### Notes
- segment io was not used in production, so the env vars used in dev/staging are not present in salt.

---
#### Code Review Tasks:

Author tasks:

~~\- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)~~
~~\- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`~~
~~\- [ ] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)~~

If I modified any environment variables:
- [X] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [X] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging
  ~~\- [ ] If I made any UI changes, I've let QA know.~~

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature

Although none of us were using it, we were still hitting segment.io.
Remove all trace of it.
