### PR TITLE
APERTA-8610 Fix Group Author email confirmation case

### DIFF
--- a/app/controllers/token_co_authors_controller.rb
+++ b/app/controllers/token_co_authors_controller.rb
@@ -1,4 +1,5 @@
-# Serves as the method for non-users to conform co-authorship without signing in.
+# Serves as the method for non-users to conform
+# co-authorship without signing in.
 class TokenCoAuthorsController < ApplicationController
   before_action :assign_template_vars
 
@@ -7,7 +8,8 @@ class TokenCoAuthorsController < ApplicationController
       redirect_to thank_you_token_co_author_path(token)
     end
 
-    # a more elegant handling of this edge case is handled in a later story
+    # a more elegant handling of this edge case
+    #   is handled in a later story
     if @author.co_author_refuted?
       render nothing: true, status: 200, content_type: 'text/html'
     end
@@ -26,18 +28,22 @@ class TokenCoAuthorsController < ApplicationController
   end
 
   def thank_you
-    redirect_to show_token_co_author_path(token) unless @author.co_author_confirmed?
+    unless @author.co_author_confirmed?
+      redirect_to show_token_co_author_path(token)
+    end
   end
 
   def refuted
-    redirect_to show_token_co_author_path(token) unless author.co_author_refuted?
+    unless author.co_author_refuted?
+      redirect_to show_token_co_author_path(token)
+    end
     assign_template_vars
   end
 
   private
 
   def assign_template_vars
-    @author ||= Author.find_by_token!(token)
+    @author ||= find_author_by_token
     @paper ||= @author.paper
     @authors ||= @paper.all_authors
     @journal_logo_url ||= @paper.journal.logo_url
@@ -45,5 +51,10 @@ class TokenCoAuthorsController < ApplicationController
 
   def token
     params[:token] || params[:invitation][:token]
+  end
+
+  # We have to check both since coauthorship is across models
+  def find_author_by_token
+    GroupAuthor.find_by_token(token) || Author.find_by_token(token)
   end
 end

--- a/spec/controllers/token_co_authors_controller_spec.rb
+++ b/spec/controllers/token_co_authors_controller_spec.rb
@@ -1,66 +1,134 @@
 require "rails_helper"
 
 describe TokenCoAuthorsController do
-  let(:author) { FactoryGirl.create(:author) }
+  context 'author' do
+    let(:author) { FactoryGirl.create(:author) }
 
-  describe 'GET /co_authors_token/:token' do
-    subject(:do_request) { get :show, token: author.token }
-    it "renders the show template" do
-      do_request
-      expect(response).to render_template("token_co_authors/show")
+    describe 'GET /co_authors_token/:token' do
+      subject(:do_request) { get :show, token: author.token }
+      it "renders the show template" do
+        do_request
+        expect(response).to render_template("token_co_authors/show")
+      end
+
+      context "author previously confirmed" do
+        let!(:author) { FactoryGirl.create(:author, co_author_state: 'confirmed') }
+        it "redirects to #thank_you" do
+          do_request
+          expect(response).to redirect_to(:thank_you_token_co_author)
+        end
+      end
     end
 
-    context "author previously confirmed" do
-      let!(:author) { FactoryGirl.create(:author, co_author_state: 'confirmed') }
+    describe "PUT /co_authors_token/:token/confirm" do
+      subject(:do_request) { put :confirm, token: author.token }
+      it "confirms the author as a co author" do
+        expect { do_request }.to change {
+          author.reload
+          author.co_author_confirmed?
+        }
+      end
+
+      it "creates an activity feed item" do
+        expect(Activity).to receive(:co_author_confirmed!).with(author, user: nil)
+        do_request
+      end
+
       it "redirects to #thank_you" do
         do_request
         expect(response).to redirect_to(:thank_you_token_co_author)
       end
-    end
-  end
 
-  describe "PUT /co_authors_token/:token/confirm" do
-    subject(:do_request) { put :confirm, token: author.token }
-    it "confirms the author as a co author" do
-      expect { do_request }.to change {
-        author.reload
-        author.co_author_confirmed?
-      }
+      context "author previously confirmed" do
+        let!(:author) { FactoryGirl.create(:author, co_author_state: 'confirmed') }
+        it "redirects to #thank_you" do
+          do_request
+          expect(response).to redirect_to(:thank_you_token_co_author)
+        end
+      end
     end
 
