### PR TITLE
Aperta 9087 configure rails sidekiq for redis sentinel

### DIFF
--- a/lib/tahi_env.rb
+++ b/lib/tahi_env.rb
@@ -148,6 +148,9 @@ class TahiEnv
   required :PUSHER_SSL_VERIFY, :boolean
   required :PUSHER_VERBOSE_LOGGING, :boolean
 
+  # Redis
+  optional :REDIS_SENTINELS
+
   # Salesforce
   optional :SALESFORCE_ENABLED, :boolean, default: true
   required :DATABASEDOTCOM_HOST, if: :salesforce_enabled?

--- a/spec/lib/tahi_env_spec.rb
+++ b/spec/lib/tahi_env_spec.rb
@@ -148,6 +148,9 @@ describe TahiEnv do
   it_behaves_like 'optional env var', var: 'PORT'
   it_behaves_like 'optional env var', var: 'RACK_ENV'
 
+  # Redis Sentinel
+  it_behaves_like 'optional env var', var: 'REDIS_SENTINELS'
+
   # Pusher / Slanger
   it_behaves_like 'required env var', var: 'PUSHER_URL'
   it_behaves_like 'required boolean env var', var: 'PUSHER_SSL_VERIFY'


### PR DESCRIPTION
JIRA issue: https://developer.plos.org/jira/browse/APERTA-9087

#### Dependent PR: https://github.com/PLOS-Formulas/aperta-formula/pull/30
#### Dependent PR: https://github.com/PLOS/molten/pull/499
#### Dependent PR: https://github.com/Tahi-project/ihat/pull/130

#### What this PR does:
This pr attempts to configure our sidekiq to use Redis Sentinel in our non vagrant environments.

---

#### Code Review Tasks:

Author tasks:

If I modified any environment variables:
- [x] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {https://github.com/PLOS/molten/pull/499}
- [x] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
