### PR TITLE
APERTA-9006 Fix group author model coauthor date

### DIFF
--- a/client/app/models/group-author.js
+++ b/client/app/models/group-author.js
@@ -33,7 +33,7 @@ export default NestedQuestionOwner.extend(Answerable, {
   contactEmail: attr('string'),
 
   coAuthorState: attr('string'),
-  coAuthorStateModified: attr('date'),
+  coAuthorStateModifiedAt: attr('date'),
 
   confirmedAsCoAuthor: Ember.computed.equal('coAuthorState', 'confirmed'),
   refutedAsCoAuthor: Ember.computed.equal('coAuthorState', 'refuted'),


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9006

#### What this PR does:

Fixes a minor name issue that prevented the coauthor status modification date from even being used in the case of group authors.  It just a two character change.

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
