### PR TITLE
switch yaml_db gemfile remote to https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,7 @@ gem 'whenever'
 
 # We need any version of yaml_db after 0.3.0 since it will
 # namespace SerializationHelper
-gem 'yaml_db',
-    github: 'yamldb/yaml_db',
+gem 'yaml_db', git: 'https://github.com/yamldb/yaml_db',
     ref: 'f980a67dfcfef76824676f3938b176b68c260e68'
 
 # has_secure_token has been accepted into rails, but isn't yet in the most

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: git://github.com/yamldb/yaml_db.git
-  revision: f980a67dfcfef76824676f3938b176b68c260e68
-  ref: f980a67dfcfef76824676f3938b176b68c260e68
-  specs:
-    yaml_db (0.3.0)
-      rails (>= 3.0, < 4.3)
-      rake (>= 0.8.7)
-
-GIT
   remote: https://github.com/ActsAsParanoid/acts_as_paranoid
   revision: c2db19554ddaedcac0a2b8d6a0563dea83c972c5
   ref: c2db19554ddaedcac0a2b8d6a0563dea83c972c5
@@ -23,6 +14,15 @@ GIT
     activemodel-globalid (0.1.1)
       activemodel (>= 4.1.0)
       activesupport (>= 4.1.0)
+
+GIT
+  remote: https://github.com/yamldb/yaml_db
+  revision: f980a67dfcfef76824676f3938b176b68c260e68
+  ref: f980a67dfcfef76824676f3938b176b68c260e68
+  specs:
+    yaml_db (0.3.0)
+      rails (>= 3.0, < 4.3)
+      rake (>= 0.8.7)
 
 PATH
   remote: engines/plos_billing


### PR DESCRIPTION
#### What this PR does:

Changes the protocol we grab `yaml_db` with from `git` to `https`. 
Circle CI periodically complains that the `git` protocol transmits without encryption, and ~~fails a build~~ emits a warning.

#### Note:

✅ Remote reference `f980a67dfcfef76824676f3938b176b68c260e68` remains the same as before. It's the exact same `yaml_db`