### PR TITLE
APERTA-9006 Add email case and paper creator rules

### DIFF
--- a/client/app/models/author.js
+++ b/client/app/models/author.js
@@ -95,7 +95,7 @@ export default NestedQuestionOwner.extend({
   title: attr('string'),
   department: attr('string'),
   coAuthorState: attr('string'),
-  coAuthorStateModifiedOn: attr('date'),
+  coAuthorStateModifiedAt: attr('date'),
   coAuthorConfirmed: computed.equal('coAuthorState', 'confirmed'),
 
   currentAddressStreet: attr('string'),

--- a/client/tests/components/author-form-test.js
+++ b/client/tests/components/author-form-test.js
@@ -8,7 +8,7 @@ import sinon from 'sinon'
 
 import hbs from 'htmlbars-inline-precompile';
 
-let journal;
+let journal, template;
 
 moduleForComponent(
   'author-form',
@@ -65,7 +65,7 @@ moduleForComponent(
   }
 );
 
-var template = hbs`
+template = hbs`
   {{author-form
       author=model.object
       authorProxy=model
@@ -99,7 +99,18 @@ test("component does not display the orcid-connect component when the author doe
 });
 
 test("component shows coauthor controls when user is considered an admin user", function(assert){
-  // Administrator
+  template = hbs`
+  {{author-form
+      author=model.object
+      authorProxy=model
+      validateField=(action validateField)
+      hideAuthorForm="toggleEditForm"
+      isNotEditable=isNotEditable
+      saveSuccess=(action toggleEditForm)
+      canRemoveOrcid=true
+      authorIsPaperCreator=false
+  }}`;
+
   Ember.run(() => {
     const can = FakeCanService.create().allowPermission('administer', journal);
     this.register('service:can', can.asService());
@@ -110,7 +121,17 @@ test("component shows coauthor controls when user is considered an admin user", 
 });
 
 test("component hides coauthor controls when user is considered an non-admin user", function(assert){
-  // Administrator
+  template = hbs`
+  {{author-form
+      author=model.object
+      authorProxy=model
+      validateField=(action validateField)
+      hideAuthorForm="toggleEditForm"
+      isNotEditable=isNotEditable
+      saveSuccess=(action toggleEditForm)
+      canRemoveOrcid=true
+      authorIsPaperCreator=false
+  }}`;
   Ember.run(() => {
     const can = FakeCanService.create().rejectPermission('administer', journal);
     this.register('service:can', can.asService());

--- a/engines/tahi_standard_tasks/client/app/components/author-form-coauthor-controls.js
+++ b/engines/tahi_standard_tasks/client/app/components/author-form-coauthor-controls.js
@@ -9,6 +9,27 @@ export default Component.extend(PropTypes, {
   
   author: PropTypes.EmberObject,
   disabled: PropTypes.bool,
+  controlsVisible: PropTypes.bool,
+
+  modifiedBy: Ember.computed('author.coAuthorStateModifiedBy.fullName', function(){
+    let modifiedBy = this.get('author.coAuthorStateModifiedBy.fullName');
+    if (modifiedBy) {
+      return modifiedBy;
+    } else {
+      return 'email';
+    }
+  }),
+
+  humanizedCoAuthorState: Ember.computed('author.coAuthorState', function(){
+    switch(this.get('author.coAuthorState')) {
+    case 'confirmed':
+      return 'Confirmed by';
+    case 'refuted':
+      return 'Refuted By';
+    default:
+      return 'Last changed by';
+    }
+  }),
 
   actions: {
     setConfirmation(status) {

--- a/engines/tahi_standard_tasks/client/app/components/author-form.js
+++ b/engines/tahi_standard_tasks/client/app/components/author-form.js
@@ -24,17 +24,6 @@ export default Component.extend({
   canRemoveOrcid: null,
   canChangeCoauthorStatus: null,
 
-  humanizedCoAuthorState: Ember.computed('author.coAuthorState', function(){
-    switch(this.get('author.coAuthorState')) {
-      case "confirmed":
-        return "Confirmed by";
-      case "refuted":
-        return "Refuted By";
-      default:
-        return "Last changed by";
-    }
-  }),
-
   authorshipConfirmed: Ember.computed.alias('author.confirmedAsCoAuthor'),
   authorshipDeclined: Ember.computed.alias('author.refutedAsCoAuthor'),
 

--- a/engines/tahi_standard_tasks/client/app/components/group-author-form.js
+++ b/engines/tahi_standard_tasks/client/app/components/group-author-form.js
@@ -25,18 +25,7 @@ export default Ember.Component.extend({
       this.initializeCoauthorshipControls();
     }
   },
-
-  humanizedCoAuthorState: Ember.computed('author.coAuthorState', function(){
-    switch(this.get('author.coAuthorState')) {
-      case "confirmed":
-        return "Confirmed by";
-      case "refuted":
-        return "Refuted By";
-      default:
-        return "Last changed by";
-    }
-  }),
-
+  
   initializeCoauthorshipControls() {
     this.get('author.paper.journal').then( (journal) => {
       this.get('can').can('administer', journal).then( (value) => {

--- a/engines/tahi_standard_tasks/client/app/templates/components/author-form-coauthor-controls.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/author-form-coauthor-controls.hbs
@@ -1,42 +1,44 @@
-<div data-test-selector="coauthor-radio-controls" class="flex-group coauthor-radio-controls">
-  <label class="confirm-coauthor-label flex-element">
-    {{radio-button
-    value="confirmed"
-    data-test-selector="confirm-authorship"
-    selection=author.coAuthorState
-    disabled=isNotEditable
-    name="coauthor-confirmation"
-    action=(action "setConfirmation")}}
-    Accept Authorship
-  </label>
+{{#if controlsVisible}}
+  <div data-test-selector="coauthor-radio-controls" class="flex-group coauthor-radio-controls">
+    <label class="confirm-coauthor-label flex-element">
+      {{radio-button
+      value="confirmed"
+      data-test-selector="confirm-authorship"
+      selection=author.coAuthorState
+      disabled=disabled
+      name="coauthor-confirmation"
+      action=(action "setConfirmation")}}
+      Accept Authorship
+    </label>
 
-  <label class="decline-coauthor-label flex-element">
-    {{radio-button
-    value="refuted"
-    data-test-selector="refute-authorship"
-    selection=author.coAuthorState
-    disabled=isNotEditable
-    name="coauthor-confirmation"
-    action=(action "setConfirmation")}}
-    Decline Authorship
-  </label>
+    <label class="decline-coauthor-label flex-element">
+      {{radio-button
+      value="refuted"
+      data-test-selector="refute-authorship"
+      selection=author.coAuthorState
+      disabled=disabled
+      name="coauthor-confirmation"
+      action=(action "setConfirmation")}}
+      Decline Authorship
+    </label>
 
-  <label class="no-response-coauthor-label flex-element">
-    {{radio-button
-    value="unconfirmed"
-    data-test-selector="unconfirm-authorship"
-    selection=author.coAuthorState
-    disabled=isNotEditable
-    name="coauthor-confirmation"
-    action=(action "setConfirmation")}}
-    No Response
-  </label>
-  {{#if author.coAuthorStateModifiedBy}}
-    <div class="flex-element">
-      <span class="coauthor-status-modified-by"><em>{{humanizedCoAuthorState}}</em> {{author.coAuthorStateModifiedBy.fullName}} on {{format-date author.coAuthorStateModified}}</span>
-    </div>
-  {{/if}}
-</div>
+    <label class="no-response-coauthor-label flex-element">
+      {{radio-button
+      value="unconfirmed"
+      data-test-selector="unconfirm-authorship"
+      selection=author.coAuthorState
+      disabled=disabled
+      name="coauthor-confirmation"
+      action=(action "setConfirmation")}}
+      No Response
+    </label>
+    {{#if author.coAuthorStateModifiedAt}}
+      <div class="flex-element">
+        <span class="coauthor-status-modified-by"><em>{{humanizedCoAuthorState}} {{modifiedBy}} on {{format-date author.coAuthorStateModifiedAt}}</em></span>
+      </div>
+    {{/if}}
+  </div>
+{{/if}}
 
 <div class="flex-group">
   <div class="flex-element">

--- a/engines/tahi_standard_tasks/client/app/templates/components/author-form.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/author-form.hbs
@@ -1,18 +1,18 @@
 <div class="flex-form">
   <fieldset>
     <legend class="flex-element">Individual Author</legend>
-      {{#if canChangeCoauthorStatus}}
+      {{#unless authorIsPaperCreator}}
         {{author-form-coauthor-controls
           author=author
+          controlsVisible=canChangeCoauthorStatus
           disabled=isNotEditable
           setConfirmation=(action "selectAuthorConfirmation")
         }}
-      {{/if}}
+      {{/unless}}
     {{#if authorIsNotCurrentUser}}
       {{error-message message=validationErrors.orcidIdentifier
                       displayIcon=true
                       displayText=true}}
-      <br><br>
     {{/if}}
 
     <div class="flex-group">

--- a/engines/tahi_standard_tasks/client/app/templates/components/group-author-form.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/group-author-form.hbs
@@ -1,13 +1,12 @@
 <div class="flex-form">
   <fieldset>
     <legend class="flex-element">Group Author</legend>
-      {{#if canChangeCoauthorStatus}}
-        {{author-form-coauthor-controls
-          author=author
-          disabled=isNotEditable
-          setConfirmation=(action "selectAuthorConfirmation")
-        }}
-      {{/if}}
+      {{author-form-coauthor-controls
+      author=author
+      controlsVisible=canChangeCoauthorStatus
+      disabled=isNotEditable
+      setConfirmation=(action "selectAuthorConfirmation")
+      }}
     <div class="flex-group">
       <div class="flex-element inset-form-control required {{if validationErrors.name "error"}}">
         <div class="inset-form-control-text">


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9006

#### What this PR does:

This fixes various AC related issues mentioned in a comment by QA.  The scope of the changes were meant to just be for AC #3, but a testing issue made it easier to just add them in to reduce complexity.  

For the main details on the original PR such as UX/UI and interaction expected, see here: https://github.com/Tahi-project/tahi/pull/2900

#### Notes

The main thing to check for is to see if email coauthor confirmation was the method in which a coauthor's status is confirmed.  

#### Major UI changes

It should look the same as before, except I took out some useless <brs> that needed to go

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [x] The Product Team has reviewed and approved this feature
