### PR TITLE
Create script for setting up Valdo

### DIFF
--- a/bin/setup_valdo
+++ b/bin/setup_valdo
@@ -4,8 +4,8 @@
 # when it's done, you'll have to `cap vagrant deploy:cold` from both tahi and ihat to have
 # a fully functional aperta.
 
-# print all commands, also exit immediately if any single command fails
-set -xe
+# exit immediately if any single command fails
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TAHI_DIR="$SCRIPT_DIR/../"


### PR DESCRIPTION
JIRA issue: none

#### What this PR does:

I was setting up valdo yet again and I decided to just script all the steps in the Readme.

script is invoked by running
```
./bin/setup
```
from within your tahi project.

Be prepared to wait, it takes about 30 minutes to run. Inconveniently, it might ask for your sudo password about halfway through (it needs to update your /etc/hosts file).
#### Notes



#### Major UI changes

None, shouldn't affect the actual tahi app at all.

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

