### PR TITLE
APERTA-8694 Fix PDF upload notification (close spinner)

### DIFF
--- a/app/models/manuscript_attachment.rb
+++ b/app/models/manuscript_attachment.rb
@@ -3,6 +3,8 @@
 class ManuscriptAttachment < Attachment
   has_paper_trail
 
+  after_commit :notify
+
   self.public_resource = false
 
   # Never ever delete manuscripts, always keep them. Safe. Sound.


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8694

#### What this PR does:

When blank information comes back from iHat, there is no model change
for ManuscriptAttachment. This notifies every time just to stop the
spinner and mark it done on the front end.

---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
