### PR TITLE
Fix pluralization of days ago

### DIFF
--- a/client/app/lib/relative-time.js
+++ b/client/app/lib/relative-time.js
@@ -14,7 +14,12 @@ export default function(date, todaysMoment) {
     // Moment doesn't have a way to *insist* that the delta be
     // displayed in days; it will round to months/years and we want
     // DAYS, specifically.
-    return Math.floor(ago/msPerDay) + ' days ago';
+    const days = Math.floor(ago/msPerDay);
+    if (days === 1) {
+      return '1 day ago';
+    } else {
+      return days + ' days ago';
+    }
   }
   return moment(date.toISOString()).fromNow();
 }

--- a/client/tests/unit/lib/relative-time-test.js
+++ b/client/tests/unit/lib/relative-time-test.js
@@ -5,6 +5,16 @@ module('RelativeTime');
 
 let now = 'September 13, 2016 13:17:56 UTC';
 
+test('1 day ago, beginning of day', function(assert) {
+  const startOfDay = moment(now).utc().startOf('day');
+  const endOfDay = moment(now).utc().endOf('day');
+
+  var date = new Date('September 12, 2016 00:00:09 UTC');
+
+  assert.equal(relativeTime(date, startOfDay), '1 day ago', 'returns a human readable string for how many days ago a date was');
+  assert.equal(relativeTime(date, endOfDay), '1 day ago', 'returns a human readable string for how many days ago a date was');
+});
+
 test('3 days ago, beginning of day', function(assert) {
   const startOfDay = moment(now).utc().startOf('day');
   const endOfDay = moment(now).utc().endOf('day');


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8606

#### What this PR does:

While looking into another issue I noticed we are displaying the string "1 days ago" on the paper tracker. I fixed this.

---

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature

