### PR TITLE
APERTA-7399: Remove erroneous trailing slash in public/uploads/ for capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :application, 'tahi'
 set :assets_roles, [:web]
 set :chruby_exec, '/usr/bin/chruby-exec'
 set :chruby_ruby, File.read(File.expand_path('../../.ruby-version', __FILE__)).strip
-set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/uploads/)
+set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/uploads)
 set :linked_files, %w(env puma.rb)
 set :repo_url, 'git@github.com:Tahi-project/tahi.git'
 set :web_service_name, 'tahi-web' # used by puma:{start,stop,restart}


### PR DESCRIPTION
JIRA issue: [APERTA-7399](https://developer.plos.org/jira/browse/APERTA-7399)
#### What this PR does:

It removes a trailing slash in the `linked_dirs`property for capistrano deploys. This would cause a capistrano failure on deploy in the target directory didn't already exist.

This is to fix a failure deploying on `ci.aperta.tech`
#### Code Review Tasks:

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
