### PR TITLE
Remove inadvertent schema changes

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -390,8 +390,6 @@ ActiveRecord::Schema.define(version: 20170209124450) do
     t.string   "paper_type"
     t.integer  "journal_id"
     t.boolean  "uses_research_article_reviewer_report", default: false
-    t.datetime "updated_at"
-    t.datetime "created_at"
   end
 
   add_index "manuscript_manager_templates", ["journal_id"], name: "index_manuscript_manager_templates_on_journal_id", using: :btree


### PR DESCRIPTION
JIRA issue: NONE

#### What this PR does:

This commit removes the `updated_at` and `created_at` timestamps for 
`ManuscriptManagerTemplate`.  The schema change and the migration that
makes it will be part of a future commit.

Here's how this happened:  we had two simultaneous streams of work happening.  The other branch had some migrations that had run and had modified the `schema.rb` correctly.  However, the modified `schema.rb` file was inadvertently checked in with the [feature flags PR](https://github.com/Tahi-project/tahi/pull/2858).

The `data.yml` file changed in the feature flags PR, but it was done prior to the schema changes, so nothing with that file needs reverted with this PR.

This PR will remove these inadvertent changes to the schema file.

---

#### Code Review Tasks:

Author tasks:

- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate production data:

- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
