### PR TITLE
APERTA-9514 Fix failing health checks

### DIFF
--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -14,8 +14,8 @@ HealthCheck.setup do |config|
   config.http_status_for_error_object = 500
 
   # ensure our databases are available:
-  config.standard_checks = [ 'custom', 'database', 'redis' ]
-  config.full_checks     = [ 'custom', 'database', 'redis' ]
+  config.standard_checks = ['custom', 'database', 'sidekiq-redis']
+  config.full_checks     = ['custom', 'database', 'sidekiq-redis']
 
   # max-age of response in seconds
   # cache-control is public when max_age > 1 and basic_auth_username is not set
@@ -47,7 +47,10 @@ HealthCheck.setup do |config|
   config.add_custom_check('redis-writability') do
     begin
 
-      redis = Redis.current
+      # use any custom redis url that was provided using env convention
+      # with fallback to localhost if custom url is not provided
+      custom_redis_url = ENV[ENV['REDIS_PROVIDER'] || 'REDIS_URL']
+      redis = Redis.new(url: custom_redis_url)
 
       what_is_deposited = rand(42_000).to_s
       scratch_key       = "scratch_key_#{what_is_deposited}"


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9514

#### What this PR does:

Currently, the red alert banner is shown on any recent heroku review apps.

![tahi 2017-03-16 15-43-25](https://cloud.githubusercontent.com/assets/18446/24015594/538a061a-0a5f-11e7-97f2-2833e3f448a6.png)

This is due to the health check failing due to two separate checks being made against the redis service. One is a redis check provided by the health_check gem. The other was a custom check written internally.

In both cases, the problem was due to the code incorrectly assuming that Redis was always going to be running on localhost. In the case of the heroku pipeline review app, Aperta is using a cloud based redis addon.

Please see inline code comments for the corrections to this problem.

To test:
* verify that the [heroku deployed app](https://ciagent-stage-pr-2937.herokuapp.com/) does not show the red banner
* verify that the [health endpoint](https://ciagent-stage-pr-2937.herokuapp.com/health) reports the app being healthy
------

#### Code Review Tasks:

Author tasks:

- [X] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature