### PR TITLE
Revert "Revert "adjust figure label explanation""

### DIFF
--- a/engines/tahi_standard_tasks/client/app/templates/components/figure-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/figure-task.hbs
@@ -19,7 +19,7 @@
                    owner=task
                    disabled=isNotEditable}}
 
-  <p>Figure labels (e.g. Fig 1) are generated from file names and will automatically place figures above matching legends.</p>
+  <p>For .doc or .docx manuscript uploads only, figure labels (e.g. 'Fig 1') are generated from file names and will automatically place figures above matching legends. PDF manuscripts are presented as uploaded.</p>
 
   <hr>
 


### PR DESCRIPTION
The change for APERTA-8152 that was removed is now being added back in:
https://developer.plos.org/jira/browse/APERTA-8152

This reverts commit a8c55d9f91b5fc610089ce42771f176538f4dea1.

JIRA issue: https://developer.plos.org/jira/browse/APERTA-8152

History, going backward in time:
* https://github.com/Tahi-project/tahi/pull/2848
* https://github.com/Tahi-project/tahi/pull/2843
* https://developer.plos.org/jira/browse/APERTA-8152

This has already been approved for merging.