### PR TITLE
Drop and restore for import_remote task

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -17,10 +17,11 @@ namespace :db do
     args[:env] = nil if args[:env] == 'prod'
     env = args[:env]
     location = "http://bighector.plos.org/aperta/#{env || 'db'}_dump.tar.gz"
-    Rake::Task['db:drop'].invoke
-    Rake::Task['db:create'].invoke
 
     with_config do |app, host, db, user, password|
+      drop_cmd = system("dropdb #{db} && createdb #{db}")
+      raise "\e[31m Error dropping and creating blank database. Is #{db} in use?\e[0m" unless drop_cmd
+
       ENV['PGPASSWORD'] = password.to_s
       cmd = "(curl -sH 'Accept-encoding: gzip' #{location} | gunzip - | pg_restore --format=tar --verbose --clean --no-acl --no-owner -h #{host} -U #{user} -d #{db}) && rake db:reset_passwords"
       result = system(cmd)


### PR DESCRIPTION
#### What this PR does:
- Updates prod dump task to succeed if someone accidentally types in 'prod'
- This also drops and creates the db as a workaround for an  issue where
  --create and --clean did not drop the db before restoring the db, causing
  issues with migrations that would create tables.
  ---
#### Code Review Tasks:

Author tasks:
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [x] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [x] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging
- [x] If I made any UI changes, I've let QA know.

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature

This also drops and creates the db as a workaround for an  issue where
--create and --clean did not drop the db before restoring the db, causing
issues with migrations that would create tables.
