### PR TITLE
APERTA-8413 Set mini_magick whiny to false

### DIFF
--- a/config/initializers/mini_magick.rb
+++ b/config/initializers/mini_magick.rb
@@ -1,0 +1,3 @@
+MiniMagick.configure do |c|
+  c.whiny = false
+end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8413

#### What this PR does:

Sets `whiny` config for minimagick to false. See https://github.com/minimagick/minimagick#errors-being-raised-when-they-shouldnt

I don't think this should have any negative impact, but it might. Thoughts?

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature

