### PR TITLE
APERTA-9444 add www to orcid info href

### DIFF
--- a/client/app/pods/components/orcid-connect/template.hbs
+++ b/client/app/pods/components/orcid-connect/template.hbs
@@ -34,7 +34,7 @@
           {{buttonText}}
       </button>
     </div>
-    <a href="https://plos.org/orcid" target="_blank" class="what-is-orcid">?</a>
+    <a href="https://www.plos.org/orcid" target="_blank" class="what-is-orcid">?</a>
   {{else}}
     {{notConnectedMessage}}
   {{/if}}


### PR DESCRIPTION
[APERTA-9444](https://developer.plos.org/jira/browse/APERTA-9444)

#### What this PR does:

If the user has not visited the domain before, the absence of www causes issues with browsers loading the linked url. 

#### Notes

I'm honestly not entirely sure why this happens. Still looking into the https and www interplay.


#### Major UI changes

None

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [x] The Product Team has reviewed and approved this feature