### PR TITLE
APERTA-7579 Only staff should be able to delete tasks

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -75,7 +75,10 @@ class TasksController < ApplicationController
 
   def paper
     paper_id = params[:paper_id] || params.dig(:task, :paper_id)
-    paper_id ||= Task.find(params[:id] || params[:task_id]).paper.id
+    unless paper_id
+      task = Task.find(params[:id] || params[:task_id])
+      paper_id = task.paper_id
+    end
     @paper ||= Paper.find(paper_id)
   end
 


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7579
#### What this PR does:

Only staff should be able to delete.

After adding `this.get('task').destroyRecord()` to the completion toggle on the client side:

![deleting_tasks_as_author](https://cloud.githubusercontent.com/assets/4078758/18215328/85a729d2-7105-11e6-9c3b-34c9df15caae.gif)

After:
Tasks will not be deleted by authors.

---
#### Code Review Tasks:

Author tasks:
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [x] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [x] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging
- [x] If I made any UI changes, I've let QA know.

If I need to migrate production data:
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [x] I verified the data-migration's results on a copy of production data
- [x] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
