### PR TITLE
APERTA-7693 lock MathJax version at 2.6

### DIFF
--- a/app/views/downloadable_paper/pdf.html.erb
+++ b/app/views/downloadable_paper/pdf.html.erb
@@ -3,7 +3,7 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <!-- Also set in /config/environment.js -->
     <script type="text/javascript" async
-            src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML-full">
+            src="https://cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=MML_HTMLorMML-full">
     </script>
 
     <style>

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -27,7 +27,7 @@ module.exports = function(environment) {
 
     // Also set in /app/views/downloadable_paper/pdf.html.erb
     'mathjax': {
-      url: '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML-full'
+      url: '//cdn.mathjax.org/mathjax/2.6-latest/MathJax.js?config=MML_HTMLorMML-full'
     },
 
     contentSecurityPolicy: {


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7693
#### What this PR does:

This ensures that we receive MathJax 2.6 from their CDN. This way, we can upgrade to 2.7 on our terms.

Note that as of right now, 2.6 _is_ the latest. So there should be no observable difference in behavior between master and this branch.
#### Notes

When testing or QAing, make sure to check math in both the browser and the PDF.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [x] The Product Team has reviewed and approved this feature