-    it "creates an activity feed item" do
-      expect(Activity).to receive(:co_author_confirmed!).with(author, user: nil)
-      do_request
-    end
-
-    it "redirects to #thank_you" do
-      do_request
-      expect(response).to redirect_to(:thank_you_token_co_author)
-    end
-
-    context "author previously confirmed" do
+    describe "GET /co_authors_token/:token/thank_you" do
       let!(:author) { FactoryGirl.create(:author, co_author_state: 'confirmed') }
-      it "redirects to #thank_you" do
+      subject(:do_request) { get :thank_you, token: author.token }
+      it "renders the thank you template" do
         do_request
-        expect(response).to redirect_to(:thank_you_token_co_author)
+        expect(response).to render_template("token_co_authors/thank_you")
+      end
+
+      describe "author is not confirmed" do
+        let!(:author) { FactoryGirl.create(:author) }
+
+        it "redirects to #show" do
+          do_request
+          expect(response).to redirect_to(:show_token_co_author)
+        end
       end
     end
   end
 
-  describe "GET /co_authors_token/:token/thank_you" do
-    let!(:author) { FactoryGirl.create(:author, co_author_state: 'confirmed') }
-    subject(:do_request) { get :thank_you, token: author.token }
-    it "renders the thank you template" do
-      do_request
-      expect(response).to render_template("token_co_authors/thank_you")
+  context 'group_author' do
+    let(:group_author) { FactoryGirl.create(:group_author) }
+
+    describe 'GET /co_authors_token/:token' do
+      subject(:do_request) { get :show, token: group_author.token }
+      it "renders the show template" do
+        do_request
+        expect(response).to render_template("token_co_authors/show")
+      end
+
+      context "author previously confirmed" do
+        let!(:author) { FactoryGirl.create(:author, co_author_state: 'confirmed') }
+        it "redirects to #thank_you" do
+          do_request
+          expect(response).to redirect_to(:thank_you_token_co_author)
+        end
+      end
     end
 
-    describe "author is not confirmed" do
-      let!(:author) { FactoryGirl.create(:author) }
+    describe "PUT /co_authors_token/:token/confirm" do
+      subject(:do_request) { put :confirm, token: group_author.token }
+      it "confirms the group_author as a co author" do
+        expect { do_request }.to change {
+          group_author.reload
+          group_author.co_author_confirmed?
+        }
+      end
 
-      it "redirects to #show" do
+      it "creates an activity feed item" do
+        expect(Activity).to receive(:co_author_confirmed!).with(group_author, user: nil)
         do_request
-        expect(response).to redirect_to(:show_token_co_author)
+      end
+
+      it "redirects to #thank_you" do
+        do_request
+        expect(response).to redirect_to(:thank_you_token_co_author)
+      end
+
+      context "group author previously confirmed" do
+        let!(:group_author) { FactoryGirl.create(:author, co_author_state: 'confirmed') }
+        it "redirects to #thank_you" do
+          do_request
+          expect(response).to redirect_to(:thank_you_token_co_author)
+        end
+      end
+    end
+
+    describe "GET /co_authors_token/:token/thank_you" do
+      let!(:group_author) { FactoryGirl.create(:group_author, co_author_state: 'confirmed') }
+      subject(:do_request) { get :thank_you, token: group_author.token }
+      it "renders the thank you template" do
+        do_request
+        expect(response).to render_template("token_co_authors/thank_you")
+      end
+
+      describe "group author is not confirmed" do
+        let!(:group_author) { FactoryGirl.create(:group_author) }
+
+        it "redirects to #show" do
+          do_request
+          expect(response).to redirect_to(:show_token_co_author)
+        end
       end
     end
   end


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-8610

#### What this PR does:

This fixes an issue where email confirmation wasn't working for group authors.   Previously, it was only working with Authors.

To test this, follow these steps:
1.  Go to a paper that is ready for full submission. (the seeds are bugged out right now, so I recommend just making a new paper)
2. Create a group author in the Author's card
3. Submit the paper
4. An email should go out (I recommend getting [mailcatcher](https://mailcatcher.me/) up so you don't have to send it to a real email address).
5. Open the email and confirm.
6. Check to see if it's marked and visible on the author view and the group author form. 

#### Notes

I personally would of split the coauthorship related stuff out into a separate table AND abstract the two models a bit more (or, even better, just merge it back into one model if possible).  We have author/group author splits from data layer down to Ember land, so this and APERTA-9006 was a bit tricky because of it.

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
