### PR TITLE
APERTA-7184 Displaying flash messages when Ember is broken

### DIFF
--- a/client/app/services/flash.js
+++ b/client/app/services/flash.js
@@ -78,8 +78,16 @@ export default Ember.Service.extend({
       text: message,
       type: type
     });
+    var that = this;
+    setTimeout(function() { that.checkDisplay(); }, 5000);
   },
 
+  checkDisplay() {
+    var flashMessage = $('.flash-messages')[0];
+    if (this.get('messages').length > 0 && flashMessage.innerHTML === '<!---->') {
+      flashMessage.innerHTML = '<div class="flash-message flash-message--error"><div class="flash-message-content">There was an error with the application. Please refresh your browser.</div></div>';
+    }
+  },
   /**
     The array of messages for each key under `errors` will be joined into a single string, separated by comma.
     ```


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-7184
#### What this PR does:

We use flash messages to display errors, but if Ember is in a broken state the flash messages won't display.  This PR adds a simple JavaScript fallback: if a flash message should be displayed but it not, an error will be shown.

---
#### Code Review Tasks:

Reviewer tasks:
- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
