### PR TITLE
Chore: Updating heroku_install to use npm-install-retry

### DIFF
--- a/bin/heroku_install
+++ b/bin/heroku_install
@@ -4,13 +4,9 @@ set -e
 
 bower="$(pwd)/node_modules/.bin/bower"
 
-function install_npm_retry {
-  npm install npm-install-retry@1.0.2
-}
-
 for app in "client"; do
   cd $app &&
-    (install_npm_retry || install_npm_retry || install_npm_retry) &&
+    (npm install npm-install-retry@1.0.2 || npm install npm-install-retry@1.0.2 || npm install npm-install-retry@1.0.2) &&
     ./node_modules/npm-install-retry/bin/npm-install-retry --wait 500 --attempts 10 &&
     $bower install &&
     cd -


### PR DESCRIPTION
This PR tries out `npm-install-retry` for our heroku app deployments to see if it can more consistently deploy successfully.
