### PR TITLE
Adding an index on tasks.title

### DIFF
--- a/db/migrate/20161118035507_add_title_on_tasks_title.rb
+++ b/db/migrate/20161118035507_add_title_on_tasks_title.rb
@@ -1,0 +1,5 @@
+class AddTitleOnTasksTitle < ActiveRecord::Migration
+  def change
+    add_index :tasks, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116041152) do
+ActiveRecord::Schema.define(version: 20161118035507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -710,6 +710,7 @@ ActiveRecord::Schema.define(version: 20161116041152) do
   add_index "tasks", ["id", "type"], name: "index_tasks_on_id_and_type", using: :btree
   add_index "tasks", ["paper_id"], name: "index_tasks_on_paper_id", using: :btree
   add_index "tasks", ["phase_id"], name: "index_tasks_on_phase_id", using: :btree
+  add_index "tasks", ["title"], name: "index_tasks_on_title", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "first_name",             default: "", null: false


### PR DESCRIPTION
There is no JIRA issue for this.

This change-set adds an index on `tasks.title` to help speed up an `UPDATE ...` query that runs on post deploy.

On ci.aperta.tech there is no index and over a hundred thousand tasks causing a full table scan. The below rake task runs after `db:migrate` on deploy, but it was taking more than 60 seconds to complete. See [TeamCity build 159](https://developer.plos.org/teamcity/viewLog.html?buildId=112097&buildTypeId=ApertaCIDeploy_DeployTahitoCI&tab=buildLog) for more information:

```
rake data:update_journal_tasks_type
```

I tested this out on ci.aperta.tech by manually adding the index, rerunning the TeamCity deploy, and seeing it was successful by a wide margin, then removing the index. This change-set should resolve the issue.
