### PR TITLE
APERTA-8501 Disabling notifications during migration

### DIFF
--- a/lib/tasks/data-migrations/APERTA-8501-add-invitation-tokens-to-missing-invitations.rake
+++ b/lib/tasks/data-migrations/APERTA-8501-add-invitation-tokens-to-missing-invitations.rake
@@ -7,6 +7,7 @@ namespace :data do
           max_retries = 5
           token = SecureRandom.hex(10)
           Invitation.where("token is null").each do |invitation|
+            invitation.notifications_enabled = false
             tries = 0
             loop do
               token = SecureRandom.hex(10)
@@ -16,6 +17,7 @@ namespace :data do
             end
             invitation.token = token
             invitation.save!
+            invitation.notifications_enabled = true
           end
         end
       end


### PR DESCRIPTION
JIRA issue: link-to-jira

#### What this PR does:

The migration to add invitation tokens was failing due to subscription messages not being able to be sent during the migration.  This PR addresses that.

---

#### Code Review Tasks:

Author tasks:

If I need to migrate production data:

- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] I verified the data-migration's results on a copy of production data

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature

