### PR TITLE
Update ihat callback URL generation

### DIFF
--- a/app/services/ihat_job_request.rb
+++ b/app/services/ihat_job_request.rb
@@ -58,13 +58,20 @@ class IhatJobRequest
   # port, but it can be overriden by the `IHAT_CALLBACK_URL` environment
   # variable
   def self.build_ihat_callback_url
-    url = ENV.fetch('IHAT_CALLBACK_URL', UrlHelpers.root_url)
-    uri = URI.parse(url)
+    url = ENV.fetch('IHAT_CALLBACK_URL') do
+      if TahiEnv.force_ssl?
+        protocol = 'https'
+        port = 443
+      else
+        protocol = 'http'
+        port = 80
+      end
 
-    UrlHelpers.ihat_jobs_url(
-      protocol: uri.scheme,
-      host: uri.host,
-      port: uri.port)
+      UrlHelpers.root_url(protocol: protocol, port: port)
+    end
+
+    uri = URI.parse(url)
+    UrlHelpers.ihat_jobs_url(protocol: uri.scheme, host: uri.host, port: uri.port)
   end
 
   private

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -9,6 +9,7 @@ Tahi::Application.configure do
     review_app_host = "#{ENV["HEROKU_APP_NAME"]}.herokuapp.com"
     config.action_controller.asset_host = "//#{review_app_host}"
     config.action_mailer.default_url_options = { host: review_app_host }
+    routes.default_url_options = { host: review_app_host }
   else
     # use overriden asset host from config
     config.action_controller.asset_host = ENV.fetch("RAILS_ASSET_HOST")


### PR DESCRIPTION
Update ihat callback URLs to take into consideration whether or not the app is requiring SSL.

Related, make sure the default URL host option is set appropriately for Heroku review apps.

This resolves ihat not being able to communicate back to the application in review apps.
