### PR TITLE
APERTA-7470: Backfill data, prevent issue from reoccurring

### DIFF
--- a/db/migrate/20160819150432_back_fill_register_decision_letter_selections.rb
+++ b/db/migrate/20160819150432_back_fill_register_decision_letter_selections.rb
@@ -1,0 +1,5 @@
+# This is a hot-fix for part of APERTA-7470. See the rake task description
+# for more information.
+class BackFillRegisterDecisionLetterSelections < DataMigration
+  RAKE_TASK_UP = 'data:migrate:set_register_decision_letter_answers'
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160808131819) do
+ActiveRecord::Schema.define(version: 20160819150432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/data-migrations/set-register-decision-letter-answers.rake
+++ b/lib/tasks/data-migrations/set-register-decision-letter-answers.rake
@@ -1,0 +1,35 @@
+namespace :data do
+  namespace :migrate do
+    desc <<-EOT.strip_heredoc
+      Ensure an answer exists for the selected-template question for each
+      RegisterDecisionTask whose paper has a decision with a verdict.
+
+      This is to backfill answers for existing decisions based on the letter
+      template work.
+    EOT
+    task set_register_decision_letter_answers: :environment do
+      question = NestedQuestion.find_by!(ident: 'register_decision_questions--selected-template')
+
+      TahiStandardTasks::RegisterDecisionTask.all.includes(:paper).find_each do |task|
+        most_recent_decision_with_a_verdict = task.paper.decisions.
+          unscoped.
+          where.not(verdict: nil).
+          order('id asc').last
+
+        # skip if there are no decisions with verdicts which indicates
+        # no decision has been registered or is in the process of being
+        # regsitered.
+        next unless most_recent_decision_with_a_verdict
+
+        answer = task.find_or_build_answer_for(nested_question: question)
+        if answer.new_record?
+          verdict = most_recent_decision_with_a_verdict.verdict
+          puts "Setting the register decision letter to #{verdict.inspect} for #{task.inspect} based on decisid id=#{most_recent_decision_with_a_verdict.id}"
+          answer.update!(value: verdict)
+        else
+          # skip, do not overwrite existing answers
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: [APERTA-7470](https://developer.plos.org/jira/browse/APERTA-7470)
#### What this PR does:

This ensures an answer exists for the selected-template question for each RegisterDecisionTask whose paper has a decision with a verdict.

This is to backfill answers for existing decisions based on the recent letter template work.

This prevents the existing letter-template component from inadvertently sending an event on behalf of the user that results in overwriting letter templates.
#### Notes

This does NOT resolve all of APERTA-7470. It just stops the issue from affecting new decisions, but it does not restore data for already affected decisions.
#### Major UI changes

None.

Although, locally I always see the text of the letter template

---
#### Code Review Tasks:

Author tasks:
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
  ~~\- [ ] If I created a data-migration task, I added copy-pastable instructions to run it on heroku to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)~~

If I modified any environment variables:
- [x] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [x] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging
- [x] If I made any UI changes, I've let QA know.

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature

RegisterDecisionTask whose paper has a decision with a verdict.

This is to backfill answers for existing decisions based on the letter
template work.

This prevents the existing letter-template component from inadvertently sending an event on behalf of the user that results in overwriting letter templates.

APERTA-7470
