### PR TITLE
Eager loading test

### DIFF
--- a/engines/plos_bio_tech_check/spec/features/initial_tech_check_task_spec.rb
+++ b/engines/plos_bio_tech_check/spec/features/initial_tech_check_task_spec.rb
@@ -5,7 +5,7 @@ feature 'Initial Tech Check', js: true do
   let(:editor) { create :user }
   let(:author) { create :user }
   let(:paper) { create :paper, :checking, journal: journal, creator: author }
-  let(:task) { create :initial_tech_check_task, paper: paper }
+  let!(:task) { create :initial_tech_check_task, paper: paper }
 
   before do
     assign_journal_role journal, editor, :editor

--- a/spec/features/gradual_engagement_spec.rb
+++ b/spec/features/gradual_engagement_spec.rb
@@ -9,15 +9,18 @@ feature 'Gradual Engagement', js: true do
 
   context 'when viewing the manuscript' do
     context 'as a non-collaborator, ie author, admin' do
+      let!(:paper) do
+        FactoryGirl.create :paper,
+                           :with_integration_journal,
+                           :gradual_engagement,
+                           creator: user
+      end
+
       context 'on the first paper view' do
         scenario 'submission process box is shown and contains proper journal
                   title in text on the first visit to the page after creation.
                   The submission process is not automatically shown on
                   subsequent page views' do
-          paper = FactoryGirl.create :paper,
-                                     :with_integration_journal,
-                                     :gradual_engagement,
-                                     creator: user
           visit "/papers/#{paper.id}?firstView=true"
           expect(find('#submission-process'))
             .to have_content(paper.journal.name)
@@ -28,10 +31,6 @@ feature 'Gradual Engagement', js: true do
         end
 
         scenario 'the X in the submission process box closes the box' do
-          paper = FactoryGirl.create :paper,
-                                     :with_integration_journal,
-                                     :gradual_engagement,
-                                     creator: user
           visit "/papers/#{paper.id}?firstView=true"
           expect(find('#submission-process'))
           find('#sp-close').click
@@ -108,14 +107,17 @@ feature 'Gradual Engagement', js: true do
 
     context 'and the paper is in revision and has incomplete submittable
       tasks' do
+      let!(:paper) do
+        FactoryGirl.create :paper,
+                           :with_integration_journal,
+                           :with_tasks,
+                           :gradual_engagement,
+                           creator: user,
+                           publishing_state: :in_revision
+      end
+
       scenario 'the sidebar submission text shows journal name and message to
                 fill out remaining tasks.' do
-        paper = FactoryGirl.create :paper,
-                                   :with_integration_journal,
-                                   :with_tasks,
-                                   :gradual_engagement,
-                                   creator: user,
-                                   publishing_state: :in_revision
         visit "/papers/#{paper.id}"
         expect(find('.gradual-engagement-presubmission-messaging'))
           .to have_content('Please provide the following information to submit
@@ -125,13 +127,16 @@ feature 'Gradual Engagement', js: true do
     end
 
     context 'and the paper is in revision and is ready for submission' do
+      let!(:paper) do
+        FactoryGirl.create :paper,
+                           :with_integration_journal,
+                           :gradual_engagement,
+                           creator: user,
+                           publishing_state: :in_revision
+      end
+
       scenario 'the sidebar submission text shows journal name and message to
                 fill out info FULL submission state information' do
-        paper = FactoryGirl.create :paper,
-                                   :with_integration_journal,
-                                   :gradual_engagement,
-                                   creator: user,
-                                   publishing_state: :in_revision
         visit "/papers/#{paper.id}"
         expect(find('.ready-to-submit'))
           .to have_content('Your manuscript is ready for Submission')
@@ -141,12 +146,14 @@ feature 'Gradual Engagement', js: true do
 
     context 'when viewing a gradual engagment paper in a pre full-submission
       state' do
+      let!(:paper) do
+        FactoryGirl.create :paper,
+                           :with_integration_journal,
+                           :gradual_engagement,
+                           creator: user
+      end
       scenario 'the circled ? toggles the visibility of the submission process
                 box' do
-        paper = FactoryGirl.create :paper,
-                                   :with_integration_journal,
-                                   :gradual_engagement,
-                                   creator: user
         visit "/papers/#{paper.id}"
         expect(page).not_to have_selector('#submission-process.show-process')
         find('#submission-process-toggle').click
@@ -160,7 +167,7 @@ feature 'Gradual Engagement', js: true do
   context 'when submitting' do
     context 'when a paper is in a gradual engagement workflow' do
       context 'On initial submission' do
-        let(:paper) do
+        let!(:paper) do
           FactoryGirl.create(
             :paper,
             :with_integration_journal,
@@ -180,7 +187,7 @@ feature 'Gradual Engagement', js: true do
       end
 
       context 'after invitation (on full submit) ' do
-        let(:paper) do
+        let!(:paper) do
           FactoryGirl.create(
             :paper,
             :with_integration_journal,
@@ -203,7 +210,7 @@ feature 'Gradual Engagement', js: true do
       end
 
       context 'when submitting after revision' do
-        let(:paper) do
+        let!(:paper) do
           FactoryGirl.create(
             :paper,
             :with_integration_journal,
@@ -225,7 +232,7 @@ feature 'Gradual Engagement', js: true do
     end
 
     context 'when a paper is NOT in a gradual engagement workflow' do
-      let(:paper) do
+      let!(:paper) do
         FactoryGirl.create(
           :paper,
           :with_integration_journal,

--- a/spec/features/production_metadata_spec.rb
+++ b/spec/features/production_metadata_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 feature 'Production Metadata Card', js: true do
   let(:admin) { create :user, :site_admin, first_name: 'Admin' }
   let(:author) { create :user, first_name: 'Author' }
-  let!(:paper) do
+  let(:paper) do
     create :paper, :with_integration_journal, :with_tasks, creator: author
   end
-  let(:production_metadata_task) do
+  let!(:production_metadata_task) do
     create :production_metadata_task, paper: paper, phase: paper.phases.first
   end
 

--- a/spec/features/view_versions_spec.rb
+++ b/spec/features/view_versions_spec.rb
@@ -12,7 +12,7 @@ feature 'Viewing Versions:', js: true do
                          second_version_body: '<p>OK second body</p>',
                          creator: user
     end
-    let(:task) do
+    let!(:task) do
       FactoryGirl.create :ethics_task,
                          paper: paper,
                          phase: paper.phases.first
@@ -90,7 +90,7 @@ feature 'Viewing Versions:', js: true do
 
     context 'The user has limited access' do
       let(:reviewer) { FactoryGirl.create :user }
-      let(:task) do
+      let!(:task) do
         FactoryGirl.create :cover_letter_task,
                            paper: paper,
                            phase: paper.phases.first

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -121,7 +121,7 @@ RSpec.configure do |config|
     end
 
     Capybara.javascript_driver = :selenium
-    Capybara.default_max_wait_time = 10
+    Capybara.default_max_wait_time = 5
     Capybara.wait_on_first_by_default = true
 
     # Store screenshots in artifacts dir on circle


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8745

#### What this PR does:

In capybara specs, if we use a `let` binding, we have to be cautious. These are lazily evaluated, and so the data will not be inserted into the database until the binding is used for the first time. Because capybara with selenium is running in multiple threads, this could mean that firefox is attempting to view a page at the same time that the data is being inserted into the db (I believe).

This PR uses an eager `let!` in place of `let` in a few places.

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
