### PR TITLE
Fix/update participant data migration

### DIFF
--- a/lib/tasks/data-migrations/APERTA-9054-remove-participant-role-from-reviewers.rake
+++ b/lib/tasks/data-migrations/APERTA-9054-remove-participant-role-from-reviewers.rake
@@ -14,20 +14,14 @@ namespace :data do
         reviewer_count = 0
         removed_participations = []
         assignment_count = 0
-        assignment_ids = []
 
         # Assertions to check the integrity of the data
-        User.joins(:roles).where(roles: { name: 'Reviewer Report Owner' }).map do |reviewer|
+        User.joins(:roles).where(roles: { name: 'Reviewer Report Owner' }).uniq.map do |reviewer|
           reviewer_count += 1
           reviewer_report_ids = reviewer.tasks.where(type: relevant_tasks).pluck(:id).uniq
           reviewer_report_ids.each do |reviewer_report_id|
             reviewer.participations.where(assigned_to_id: reviewer_report_id).each do |assignment|
-              if assignment_ids.include? assignment.id
-                STDOUT.puts("Skipping #{assignment.id} because it is already counted")
-              else
-                assignment_ids << assignment.id
-                assignment_count += 1
-              end
+              assignment_count += 1
             end
           end
         end
@@ -39,7 +33,7 @@ namespace :data do
           raise "Reviewer participants higher than Reviewer Reports"
         end
 
-        User.joins(:roles).where(roles: { name: 'Reviewer Report Owner' }).find_each do |reviewer|
+        User.joins(:roles).where(roles: { name: 'Reviewer Report Owner' }).uniq.find_each do |reviewer|
           user_count += 1
           reviewer_report_ids = reviewer.tasks.where(type: relevant_tasks).pluck(:id).uniq
           reviewer_report_ids.each do |reviewer_report_id|


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9054

#### What this PR does:

This fixes the data migration for the RC

---

#### Code Review Tasks:


If I need to migrate existing data:

- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`

- [x] I verified the data-migration's results on a copy of production data


Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
