### PR TITLE
Chore — Don’t Import From `ember-getowner-polyfill`

### DIFF
--- a/client/app/adapters/application.js
+++ b/client/app/adapters/application.js
@@ -1,5 +1,7 @@
-import getOwner from 'ember-getowner-polyfill';
+import Ember from 'ember';
 import ActiveModelAdapter from 'active-model-adapter';
+
+const { getOwner } = Ember;
 
 export default ActiveModelAdapter.extend({
   namespace: 'api',

--- a/client/app/pods/application/route.js
+++ b/client/app/pods/application/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import ENV from 'tahi/config/environment';
-import getOwner from 'ember-getowner-polyfill';
+
+const { getOwner } = Ember;
 
 const debug = function(description, obj) {
   const devOrTest = ENV.environment === 'development' ||

--- a/client/app/pods/components/card-preview/component.js
+++ b/client/app/pods/components/card-preview/component.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import ENV from 'tahi/config/environment';
 import taskComponentName from 'tahi/lib/task-component-name';
+
+const { getOwner } = Ember;
 
 export default Ember.Component.extend({
   classNames: ['card'],

--- a/client/app/pods/components/inline-edit-email/component.js
+++ b/client/app/pods/components/inline-edit-email/component.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 export default Ember.Component.extend({
   editing: false,

--- a/client/app/services/restless.js
+++ b/client/app/services/restless.js
@@ -1,8 +1,9 @@
 /* jshint unused: false */
 
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 import camelizeKeys from 'tahi/lib/camelize-keys';
+
+const { getOwner } = Ember;
 
 export default Ember.Service.extend({
   pathFor(model) {


### PR DESCRIPTION
#### What this PR does:

Since moving to Ember 2.8 we no longer need the Ember `getOwner` polyfill. 

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I read the code; it looks good
- [x] I performed a 5 minute walkthrough of the site looking for oddities
#### After the Code Review:

Author tasks:
- ~~[ ] The Product Team has reviewed and approved this feature~~ (n/a)
