### PR TITLE
Fix/aperta 7609 paper body

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -291,7 +291,7 @@ class Paper < ActiveRecord::Base
     if latest_version.nil?
       @new_body = new_body
     else
-      draft.update(original_text: new_body)
+      latest_version.update(original_text: new_body)
       notify(action: "updated") unless changed?
     end
   end

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -179,10 +179,33 @@ describe Paper do
   end
 
   describe "#body=" do
+    let(:version) { paper.latest_version }
+    let(:old_body) { Faker::Lorem.paragraph }
+    let(:new_body) { Faker::Lorem.paragraph }
+
     it "can set body on creation" do
       paper_new = FactoryGirl.create :paper, body: 'foo'
       expect(paper_new.body).to eq('foo')
       expect(paper_new.latest_version.text).to eq('foo')
+    end
+
+    context 'when the paper is submitted' do
+      subject(:paper) { create :paper, :submitted_lite, body: old_body }
+
+      it "sets the body on the latest_version" do
+        expect(paper.draft).to be_nil
+        expect { paper.update!(body: new_body) }.to change { version.reload.original_text }.from(old_body).to(new_body)
+      end
+    end
+
+    context 'when the paper is not submitted' do
+      subject(:paper) { create :paper, body: old_body }
+
+      it "sets the body on the latest_version" do
+        expect(paper.draft).to be_present
+        expect(paper.draft).to eq(paper.latest_version)
+        expect { paper.update!(body: new_body) }.to change { version.reload.original_text }.from(old_body).to(new_body)
+      end
     end
 
     it "can use body= before save" do


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7609
#### What this PR does:

When `Paper#body=` is called, it will now update the latest version of a paper, not the draft (which will not exist in a submitted state)

This fixes APERTA-7609, where users saw an endless spinner after uploading a new docx to a paper when the paper was in a submitted state.

Authors could not before and still cannot upload a new docx when a paper is in the submitted state.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
