### PR TITLE
APERTA-8396 Disable prepared statements for now to see if it addresse…

### DIFF
--- a/app/models/authorizations/hydrate_objects_query.rb
+++ b/app/models/authorizations/hydrate_objects_query.rb
@@ -69,8 +69,15 @@ module Authorizations
         .join(klass.arel_table).on(klass.arel_table[:id].eq(as_table[:id]))
     end
 
+    # This #to_sql will run the query as an unprepared_statement since by default
+    # Rails and Postgres will run all queries as prepared statements. The large queries
+    # associated with R&P may adversely memory usage on the database server if run as
+    # a prepared statement. Assuming that many of these R&P calls will be relatively unique
+    # per user, we are trading off increased available memory for running an unprepared statement here.
     def to_sql
-      to_arel.to_sql
+      @klass.connection.unprepared_statement do
+        to_arel.to_sql
+      end
     end
 
     private

--- a/app/models/authorizations/hydrate_objects_query.rb
+++ b/app/models/authorizations/hydrate_objects_query.rb
@@ -69,20 +69,8 @@ module Authorizations
         .join(klass.arel_table).on(klass.arel_table[:id].eq(as_table[:id]))
     end
 
-    # This #to_sql will run the query as an unprepared_statement since by default
-    # Rails and Postgres will run all queries as prepared statements. The large queries
-    # associated with R&P may adversely affect memory usage on the database server if run as
-    # a prepared statement. Assuming that many of these R&P calls will be relatively unique
-    # per user, we are trading off increased available memory for not much benefit if we use
-    # prepared statements so we are running this as an unprepared statement here.
-    # Issue links: https://github.com/rails/rails/issues/14645
-    #              https://github.com/rails/rails/issues/21992
-    # Potential fix in Rails 5:
-    #              https://github.com/rails/rails/commit/cbcdecd2c55fca9613722779231de2d8dd67ad02
     def to_sql
-      @klass.connection.unprepared_statement do
-        to_arel.to_sql
-      end
+      to_arel.to_sql
     end
 
     private

--- a/app/models/authorizations/hydrate_objects_query.rb
+++ b/app/models/authorizations/hydrate_objects_query.rb
@@ -71,9 +71,14 @@ module Authorizations
 
     # This #to_sql will run the query as an unprepared_statement since by default
     # Rails and Postgres will run all queries as prepared statements. The large queries
-    # associated with R&P may adversely memory usage on the database server if run as
+    # associated with R&P may adversely affect memory usage on the database server if run as
     # a prepared statement. Assuming that many of these R&P calls will be relatively unique
-    # per user, we are trading off increased available memory for running an unprepared statement here.
+    # per user, we are trading off increased available memory for not much benefit if we use
+    # prepared statements so we are running this as an unprepared statement here.
+    # Issue links: https://github.com/rails/rails/issues/14645
+    #              https://github.com/rails/rails/issues/21992
+    # Potential fix in Rails 5:
+    #              https://github.com/rails/rails/commit/cbcdecd2c55fca9613722779231de2d8dd67ad02
     def to_sql
       @klass.connection.unprepared_statement do
         to_arel.to_sql

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,6 +14,19 @@ on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ar_config = ActiveRecord::Base.configurations[Rails.env]
     ar_config['pool'] = thread_count
+    # The line below will run all queries as unprepared_statements since by default
+    # Rails and Postgres will run all queries as prepared statements. The large queries
+    # associated with R&P may adversely affect memory usage on the database server if run as
+    # a prepared statement. Assuming that many of these R&P calls will be relatively unique
+    # per user, we are trading off increased available memory for not much benefit if we use
+    # prepared statements so we are disabling prepared statements.
+    # The Rails Guides mention to disable prepared statements to save on memory:
+    # http://edgeguides.rubyonrails.org/configuring.html
+    # Issue links: https://github.com/rails/rails/issues/14645
+    #              https://github.com/rails/rails/issues/21992
+    # Potential fix in Rails 5:
+    #              https://github.com/rails/rails/commit/cbcdecd2c55fca9613722779231de2d8dd67ad02
+    ar_config['prepared_statements'] = false
     ActiveRecord::Base.establish_connection(ar_config)
   end
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,7 +14,6 @@ on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ar_config = ActiveRecord::Base.configurations[Rails.env]
     ar_config['pool'] = thread_count
-    ar_config['prepared_statements'] = false
     ActiveRecord::Base.establish_connection(ar_config)
   end
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,6 +14,7 @@ on_worker_boot do
   ActiveSupport.on_load(:active_record) do
     ar_config = ActiveRecord::Base.configurations[Rails.env]
     ar_config['pool'] = thread_count
+    ar_config['prepared_statements'] = false
     ActiveRecord::Base.establish_connection(ar_config)
   end
 


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8396

#### What this PR does:

This disables prepared statements to see if this will allow postgres to use less memory when storing gigantic queries. 


This change only changes it locally.  The key part of the change is here:

https://github.com/PLOS/molten/pull/305

---

#### Code Review Tasks:

Author tasks:

- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate production data:

- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature

…s our memory issue