### PR TITLE
Remove hipchat cap integration

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -6,7 +6,6 @@ require 'capistrano/chruby'
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
-require 'hipchat/capistrano' unless ENV['HIPCHAT_AUTH_TOKEN'].nil?
 require "whenever/capistrano"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,6 @@ group :development do
   gem 'capistrano-chruby'
   gem 'capistrano-rails'
   gem 'foreman', require: false
-  gem 'hipchat'
   gem 'overcommit'
   gem 'rubocop'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,17 +384,11 @@ GEM
     hashie (3.4.2)
     heroku-deflater (0.5.3)
       rack (>= 1.4.5)
-    hipchat (1.5.3)
-      httparty
-      mimemagic
     hitimes (1.2.3)
     html_page (0.1.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
-    httparty (0.13.7)
-      json (~> 1.8)
-      multi_xml (>= 0.5.2)
     httpclient (2.6.0.1)
     humanize (1.1.0)
     i18n (0.7.0)
@@ -424,7 +418,6 @@ GEM
     migration_data (0.0.4)
       rails (>= 4.0.0.rc1)
     mime-types (2.99.2)
-    mimemagic (0.3.1)
     mini_magick (4.3.3)
     mini_portile (0.6.2)
     mini_portile2 (2.1.0)
@@ -729,7 +722,6 @@ DEPENDENCIES
   gepub (~> 0.7.0beta1)
   has_secure_token
   heroku-deflater
-  hipchat
   kaminari
   lograge
   mail_safe

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,11 +5,6 @@ set :application, 'tahi'
 set :assets_roles, [:web]
 set :chruby_exec, '/usr/bin/chruby-exec'
 set :chruby_ruby, File.read(File.expand_path('../../.ruby-version', __FILE__)).strip
-unless ENV['HIPCHAT_AUTH_TOKEN'].nil?
-  set :hipchat_room_name, '1777105'
-  set :hipchat_options, api_version: 'v2'
-  set :hipchat_token, ENV.fetch('HIPCHAT_AUTH_TOKEN')
-end
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle)
 set :linked_files, %w(env puma.rb)
 set :repo_url, 'git@github.com:Tahi-project/tahi.git'

--- a/lib/tahi_env.rb
+++ b/lib/tahi_env.rb
@@ -105,9 +105,6 @@ class TahiEnv
   required :EVENT_STREAM_WS_HOST
   required :EVENT_STREAM_WS_PORT
 
-  # Hipchat
-  optional :HIPCHAT_AUTH_TOKEN
-
   # Heroku
   optional :HEROKU_APP_NAME
   optional :HEROKU_PARENT_APP_NAME

--- a/spec/lib/tahi_env_spec.rb
+++ b/spec/lib/tahi_env_spec.rb
@@ -110,9 +110,6 @@ describe TahiEnv do
   it_behaves_like 'optional env var', var: 'HEROKU_APP_NAME'
   it_behaves_like 'optional env var', var: 'HEROKU_PARENT_APP_NAME'
 
-  # Hipchat
-  it_behaves_like 'optional env var', var: 'HIPCHAT_AUTH_TOKEN'
-
   # iHat
   it_behaves_like 'required env var', var: 'IHAT_URL'
   it_behaves_like 'optional env var', var: 'IHAT_CALLBACK_HOST'


### PR DESCRIPTION
Deploys are being reported to hipchat via Teamcity, so there is no need

Also removes HTTParty and that annoying message which is a bonus.
