### PR TITLE
Chore: Fix flaky journal spec 

### DIFF
--- a/spec/support/pages/admin_dashboard_page.rb
+++ b/spec/support/pages/admin_dashboard_page.rb
@@ -131,7 +131,10 @@ class EditJournalFragment < PageFragment
 
   def save
     click_on "Save"
-    wait_for_ajax timeout: 20
+    # Creating a journal takes time to initialize everything it needs, e.g.
+    # its roles and permissions, MMTs, task templates, etc. So be kind to
+    # journal and allot it some more time to get set up.
+    wait_for_ajax timeout: 60
     session.has_content? @name
   end
 


### PR DESCRIPTION
JIRA issue: link-to-jira
#### What this PR does:

Give the journal more time to initialize itself for feature specs to avoid `execution expired` failures on CircleCI.

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
