### PR TITLE
APERTA-8112 Add < to HAS_BEEN_COMPLETED as well as <= and >=

### DIFF
--- a/spec/services/query_parser_spec.rb
+++ b/spec/services/query_parser_spec.rb
@@ -295,138 +295,22 @@ describe QueryParser do
       end
     end
 
-    shared_examples_for "a date query" do |term:, sql:|
-      it "parses '#{term} = mm/dd/yyyy'" do
-        start_time = '04/12/2016'.to_date.beginning_of_day.to_formatted_s(:db)
-        end_time = '04/12/2016'.to_date.end_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} = 04/12/2016"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} BETWEEN '#{start_time}' AND '#{end_time}'
-          SQL
-        end
-      end
-
-      it "parses '#{term} < mm/dd/yyyy'" do
-        start_time = '04/12/2016'.to_date.beginning_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} < 04/12/2016"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} <= '#{start_time}'
-          SQL
-        end
-      end
- 
-      it "parses '#{term} > mm/dd/yyyy'" do
-        end_time = '04/12/2016'.to_date.end_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} > 04/12/2016"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} >= '#{end_time}'
-          SQL
-        end
-      end
- 
-      it "parses '#{term} <= mm/dd/yyyy'" do
-        end_time = '04/12/2016'.to_date.end_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} <= 04/12/2016"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} <= '#{end_time}'
-          SQL
-        end
-      end
-
-      it "parses '#{term} >= mm/dd/yyyy'" do
-        start_time = '04/12/2016'.to_date.beginning_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} >= 04/12/2016"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} >= '#{start_time}'
-          SQL
-        end
-      end
-
-      it "falls back to today's date when given a bad input date" do
-        today = Time.now.utc.end_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} > bad date"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} >= '#{today}'
-          SQL
-        end
-      end
-
-      it "parses '#{term} = n DAYS AGO'" do
-        start_time = Time.now.utc.days_ago(3).beginning_of_day.to_formatted_s(:db)
-        end_time = Time.now.utc.days_ago(3).end_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} = 3 days ago"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} BETWEEN '#{start_time}' AND '#{end_time}'
-          SQL
-        end
-      end
-
-      it "parses '#{term} > n DAYS AGO'" do
-        start_time = Time.now.utc.days_ago(3).beginning_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} > 3 days ago"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} <= '#{start_time}'
-          SQL
-        end
-      end
-
-      it "parses '#{term} < n DAYS AGO'" do
-        end_time = Time.now.utc.days_ago(3).end_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} < 3 days ago"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} >= '#{end_time}'
-          SQL
-        end
-      end
-
-      it "parses '#{term} >= n DAYS AGO'" do
-        # >= includes the day, just like how '=' works
-        three_days_ago_inclusive = Time.now.utc.days_ago(3).end_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} >= 3 days ago"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} <= '#{three_days_ago_inclusive}'
-          SQL
-        end
-      end
-
-      it "parses '#{term} <= n DAYS AGO'" do
-        # >= includes the day, just like how '=' works
-        three_days_ago_inclusive = Time.now.utc.days_ago(3).beginning_of_day.to_formatted_s(:db)
-        Timecop.freeze do
-          parse = QueryParser.new.parse "#{term} <= 3 days ago"
-          expect(parse.to_sql).to eq(<<-SQL.strip)
-            #{sql} >= '#{three_days_ago_inclusive}'
-          SQL
-        end
-      end
-    end
-
     context 'Date Queries' do
       describe 'task date queries' do
-        it_behaves_like "a date query",
-          term: "TASK anytask HAS BEEN COMPLETED",
+        it_behaves_like "a query parser date query",
+          query: "TASK anytask HAS BEEN COMPLETED",
           sql: '"tasks_0"."title" ILIKE \'anytask\' AND "tasks_0"."completed_at"'
       end
 
       describe 'VERSION DATE queries' do
