### PR TITLE
Removing adding indexes which are later removed

### DIFF
--- a/db/migrate/20161129174005_journal_doi_files_required.rb
+++ b/db/migrate/20161129174005_journal_doi_files_required.rb
@@ -3,7 +3,5 @@ class JournalDoiFilesRequired < ActiveRecord::Migration
     change_column :journals, :doi_publisher_prefix, :string, null: false
     change_column :journals, :doi_journal_prefix, :string, null: false
     change_column :journals, :last_doi_issued, :string, null: false, default: "0"
-
-    add_index :journals, [:doi_publisher_prefix], :unique => true
   end
 end

--- a/db/migrate/20161219214719_allow_duplicate_publisher_prefixes.rb
+++ b/db/migrate/20161219214719_allow_duplicate_publisher_prefixes.rb
@@ -1,6 +1,5 @@
 class AllowDuplicatePublisherPrefixes < ActiveRecord::Migration
   def change
-    remove_index :journals, :doi_publisher_prefix
     remove_index :journals, :doi_journal_prefix
     add_index :journals, [:doi_publisher_prefix, :doi_journal_prefix], name: "unique_doi", unique: true, using: :btree
   end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8784

#### What this PR does:

Not adding migrations which are later removed.  Then removing the removal of them.

---

#### Code Review Tasks:

Author tasks:

If I need to migrate production data:

- [x] I verified the data-migration's results on a copy of production data

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
~~- [ ] I like the CHANGELOG entry~~
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
