### PR TITLE
Update analyze_attachment_failures_report_spec.rb to run all of the examples using noon today

### DIFF
--- a/spec/lib/tahi_reports/analyze_attachment_failures_report_spec.rb
+++ b/spec/lib/tahi_reports/analyze_attachment_failures_report_spec.rb
@@ -14,6 +14,15 @@ describe TahiReports::AnalyzeAttachmentFailuresReport do
       output.tap(&:rewind).read
     end
 
+    # Ensure that all of the examples below run with a consistent
+    # time that is on the same day. Otherwise, times may end up on different
+    # days based on timezone offsets.
+    around do |example|
+      Timecop.freeze Chronic.parse("today noon") do
+        example.run
+      end
+    end
+
     let(:output) { StringIO.new }
 
     let!(:processing_attachment_from_today) { FactoryGirl.create(:attachment, :processing, updated_at: 6.minutes.ago) }


### PR DESCRIPTION
JIRA issue: link-to-jira

#### What this PR does:

Update analyze_attachment_failures_report_spec.rb to run all of the examples using noon today

Otherwise timezone offsets may switch the underlying day and cause the report to produce different results than if they were on the same day.

E.g. if it's 11:00 PM -0500 in UTC it's going to be the next day at 4:00 AM.

Note: this is to resolve spec failures from running this spec near day boundaries in various timezones.

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
