### PR TITLE
APERTA-7759 move ember-prop-types from dev to regular dependencies

### DIFF
--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -13765,6 +13765,20 @@
       "version": "4.0.11",
       "from": "loader.js@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/loader.js/-/loader.js-4.0.11.tgz"
+    },
+    "ember-prop-types": {
+      "version": "3.0.0",
+      "from": "ember-prop-types@*",
+      "dependencies": {
+        "ember-get-config": {
+          "version": "0.1.7",
+          "from": "ember-get-config@0.1.7"
+        },
+        "npm-install-security-check": {
+          "version": "1.0.4",
+          "from": "npm-install-security-check@>=1.0.0 <2.0.0"
+        }
+      }
     }
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "ember-can": "0.7.0",
     "ember-cli-font-awesome": "^1.5.0",
-    "ember-prop-types": "2.0.0",
     "ember-sinon": "0.5.0",
     "yuidocjs": "^0.10.2"
   },
@@ -57,6 +56,7 @@
     "ember-hash-helper-polyfill": "0.1.0",
     "ember-load-initializers": "^0.5.0",
     "ember-power-select": "0.7.2",
+    "ember-prop-types": "3.0.0",
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "^1.2.0",
     "ember-wormhole": "0.3.4",


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7759
#### What this PR does:

Moves ember-prop-types out of devDependencies into regular dependencies because we obviously need it outside of the dev environment. Also adds it to the shrinkwrap.

Also upgrades it from 2.0.0 to 3.0.0

---

Reviewer tasks:
- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
