### PR TITLE
APERTA-8125 — Fix SI file replace button in Firefox

### DIFF
--- a/app/assets/stylesheets/components/_supporting-information-file.scss
+++ b/app/assets/stylesheets/components/_supporting-information-file.scss
@@ -39,7 +39,7 @@
       color: $aperta-grey;
       font-size: 1.3rem;
       display: inline;
-      margin-left: 3px;
+      margin-left: 6px;
       background: transparent;
       border: none;
       i {

--- a/client/app/pods/components/supporting-information-file/template.hbs
+++ b/client/app/pods/components/supporting-information-file/template.hbs
@@ -3,7 +3,7 @@
     <div class="si-file-filename">
       <a href="{{ file.src }}"><i class="fa {{iconClass}}"></i>{{ file.filename }}</a>
 
-      <button class="fileinput-button">
+      <div class="fileinput-button">
         {{fa-icon icon="refresh"}}
         <span>Replace File</span>
         {{file-uploader url=attachmentUrl
@@ -11,7 +11,7 @@
                         multiple=false
                         filePrefix="supporting-info"
                         cancel="cancelUploads"}}
-      </button>
+      </div>
     </div>
     <div class="flex-group">
       {{input class="form-control flex-element si-file-label-input"


### PR DESCRIPTION
https://developer.plos.org/jira/browse/APERTA-8125
#### What this PR does:

The SI replace file button was a `<button>` and Firefox didn't seem to be passing the event to the `fileupload-input` component.

---

#### Code Review Tasks:

Reviewer tasks:
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
#### After the Code Review:

Author tasks:
- [ ] The Product Team has reviewed and approved this feature
