### PR TITLE
Add commit id endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ guidelines from here: https://github.com/olivierlacan/keep-a-changelog
 
 ## ## [x.x.x] - {yyyy-mm-dd}
 ### Added
+* Inject the Git Commit ID in <meta> tag for easier debugging
 ### Changed
 * Edited CSS (color and hover features) for manuscript list on dashboard to be
 more user friendly.

--- a/app/helpers/template_helper.rb
+++ b/app/helpers/template_helper.rb
@@ -2,4 +2,10 @@ module TemplateHelper
   def app_name
     TahiEnv.app_name
   end
+
+  def git_commit_id_meta_tag
+    content_tag(:meta, nil,
+                name: "git-commit-id",
+                content: Rails.configuration.x.git_commit_id)
+  end
 end

--- a/app/views/ember_cli/ember/index.html.erb
+++ b/app/views/ember_cli/ember/index.html.erb
@@ -1,5 +1,7 @@
 <%= render_ember_app :client do |head, body| %>
   <% head.append do %>
+    <%= git_commit_id_meta_tag %>
+
     <script type='text/javascript'>
       window.appName = "<%= app_name %>"
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html class="bg-<%= (rand() * 2).to_i + 1 %>">
   <head>
+    <%= git_commit_id_meta_tag %>
+
     <title>
       <%= app_name %>
     </title>

--- a/config/initializers/load_git_revision.rb
+++ b/config/initializers/load_git_revision.rb
@@ -1,0 +1,21 @@
+Rails.configuration.x.git_commit_id = \
+  begin
+    revision_path = Rails.root.join('REVISION')
+    if File.exist?(revision_path)
+      File.read(revision_path).strip
+    elsif system('git status')
+      id = `git rev-parse HEAD`[0..6]
+      if `git status --porcelain`.strip.empty?
+        id
+      else
+        "#{id} (dirty)"
+      end
+    elsif ENV['HEROKU_SLUG_COMMIT'].present?
+      ENV['HEROKU_SLUG_COMMIT'][0..6]
+    end
+  rescue => ex
+    Bugsnag.notify(ex)
+    Rails.logger.warn("Caught exception: #{ex} when loading git version")
+  end
+
+Rails.configuration.x.git_commit_id ||= 'UNKNOWN'


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9534

#### What this PR does:

Adds a commit id meta tag to our app so our devs can verify what the latest code deploy was.

View the source of https://ciagent-stage-pr-2941.herokuapp.com/ to see it in action

It should work locally (by checking `git`), on production (checking the cap-generated `REVISION` file), and on heroku (if https://devcenter.heroku.com/articles/dyno-metadata is enabled)

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- ~~[ ] I have found the tests to be sufficient~~
- ~~[ ] I like the CHANGELOG entry~~
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
