### PR TITLE
Revert "adjust figure label explanation"

### DIFF
--- a/engines/tahi_standard_tasks/client/app/templates/components/figure-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/figure-task.hbs
@@ -19,7 +19,7 @@
                    owner=task
                    disabled=isNotEditable}}
 
-  <p>For .doc or .docx manuscript uploads only, figure labels (e.g. 'Fig 1') are generated from file names and will automatically place figures above matching legends. PDF manuscripts are presented as uploaded.</p>
+  <p>Figure labels (e.g. Fig 1) are generated from file names and will automatically place figures above matching legends.</p>
 
   <hr>
 


### PR DESCRIPTION
Reverts Tahi-project/tahi#2843

it has been decided that  APERTA-8152 should be removed from `master`.  This does that.