### PR TITLE
Introduce helper of some kind for Task-related integration tests in Ember

### DIFF
--- a/client/tests/components/billing-task-test.js
+++ b/client/tests/components/billing-task-test.js
@@ -1,19 +1,14 @@
-import { test, moduleForComponent } from 'ember-qunit';
+import { test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { manualSetup, make } from 'ember-data-factory-guy';
-import { createQuestion, createQuestionWithAnswer } from 'tahi/tests/factories/nested-question';
-import registerCustomAssertions from '../helpers/custom-assertions';
+import { make } from 'ember-data-factory-guy';
+import { createQuestionWithAnswer } from 'tahi/tests/factories/nested-question';
 import Factory from '../helpers/factory';
 import Ember from 'ember';
-import wait from 'ember-test-helpers/wait';
+import moduleForComponentIntegration from 'tahi/tests/helpers/module-for-component-integration';
 
-moduleForComponent('billing-task', 'Integration | Component | billing task', {
-  integration: true,
+moduleForComponentIntegration('billing-task', {
+  useRealCanService: true,
   beforeEach() {
-    registerCustomAssertions();
-    manualSetup(this.container);
-
-    this.registry.register('pusher:main', Ember.Object.extend({socketId: 'foo'}));
     $.mockjax({url: '/api/countries', status: 200, responseText: {
       countries: [],
     }});
@@ -22,9 +17,6 @@ moduleForComponent('billing-task', 'Integration | Component | billing task', {
     }});
     Factory.createPermission('billingTask', 1, ['edit', 'view']);
   },
-  afterEach() {
-    $.mockjax.clear();
-  }
 });
 
 let template = hbs`{{billing-task task=testTask}}`;
@@ -93,7 +85,7 @@ test('validates numericality of a few fields', function(assert) {
   this.$('input[name=plos_billing--pfa_question_4a]').val('not a number').trigger('input');
 
   let done = assert.async();
-  wait().then(() => {
+  this.wait().then(() => {
     assert.textPresent('#error-for-plos_billing--pfa_question_1b', 'Must be a number');
     assert.textPresent('#error-for-plos_billing--pfa_question_2b', 'Must be a number');
     assert.textPresent('#error-for-plos_billing--pfa_question_3a', 'Must be a number');
@@ -109,7 +101,7 @@ test('it reports validation errors on the task when attempting to complete', fun
   this.$('.billing-task button.task-completed').click();
 
   let done = assert.async();
-  wait().then(() => {
+  this.wait().then(() => {
     // Error at the task level
     assert.textPresent('.billing-task', 'Please fix all errors');
     done();
@@ -123,7 +115,7 @@ test('it does not allow the user to complete when there are validation errors', 
   this.$('.billing-task button.task-completed').click();
 
   let done = assert.async();
-  wait().then(() => {
+  this.wait().then(() => {
     assert.equal(testTask.get('completed'), false, 'task remained incomplete');
     done();
   });
@@ -140,7 +132,7 @@ test('it lets you complete the task when there are no validation errors', functi
   this.$('.billing-task button.task-completed').click();
 
   let done = assert.async();
-  wait().then(() => {
+  this.wait().then(() => {
     assert.equal(testTask.get('completed'), true, 'task was completed');
     assert.mockjaxRequestMade('/api/tasks/1', 'PUT');
     done();
@@ -162,7 +154,7 @@ test('it lets you uncomplete the task when it has validation errors', function(a
   this.$('.billing-task button.task-completed').click();
 
   let done = assert.async();
-  wait().then(() => {
+  this.wait().then(() => {
     assert.equal(testTask.get('completed'), false, 'task was marked as incomplete');
     assert.mockjaxRequestMade('/api/tasks/1', 'PUT');
     $.mockjax.clear();
@@ -170,7 +162,7 @@ test('it lets you uncomplete the task when it has validation errors', function(a
     // try complete again
     this.$('.billing-task button.task-completed').click();
 
-    wait().then(() => {
+    this.wait().then(() => {
       assert.textPresent('.billing-task', 'Please fix all errors');
       assert.equal(testTask.get('completed'), false, 'task did not input completion status');
       assert.mockjaxRequestNotMade('/api/tasks/1', 'PUT');

--- a/client/tests/components/nested-question-textarea-test.js
+++ b/client/tests/components/nested-question-textarea-test.js
@@ -1,35 +1,20 @@
-import { test, moduleForComponent } from 'ember-qunit';
+import { test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { manualSetup, make } from 'ember-data-factory-guy';
-import { createQuestion } from 'tahi/tests/factories/nested-question';
-import registerCustomAssertions from '../helpers/custom-assertions';
-import FakeCanService from '../helpers/fake-can-service';
-import Ember from 'ember';
-import wait from 'ember-test-helpers/wait';
+import { make } from 'ember-data-factory-guy';
+import moduleForComponentIntegration from 'tahi/tests/helpers/module-for-component-integration';
 
-moduleForComponent('nested-question-textarea', 'Integration | Component | nested question textarea', {
-  integration: true,
+moduleForComponentIntegration('nested-question-textarea', {
   beforeEach() {
-    registerCustomAssertions();
-    manualSetup(this.container);
-    this.registry.register('pusher:main', Ember.Object.extend({socketId: 'foo'}));
-    this.registry.register('service:can', FakeCanService);
-
     this.getAnswers = function() {
       return this.container.lookup('service:store').peekAll('nested-question-answer');
     };
-  },
-
-  afterEach() {
-    $.mockjax.clear();
   }
 });
 
 test('saves on input events', function(assert) {
   let task =  make('ad-hoc-task');
-  let fake = this.container.lookup('service:can');
-  fake.allowPermission('edit', task);
-  createQuestion(task, 'foo');
+  this.fakeCan.allowPermission('edit', task);
+  this.createQuestion(task, 'foo');
   this.set('task', task);
 
   this.render(hbs`
@@ -39,16 +24,15 @@ test('saves on input events', function(assert) {
   $.mockjax({url: '/api/nested_questions/1/answers', type: 'POST', status: 204, responseText: '{}'});
   this.$('textarea').val('new comment').trigger('input');
 
-  return wait().then(() => {
+  return this.wait().then(() => {
     assert.mockjaxRequestMade('/api/nested_questions/1/answers', 'POST', 'it saves the new answer on input');
   });
 });
 
 test('does not save on change events', function(assert) {
   let task =  make('ad-hoc-task');
-  let fake = this.container.lookup('service:can');
-  fake.allowPermission('edit', task);
-  createQuestion(task, 'foo');
+  this.fakeCan.allowPermission('edit', task);
+  this.createQuestion(task, 'foo');
   this.set('task', task);
 
   this.render(hbs`
@@ -58,7 +42,7 @@ test('does not save on change events', function(assert) {
   $.mockjax({url: '/api/nested_questions/1/answers', type: 'POST', status: 204, responseText: '{}'});
   this.$('textarea').val('new comment').trigger('change');
 
-  return wait().then(() => {
+  return this.wait().then(() => {
     assert.mockjaxRequestNotMade('/api/nested_questions/1/answers', 'POST', 'it saves the new answer on input');
   });
 });

--- a/client/tests/helpers/module-for-component-integration.js
+++ b/client/tests/helpers/module-for-component-integration.js
@@ -1,0 +1,77 @@
+import { moduleForComponent } from 'ember-qunit';
+import { manualSetup } from 'ember-data-factory-guy';
+import { createQuestion, createQuestionWithAnswer } from 'tahi/tests/factories/nested-question';
+import registerCustomAssertions from '../helpers/custom-assertions';
+import FakeCanService from '../helpers/fake-can-service';
+import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
+
+/**
+ * moduleForComponentIntegration removes a some of the boilerplate that's sprung up when
+ * we do component integration tests recently.  It also names our 
+ *
+ **/
+export default function(componentModuleName, options = {}) {
+  let moduleParts = componentModuleName.split('-');
+  let testName;
+  if (moduleParts.get('lastObject') === 'task') {
+    moduleParts.pop();
+    testName = `Integration | Component | Tasks | ${moduleParts.join(' ')}`;
+  } else {
+    testName = `Integration | Component | ${moduleParts.join(' ')}`;
+  }
+  moduleForComponent(componentModuleName, testName, {
+    integration: true,
+    beforeEach() {
+      // we have a bunch of useful custom assertions that we have to manually register
+      // each time
+      registerCustomAssertions();
+
+      // for component tests FactoryGuy needs to be set up manually
+      manualSetup(this.container);
+
+      // any time an ajax request gets made (even one that gets caught by mockjax or sinon)
+      // it makes a call to the pusher service to set a header.  We don't care about it during
+      // component tests, and that service normally gets created in an initializer.  Here we just
+      // fake it out.
+      this.registry.register('pusher:main', Ember.Object.extend({socketId: 'foo'}));
+
+      // The FakeCanService lets us avoid having to stub out network requests for a given resource.
+      // Here's an example of using it (either in a beforeEach or in the test itself)
+      //     ```
+      //     let task = make('some-task-class');
+      //     this.fakeCan.allowPermission('edit', task);
+      //     ```
+      // At this point using FakeCan is probably a better option than using the Factory.createPermission
+      // option that exists in other places, as it shortcircuits the 'can' methods before having to fake out
+      // any actual ajax requests
+      if(!options.useRealCanService) {
+        this.registry.register('service:can', FakeCanService);
+        this.fakeCan = this.container.lookup('service:can');
+      }
+
+      // wait is a built-in ember helper that lets us wait for async stuff to finish.  It's actually
+      // what powers the async helpers that we use in the full acceptance tests
+      this.wait = wait;
+
+      // ********** put other common helpers here and document what they do
+      // createQuestion will put a nested question with the given ident and owner into the store
+      this.createQuestion = createQuestion;
+      // createQuestionWithAnswer will put a nested question with the given ident and owner into the store,
+      // also creating an answer with the given value
+      this.createQuestionWithAnswer = createQuestionWithAnswer;
+
+      // just like moduleForAcceptance you can pass additional beforeEach and afterEach arguments
+      // to moduleForComponentIntegration and they'll get called after the ones specified here.
+      if (options.beforeEach) {
+        return options.beforeEach.apply(this, arguments);
+      }
+    },
+
+    afterEach() {
+      $.mockjax.clear();
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Ember.RSVP.Promise.resolve(afterEach);
+    }
+  });
+}


### PR DESCRIPTION
Just like we have `moduleForAcceptance`, `moduleForComponentIntegration`
is here to eliminate boilerplate and condense some of the current best
practices around testing components into a single file.  I think having to specify `this.` extra times
is more than worth having to copy and paste imports, and the lack of discoverability that goes with it.

I'm hoping we can get to the point where any new person who needs to make component tests can look at this helper and have a little guide on how to do so.  

I've done a few conversions so far, but I'd like to get feedback before going any further

JIRA issue: None, this is a quality of life issue for Ember component tests only

Please take a look and see if there are other common imports, etc you'd like to see in the helper. 
I'm already considering putting `make` onto the test context as well. 

