### PR TITLE
APERTA-6647 Display decision on ms activity feed

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -93,22 +93,13 @@ class Activity < ActiveRecord::Base
   end
 
   def self.decision_made!(decision, user:)
-    [
-      create(
-        feed_name: "workflow",
-        activity_key: "decision.made",
-        subject: decision.paper,
-        user: user,
-        message: "A decision was made: #{decision.verdict.titleize}"
-      ),
-      create(
-        feed_name: "manuscript",
-        activity_key: "decision.sent",
-        subject: decision.paper,
-        user: user,
-        message: "A decision was sent to the author"
-      )
-    ]
+    create(
+      feed_name: "manuscript",
+      activity_key: "decision.made",
+      subject: decision.paper,
+      user: user,
+      message: "A decision was made: #{decision.verdict.titleize}"
+    )
   end
 
   def self.decision_rescinded!(decision, user:)

--- a/spec/controllers/decisions_controller_spec.rb
+++ b/spec/controllers/decisions_controller_spec.rb
@@ -210,21 +210,12 @@ describe DecisionsController do
       end
 
       it "posts to the activity stream" do
-        expected_activity_1 = {
-          message: "A decision was sent to the author",
-          feed_name: "manuscript"
-        }
-        expected_activity_2 = {
+        expect(Activity).to receive(:create).with hash_including(
           message: "A decision was made: Accept",
-          feed_name: "workflow"
-        }
-        expected_activity_3 = {
+          feed_name: "manuscript")
+        expect(Activity).to receive(:create).with hash_including(
           message: "Paper state changed to submitted",
-          feed_name: "forensic"
-        }
-        expect(Activity).to receive(:create).with hash_including(expected_activity_1)
-        expect(Activity).to receive(:create).with hash_including(expected_activity_2)
-        expect(Activity).to receive(:create).with hash_including(expected_activity_3)
+          feed_name: "forensic")
         do_request
       end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -95,23 +95,16 @@ describe Activity do
   end
 
   describe "#decision_made!" do
-    subject(:activities) { Activity.decision_made!(decision, user: user) }
+    subject(:activity) { Activity.decision_made!(decision, user: user) }
     let(:decision) { FactoryGirl.build_stubbed(:decision) }
 
-    it "creates two activities" do
-      expect(activities[0]).to have_attributes(
-        feed_name: "workflow",
+    it do
+      is_expected.to have_attributes(
+        feed_name: "manuscript",
         activity_key: "decision.made",
         subject: decision.paper,
         user: user,
         message: "A decision was made: #{decision.verdict.titleize}"
-      )
-      expect(activities[1]).to have_attributes(
-        feed_name: "manuscript",
-        activity_key: "decision.sent",
-        subject: decision.paper,
-        user: user,
-        message: "A decision was sent to the author"
       )
     end
   end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-6647
#### What this PR does:

Moves the "Decision was made" information from the workflow feed to the manuscript feed (which means it will be visible to authors)

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
