### PR TITLE
APERTA-9054 Allow Cover Editor and Handling Editor to view discussion…

### DIFF
--- a/app/services/journal_factory.rb
+++ b/app/services/journal_factory.rb
@@ -108,6 +108,7 @@ class JournalFactory
         role.ensure_permission_exists(:manage, applies_to: klass)
         role.ensure_permission_exists(:manage_invitations, applies_to: klass)
         role.ensure_permission_exists(:manage_participant, applies_to: klass)
+        role.ensure_permission_exists(:view_discussion_footer, applies_to: klass)
         role.ensure_permission_exists(:view, applies_to: klass)
         role.ensure_permission_exists(:view_participants, applies_to: klass)
       end
@@ -309,6 +310,7 @@ class JournalFactory
         role.ensure_permission_exists(:manage, applies_to: klass)
         role.ensure_permission_exists(:manage_invitations, applies_to: klass)
         role.ensure_permission_exists(:manage_participant, applies_to: klass)
+        role.ensure_permission_exists(:view_discussion_footer, applies_to: klass)
         role.ensure_permission_exists(:view, applies_to: klass)
         role.ensure_permission_exists(:view_participants, applies_to: klass)
       end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9054

#### What this PR does:

This allows Cover Editors and Handling Editors to see the discussion footer per this confluence doc:
https://developer.plos.org/confluence/pages/viewpage.action?spaceKey=TAHI&title=Card+Discussion+Permissions


---

#### Code Review Tasks:
Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [x] The Product Team has reviewed and approved this feature
