### PR TITLE
Fix/aperta 9385 part 2

### DIFF
--- a/client/app/pods/components/paper-downloads/component.js
+++ b/client/app/pods/components/paper-downloads/component.js
@@ -28,7 +28,7 @@ export default Ember.Component.extend({
     // TMP: APERTA-9385: Displaying only the latest version
     let version = versions.findBy('isDraft', true);
     if (!version) {
-      version = versions.toArray().sortBy('majorVersion').sortBy('minorVersion')[versions.length - 1];
+      version = versions.toArray().sortBy('majorVersion', 'minorVersion')[versions.length - 1];
     }
     this.set('versions', [version]);
   }),


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9385

#### What this PR does:

Javascript does not provide a stable sort, so we need to provide multiple arguments to `sortBy` rather than chain our sorts (and I got the chaining in the wrong order anyhow)

See https://github.com/emberjs/ember.js/blob/v2.11.0/packages/ember-runtime/lib/mixins/enumerable.js#L1044


Using `sortBy('majorVersion', 'minorVersion')` will compare each array entry first by major version, then minor version if the major version is the same.

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