-        it_behaves_like "a date query",
-          term: "VERSION DATE",
+        it_behaves_like "a query parser date query",
+          query: "VERSION DATE",
           sql: '"papers"."submitted_at"'
       end
 
       describe 'SUBMISSION DATE queries' do
-        it_behaves_like "a date query",
-          term: "SUBMISSION DATE",
+        it_behaves_like "a query parser date query",
+          query: "SUBMISSION DATE",
           sql: '"papers"."first_submitted_at"'
       end
     end

--- a/spec/support/shared_examples/query_parser_shared_examples.rb
+++ b/spec/support/shared_examples/query_parser_shared_examples.rb
@@ -1,0 +1,117 @@
+RSpec.shared_examples_for 'a query parser date query' do |query:, sql:|
+  describe 'when download! fails' do
+    it "parses '#{query} = mm/dd/yyyy'" do
+      start_time = '04/12/2016'.to_date.beginning_of_day.to_formatted_s(:db)
+      end_time = '04/12/2016'.to_date.end_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} = 04/12/2016"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} BETWEEN '#{start_time}' AND '#{end_time}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} < mm/dd/yyyy'" do
+      start_time = '04/12/2016'.to_date.beginning_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} < 04/12/2016"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} <= '#{start_time}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} > mm/dd/yyyy'" do
+      end_time = '04/12/2016'.to_date.end_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} > 04/12/2016"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} >= '#{end_time}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} <= mm/dd/yyyy'" do
+      end_time = '04/12/2016'.to_date.end_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} <= 04/12/2016"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} <= '#{end_time}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} >= mm/dd/yyyy'" do
+      start_time = '04/12/2016'.to_date.beginning_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} >= 04/12/2016"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} >= '#{start_time}'
+        SQL
+      end
+    end
+
+    it "falls back to today's date when given a bad input date" do
+      today = Time.now.utc.end_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} > bad date"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} >= '#{today}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} = n DAYS AGO'" do
+      start_time = Time.now.utc.days_ago(3).beginning_of_day.to_formatted_s(:db)
+      end_time = Time.now.utc.days_ago(3).end_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} = 3 days ago"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} BETWEEN '#{start_time}' AND '#{end_time}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} > n DAYS AGO'" do
+      start_time = Time.now.utc.days_ago(3).beginning_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} > 3 days ago"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} <= '#{start_time}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} < n DAYS AGO'" do
+      end_time = Time.now.utc.days_ago(3).end_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} < 3 days ago"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} >= '#{end_time}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} >= n DAYS AGO'" do
+      # >= includes the day, just like how '=' works
+      three_days_ago_inclusive = Time.now.utc.days_ago(3).end_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} >= 3 days ago"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} <= '#{three_days_ago_inclusive}'
+        SQL
+      end
+    end
+
+    it "parses '#{query} <= n DAYS AGO'" do
+      # >= includes the day, just like how '=' works
+      three_days_ago_inclusive = Time.now.utc.days_ago(3).beginning_of_day.to_formatted_s(:db)
+      Timecop.freeze do
+        parse = QueryParser.new.parse "#{query} <= 3 days ago"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          #{sql} >= '#{three_days_ago_inclusive}'
+        SQL
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8112

#### What this PR does:

CJ Rayhill reports that she is unable to query the paper tracker with the query:
TASK Register Decision HAS BEEN COMPLETE < 30 DAYS
This is especially perplexing because:
TASK Register Decision HAS BEEN COMPLETE > 30 DAYS
works.
We'd also like to verify whether other operators e.g. =, <=, >= are meant to be supported and whether they're working as expected. Introducing others if not currently meant to be supported would be out of scope.
AC:
TASK Register Decision HAS BEEN COMPLETE < 30 DAYS should work as expected
Confirm whether other operators are meant to work and are failing as well
OS:
Add support or fix all other operators

---

#### Code Review Tasks:

Author tasks:

- [ ] If I made any UI changes, I've let QA know.

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature

