### PR TITLE
APERTA-9315 Run rake db:migrate on release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma
 worker: bundle exec sidekiq -C config/sidekiq.heroku.yml
+release: rake db:migrate


### PR DESCRIPTION
Per https://devcenter.heroku.com/articles/github-integration-review-apps, the
proper way to run a db migration on every release is using a release phase in
the Procfile.

JIRA issue: https://developer.plos.org/jira/browse/APERTA-9315

#### What this PR does:

Runs a `rake db:migrate` on every update of the review app.

---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
