### PR TITLE
Load ember inspector in selenium

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -179,6 +179,9 @@ Dir.chdir APP_ROOT do
   header 'setting up overcommit'
   system 'overcommit --install'
 
+  header 'downloading ember inspector'
+  system 'cd tmp && rm -f addon-470970-latest.xpi && wget https://addons.mozilla.org/firefox/downloads/latest/ember-inspector/addon-470970-latest.xpi'
+
   puts
   puts 'Success!'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -106,6 +106,14 @@ RSpec.configure do |config|
       ENV['SELENIUM_FIREFOX_PATH']
     Capybara.register_driver :selenium do |app|
       profile = Selenium::WebDriver::Firefox::Profile.new
+      ember_inspector_path = Rails.root.join('tmp/addon-470970-latest.xpi')
+      # https://addons.mozilla.org/firefox/downloads/latest/ember-inspector/addon-470970-latest.xpi
+      if File.exist?(ember_inspector_path)
+        profile.add_extension(ember_inspector_path)
+      elsif $stdout.tty?
+        puts "\e[33mEmber inspector not installed in #{ember_inspector_path}\e[0m"
+      end
+
       client = Selenium::WebDriver::Remote::Http::Default.new
       client.timeout = 90
       Capybara::Selenium::Driver


### PR DESCRIPTION
I set this up recently while debugging some issues.

Do you all think it's worth it?

When you throw a `binding.pry` in your specs, you can then do some ember inspecting while it's stopped. It doesn't always work perfectly, but it seems to help.

Thoughts?