### PR TITLE
APERTA-6719 add rescind to activity feed

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -53,6 +53,8 @@ class DecisionsController < ApplicationController
 
     decision.rescind!
 
+    Activity.decision_rescinded! decision, user: current_user
+
     render json: decision.paper.decisions,
            each_serializer: DecisionSerializer,
            root: 'decisions'

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -111,6 +111,16 @@ class Activity < ActiveRecord::Base
     ]
   end
 
+  def self.decision_rescinded!(decision, user:)
+    create(
+      feed_name: "workflow",
+      activity_key: "decision.rescinded",
+      subject: decision.paper,
+      user: user,
+      message: "A decision was rescinded"
+    )
+  end
+
   def self.invitation_created!(invitation, user:)
     create(
       feed_name: "workflow",

--- a/spec/controllers/decisions_controller_spec.rb
+++ b/spec/controllers/decisions_controller_spec.rb
@@ -310,6 +310,13 @@ describe DecisionsController do
           expect(paper.reload.publishing_state).to eq("submitted")
           expect(decision.reload.rescinded).to be(true)
         end
+
+        it "posts to the activity stream" do
+          expect(Activity)
+            .to(receive(:decision_rescinded!))
+            .with(decision, user: user)
+          do_request
+        end
       end
 
       context "the decision is not rescindable" do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -116,6 +116,21 @@ describe Activity do
     end
   end
 
+  describe "#decision_rescinded!" do
+    subject(:activities) { Activity.decision_rescinded!(decision, user: user) }
+    let(:decision) { FactoryGirl.build_stubbed(:decision) }
+
+    it do
+      is_expected.to have_attributes(
+        feed_name: "workflow",
+        activity_key: "decision.rescinded",
+        subject: decision.paper,
+        user: user,
+        message: "A decision was rescinded"
+      )
+    end
+  end
+
   describe "#invitation_created!" do
     subject(:activity) { Activity.invitation_created!(invitation, user: user) }
     let(:invitation) { FactoryGirl.build_stubbed(:invitation) }


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6719
#### What this PR does:

Rescind. It's back! And it's hungry for an activity feed entry!

Now when a user rescinds a paper, an entry should appear in that paper's activity log saying "A decision has been rescinded".
#### Notes
#### Major UI changes

---
#### Code Review Tasks:

Author tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
