### PR TITLE
APERTA-8598 Allow for impossible unuploaded papers to unblock CI deploy

### DIFF
--- a/lib/tasks/data-migrations/APERTA-7826-migrate_file_type_on_manuscript_attachment.rake
+++ b/lib/tasks/data-migrations/APERTA-7826-migrate_file_type_on_manuscript_attachment.rake
@@ -7,19 +7,24 @@ namespace :data do
     task migrate_file_type_on_manuscript_attachment: :environment do
       messages = []
       Paper.find_each do |paper|
-        file_type = paper.file.file.file.try(:extension)
+        file_type = paper.file.try(:file).try(:file).try(:extension)
         if file_type
           STDOUT.puts("Updating 'file_type' column for paper #{paper.id} to #{file_type}")
-          paper.file.update_column(:file_type, file_type)
+          paper.file.update_column(:file_type, file_type.downcase)
         else
-          api_paper_url = Rails.application.routes.url_helpers.paper_url(paper)
-          api_paper_url.slice!('api/')
+          paper_url = Rails.application.routes.url_helpers.paper_url(paper)
+          paper_url.slice!('api/')
+
           if paper.processing && paper.withdrawn?
-            messages << "Skipped #{api_paper_url} (paper id: #{paper.id}) because it is stuck in processing"
+            messages << "Skipped #{paper_url} (paper id: #{paper.id}) because it is stuck in processing"
           else
-            # Assume a filetype of docx for papers without an uploaded filetype run before this point
-            paper.file.update_column(:file_type, 'docx')
-            messages << "UNUPLOADED_PAPER: Updating paper #{paper.id} to docx filetype"
+            if paper.file
+              # Assume a filetype of docx for papers without an uploaded filetype run before this point
+              paper.file.update_column(:file_type, 'docx')
+              messages << "UNUPLOADED_PAPER: Updating paper #{paper.id} to docx filetype"
+            else
+              messages << "UNUPLOADED_PAPER: Skipping paper #{paper.id} since there is no uploaded paper"
+            end
           end
         end
       end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8598

#### What this PR does:

This allows the data migration to continue for our CI environment.
There are some conditions that cannot be reached in reality, (like papers that exist with no uploaded paper) but this rake task gets around that by skipping those papers.

I tried this against both the `ci` and `prod` databases.

---

#### Code Review Tasks:

Author tasks:

- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate production data:

- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature

