### PR TITLE
APERTA-7715 rename variable

### DIFF
--- a/client/app/pods/components/file-uploader/component.js
+++ b/client/app/pods/components/file-uploader/component.js
@@ -129,7 +129,7 @@ export default Ember.TextField.extend({
       } else {
       // without a resourceUrl pass the data up and allow the caller to
       // decide what to do with it.
-        this.sendAction('done', location, filename);
+        this.sendAction('done', uploadedS3Url, filename);
       }
     });
     uploader.on('fileuploadprogress', (e, data) => {


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7715

I flubbed this as part of 36a29ac. `location` made sense before the
change, but here it's shadowing `window.location` which is totally
wrong.

There are a lot of other things I need to do, but this bugfix is the start.
