### PR TITLE
APERTA-7321 — Classes for form elements in Reviewer Report Task

### DIFF
--- a/client/app/pods/components/binary-radio-button/template.hbs
+++ b/client/app/pods/components/binary-radio-button/template.hbs
@@ -2,6 +2,7 @@
   {{radio-button selection=selection
                  name=name
                  id=idYes
+                 class=yesClass
                  value=yesValue
                  action=(action "selectYes")
                  disabled=disabled}}
@@ -12,6 +13,7 @@
   {{radio-button selection=selection
                  name=name
                  id=idNo
+                 class=noClass
                  value=noValue
                  action=(action "selectNo")
                  disabled=disabled}}

--- a/client/app/pods/components/nested-question-radio-decision/template.hbs
+++ b/client/app/pods/components/nested-question-radio-decision/template.hbs
@@ -26,6 +26,7 @@
     <label class="flex-element">
       {{radio-button value="accept"
                      name=namePrefix
+                     class=(concat ident "-accept")
                      selection=model.answer.value
                      action=(action "setAnswer")}}
       Accept
@@ -34,6 +35,7 @@
     <label class="flex-element">
       {{radio-button value="reject"
                      name=namePrefix
+                     class=(concat ident "-reject")
                      selection=model.answer.value
                      action=(action "setAnswer")}}
       Reject
@@ -42,6 +44,7 @@
     <label class="flex-element">
       {{radio-button value="major_revision"
                      name=namePrefix
+                     class=(concat ident "-major-revision")
                      selection=model.answer.value
                      action=(action "setAnswer")}}
       Major Revision
@@ -50,6 +53,7 @@
     <label class="flex-element">
       {{radio-button value="minor_revision"
                      name=namePrefix
+                     class=(concat ident "-minor-revision")
                      selection=model.answer.value
                      action=(action "setAnswer")}}
       Minor Revision

--- a/client/app/pods/components/nested-question-radio/template.hbs
+++ b/client/app/pods/components/nested-question-radio/template.hbs
@@ -39,6 +39,8 @@
                           noValue=noValue
                           yesLabel=yesLabel
                           noLabel=noLabel
+                          yesClass=(concat ident "-yes")
+                          noClass=(concat ident "-no")
                           yesAction="yesAction"
                           noAction="noAction"
                           disabled=disabled}}

--- a/client/tests/components/nested-question-radio-test.js
+++ b/client/tests/components/nested-question-radio-test.js
@@ -1,0 +1,33 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('nested-question-radio', 'Integration | Component | nested question radio', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  const fakeQuestion = Ember.Object.create({
+    ident: 'foo',
+    additionalData: [{}],
+    text: 'Test Question',
+    answerForOwner: function(){ return Ember.Object.create(); },
+    save() { return null; },
+  });
+
+  this.set('task', Ember.Object.create({
+    findQuestion: function(){ return fakeQuestion; }
+  }));
+
+  this.render(hbs`
+    {{nested-question-radio ident="foo" owner=task}}
+  `);
+
+  assert.textPresent(this.$('.question-text'), 'Test Question');
+  assert.elementFound('.foo-yes', '"Yes" radio found with class');
+  assert.elementFound('.foo-no',  '"No"  radio found with class');
+});

--- a/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-questions.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-questions.hbs
@@ -7,16 +7,18 @@
   </li>
   <li class="question">
     {{nested-question-radio ident="reviewer_report--competing_interests"
-      owner=model
-      decision=decision
-      displayContent=true
-      helpText=(concat "Please review our <a href='" competingInterestsLink "'>Competing Interests policy</a> and declare any potential interests that you feel the Editor should be aware of when considering your review.")
-      readOnly=readOnly}}
+                            owner=model
+                            decision=decision
+                            displayContent=true
+                            helpText=(concat "Please review our <a href='" competingInterestsLink "'>Competing Interests policy</a> and declare any potential interests that you feel the Editor should be aware of when considering your review.")
+                            readOnly=readOnly}}
+
     {{nested-question-textarea ident="reviewer_report--competing_interests--detail"
-      owner=model
-      decision=decision
-      shouldDisplayQuestionText=false
-      readOnly=readOnly}}
+                               owner=model
+                               decision=decision
+                               shouldDisplayQuestionText=false
+                               inputClassNames="form-control reviewer_report--competing_interests--detail"
+                               readOnly=readOnly}}
   </li>
 
   <li class="question">
@@ -24,6 +26,7 @@
                         owner=model
                         decision=decision
                         displayContent=true
+                        inputClassNames="form-control reviewer_report--identity"
                         helpText="Your name and review will not be published with the manuscript."
                         readOnly=readOnly}}
   </li>
@@ -33,7 +36,7 @@
                         owner=model
                         decision=decision
                         displayContent=true
-                        inputClassNames="form-control taller"
+                        inputClassNames="form-control taller reviewer_report--comments_for_author"
                         helpText="These comments will be transmitted to the author."
                         readOnly=readOnly}}
   </li>
@@ -43,6 +46,7 @@
                         owner=model
                         decision=decision
                         displayContent=true
+                        inputClassNames="form-control reviewer_report--additional_comments"
                         helpText="Additional comments may include concerns about dual publication, research or publication ethics.<br><br>These comments will not be transmitted to the authors."
                         readOnly=readOnly}}
   </li>
@@ -57,6 +61,7 @@
     {{nested-question-textarea ident="reviewer_report--suitable_for_another_journal--journal"
       owner=model
       decision=decision
+      inputClassNames="form-control reviewer_report--suitable_for_another_journal--journal"
       shouldDisplayQuestionText=false
       readOnly=readOnly}}
   </li>

--- a/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-task.hbs
@@ -19,10 +19,10 @@
         {{#if submissionConfirmed}}
           <h4>Once you submit the report, you will no longer be able to edit it. Are you sure?</h4>
 
-          <button class="button-primary button--green" {{action "submitReport"}}>Yes, I’m sure</button>
-          <button class="button-secondary button--green" {{action "cancelSubmission"}}>Nope</button>
+          <button class="button-primary button--green reviewer-report-confirm-submit-button" {{action "submitReport"}}>Yes, I’m sure</button>
+          <button class="button-secondary button--green reviewer-report-cancel-submit-button" {{action "cancelSubmission"}}>Nope</button>
         {{else}}
-          <button class="button-primary button--green" {{action "confirmSubmission"}}>Submit this Report</button>
+          <button class="button-primary button--green reviewer-report-submit-button" {{action "confirmSubmission"}}>Submit this Report</button>
         {{/if}}
       </div>
     {{/if}}


### PR DESCRIPTION
https://developer.plos.org/jira/browse/APERTA-7321

#### What this PR does:

Adds classes to all the form elements so QA can test this thing.

—
“Submit this Report” button: `.reviewer-report-submit-button`
“Yes, I’m sure” button: `.reviewer-report-confirm-submit-button`
“Nope”: button: `.reviewer-report-cancel-submit-button`

—
Q1 radios have classes based on question ident

—
Q2 radios and textarea have classes based on question ident

—
Q3 textarea has a class based on question ident

—
Q4 textarea has a class based on question ident

—
Q5 textarea has a class based on question ident

—
Q6 radios and textarea have classes based on question ident


*note*  All “nested-question-radio” components will now have classes based on question idents. These appear to be used in all “Yes”, “No” situations.

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
