### PR TITLE
Chore — Remove `read-path` Handlebars Helper

### DIFF
--- a/client/app/helpers/read-path.js
+++ b/client/app/helpers/read-path.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Helper.helper(function([object, path]) {
-  // TODO: When upgraded to Ember 2.0 this should be removed in
-  // favor of the Handlebars `get` helper
-  return Ember.get(object, path);
-});

--- a/client/app/pods/components/select-native/template.hbs
+++ b/client/app/pods/components/select-native/template.hbs
@@ -6,9 +6,9 @@
 
 {{#if optionValuePath}}
   {{#each content key="@index" as |item|}}
-    <option value="{{read-path item optionValuePath}}"
+    <option value="{{get item optionValuePath}}"
             selected={{eq item selection}}>
-      {{read-path item optionLabelPath}}
+      {{get item optionLabelPath}}
      </option>
   {{/each}}
 {{else}}


### PR DESCRIPTION
#### What this PR does:

Removing an old helper that was around before `Ember.get`. This was only used for the drop downs on the Manuscript Versions screen.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
#### After the Code Review:
