### PR TITLE
APERTA-6860 — Dynamic Journal Name in Withdrawal Banner

### DIFF
--- a/client/app/pods/components/withdrawal-banner/template.hbs
+++ b/client/app/pods/components/withdrawal-banner/template.hbs
@@ -1,6 +1,6 @@
 {{#if withdrawn}}
   <div class="withdrawal-banner">
-    This paper has been withdrawn from Plos Biology and is in View Only mode
+    This paper has been withdrawn from {{paper.journal.name}} and is in View Only mode
     {{#if (can 'reactivate' paper)}}
       <button class='button-secondary reactivate' {{action 'reactivate'}}>REACTIVATE</button>
     {{/if}}

--- a/spec/support/pages/paper_page.rb
+++ b/spec/support/pages/paper_page.rb
@@ -190,7 +190,7 @@ HERE
 
     expect(page).to have_css(
       '.withdrawal-banner',
-      text: 'This paper has been withdrawn from Plos Biology and is in View Only mode'
+      text: /This paper has been withdrawn from.*and is in View Only mode/
     )
   end
 


### PR DESCRIPTION
[JIRA issue](https://developer.plos.org/jira/browse/APERTA-6860)
#### What this PR does:

The withdrawal banner had "PLOS Biology" hard wired, no more.

---
#### Reviewer tasks:
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
#### Author tasks:
- [ ] The Product Team has reviewed and approved this feature
