### PR TITLE
APERTA-7861 - Part Deux: Make sure no environments have a 'SUBCLASSME' JournalTaskType

### DIFF
--- a/db/migrate/20161005134751_remove_task_journal_task_types.rb
+++ b/db/migrate/20161005134751_remove_task_journal_task_types.rb
@@ -1,0 +1,5 @@
+# This data migration is for removing JournalTaskType records
+# that are tied to the Task class.
+class RemoveTaskJournalTaskTypes < DataMigration
+  RAKE_TASK_UP = 'data:migrate:remove_task_journal_task_types'
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161003163044) do
+ActiveRecord::Schema.define(version: 20161005134751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/data-migrations/APERTA-7861_remove_task_journal_task_types.rake
+++ b/lib/tasks/data-migrations/APERTA-7861_remove_task_journal_task_types.rake
@@ -1,0 +1,14 @@
+namespace :data do
+  namespace :migrate do
+    desc <<-DESC
+      APERTA-7861: Removes JournalTaskTypes for Task.
+
+      These are no longer nececessary now that Task is an abstract
+      class. We want them removed so they do not show up in the UI
+      of possible cards that a user can add to a paper.
+    DESC
+    task remove_task_journal_task_types: :environment do
+      JournalTaskType.where(kind: 'Task').destroy_all
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: [APERTA-7861](https://developer.plos.org/jira/browse/APERTA-7861)
### What this PR does:

This is part deux of PR #2642 . It adds a data migration to clear out any `JournalTaskType` records tied to `Task`. These JTTs are no longer necessary now that `Task` is an abstract base class. 

This prevents the `SUBCLASSME` checkbox in the "Add card" to a manuscript screen.

E.g. we don't want this: 

![stillsubclassme](https://cloud.githubusercontent.com/assets/967/19116379/599564f6-8ae3-11e6-9959-af30c671d4c5.png)
### How to verify

_Note: this issue only exists on https://ci.aperta.tech  because a record got put in the database before PR #2642 was done.)

Connect to the VPN, download the CI environment backup, load up rails console, and look look at the `JournalTaskType` records that exist whose kind is `Task`:

```
bundle exec rake db:import_remote[ci]

bundle exec rails console
console> JournalTaskType.where(kind: 'Task').all
```

Now, migrate:

```
bundle exec rake db:migrate
```

Go back to rails console and see that there are no JournalTaskType records for Task:

```
bundle exec rails console
console> JournalTaskType.where(kind: 'Task').all
# => []
```

Also, if you load up the application you will no longer see `SUBCLASSME` as an "Add card" checkbox option.

You can also verify this on a production data-set by importing `prod` and then running `db:migrate`. You should see there are no JTTs for Task when its done migrating.

---
#### Code Review Tasks:

Author tasks:
- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

~~If I modified any environment variables:~~
- ~~[ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}~~
- ~~[ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging~~
- ~~[ ] If I made any UI changes, I've let QA know.~~

If I need to migrate production data:
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- ~~[ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)~~
- [x] I verified the data-migration's results on a copy of production data
- [x] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks
