### PR TITLE
APERTA-8159:  Add a work around rake task for running the attachment report

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,7 +9,7 @@ job_type :rake, "cd :path && chruby-exec #{RUBY_VERSION} -- "\
 every :day, at: '00:01' do
   rake 'plos_billing:daily_billing_log_export'
   rake 'clean:temp_files'
-  rake 'reports:analyze_attachments:send_email[apertadevteam@plos.org]'
+  rake 'reports:analyze_attachments:send_email_to_aperta_dev_team'
 end
 
 every :day, at: '09:00' do

--- a/lib/tasks/reports/analyze_attachments_report.rake
+++ b/lib/tasks/reports/analyze_attachments_report.rake
@@ -11,6 +11,22 @@ namespace :reports do
     end
 
     desc <<-DESCRIPTION.strip_heredoc
+      Runs the AnalyzeAttachmentFailuresReport and emails apertadevteam@plos.org.
+
+      Usage:
+        rake reports:analyze_attachments:send_email_to_aperta_dev_team
+
+      Note: this is workaround because the version of chruby deployed
+      incorrectly escapes square brackets and causes issues when executing
+      on ci, rc, production, etc.
+    DESCRIPTION
+    task send_email_to_aperta_dev_team: :environment do
+      task = Rake::Task['reports:analyze_attachments:send_email']
+      task.reenable
+      task.invoke('apertadevteam@plos.org')
+    end
+
+    desc <<-DESCRIPTION.strip_heredoc
       Runs the AnalyzeAttachmentFailuresReport and emails the team
 
       Usage:


### PR DESCRIPTION
JIRA issue: [APERTA-8159](https://developer.plos.org/jira/browse/APERTA-8159)

#### What this PR does:

This changeset adds a workaround to calling a rake task via the `config/schedule.rb` defined cron job. The workaround rake task is:

```
rake reports:analyze_attachments:send_email_to_aperta_dev_team
```

This is because the current version of chruby deployed to SFO and SOMA environments has a bug in processing shell arguments and it results in improperly escape square brackets.

When chruby gets updated this task can go away and the config/schedule.rb can be updated to pass along the email via the CLI rake task invocation.

#### Notes

* The original work for this has been reviewed and merged to master. Everything worked well except running the task via cron. *This PR should go directly back to QA once merged.* There is no PO review for this.

* This needs to go in before the next release OR the #2773 needs to be reverted on master since it will cause the cron job to blow up each day.

#### Code Review Tasks:

Author tasks: 😄 

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- ~~[] I like the CHANGELOG entry~~ (n/a)
- ~~[] I agree the code fulfills the Acceptance Criteria~~ (n/a)
- [ ] I agree the author has fulfilled their tasks

