### PR TITLE
APERTA-8125 restyle replace button

### DIFF
--- a/app/assets/stylesheets/components/_supporting-information-file.scss
+++ b/app/assets/stylesheets/components/_supporting-information-file.scss
@@ -38,7 +38,8 @@
     .fileinput-button {
       color: $aperta-grey;
       font-size: 1.3rem;
-      display: inline;
+      display: inline-block;
+      vertical-align: sub;
       margin-left: 6px;
       background: transparent;
       border: none;


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8125

#### What this PR does:

Changes a parent of the file input's style from `display: inline` to `display: inline-block`

#### Notes

We've commonly used this bootstrap styling trick to 'style' file inputs.  The input is nested inside another element, then absolutely positioned and pushed off to the side.  Although it looks wonky (and huge) this is the first time we've had a problem with it.

![screen shot 2016-11-03 at 3 33 32 pm](https://cloud.githubusercontent.com/assets/2043348/19983985/9edf87f6-a1e2-11e6-8c91-006520eee484.png)

Apparently styling the parent inline is a nono.

#### Major UI changes

None

---

#### Code Review Tasks:

Author tasks:

No UI changes



Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature

