### PR TITLE
APERTA-9794 add data migration to fix response to reviewer attachments

### DIFF
--- a/db/migrate/20170407183905_reassign_decision_attachments.rb
+++ b/db/migrate/20170407183905_reassign_decision_attachments.rb
@@ -1,0 +1,4 @@
+class ReassignDecisionAttachments < DataMigration
+  RAKE_TASK_UP =
+    'data:migrate:reassign_attachments_to_completed_decisions'.freeze
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170329140911) do
+ActiveRecord::Schema.define(version: 20170407183905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/data_transformation/reassign_decision_attachments.rb
+++ b/lib/data_transformation/reassign_decision_attachments.rb
@@ -1,0 +1,24 @@
+module DataTransformation
+  # Reassigns attachments which were erroneously assigned to draft decisions
+  # in APERTA-7093. They should be assigned to the latest _completed_ decision
+  # instead
+  class ReassignDecisionAttachments < Base
+    counter :attachments_assigned_to_draft_decisions
+    counter :migrated_attachments
+
+    def transform
+      DecisionAttachment.find_each do |decision_attachment|
+        next if decision_attachment.owner.completed?
+        increment_counter(:attachments_assigned_to_draft_decisions)
+        true_decision = decision_attachment.owner.paper.last_completed_decision
+        assert(
+          true_decision.present?,
+          "no completed decision for attachment #{decision_attachment.id}"
+        )
+        decision_attachment.update!(owner: true_decision)
+        log("Migrated attachment #{decision_attachment.id}")
+        increment_counter(:migrated_attachments)
+      end
+    end
+  end
+end

--- a/lib/tasks/data-migrations/APERTA-9794-reassign_decision-attachments.rake
+++ b/lib/tasks/data-migrations/APERTA-9794-reassign_decision-attachments.rake
@@ -1,0 +1,12 @@
+namespace :data do
+  namespace :migrate do
+    desc <<-DESC
+      Reassigns attachments which were erroneously assigned to draft decisions
+      in APERTA-7093. They should be assigned to the latest _completed_ decision
+      instead
+    DESC
+    task reassign_attachments_to_completed_decisions: :environment do
+      DataTransformation::ReassignDecisionAttachments.new.call
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9794

#### What this PR does:

The data migration in 7094 associated some attachments to the wrong decision. On papers where there was a draft decision, these attachments were associated with the draft decision. They should have actually been associated with the latest completed decision instead. The migration herein should fix that.

Note that there were no Response to Reviewers attachments in the data.yml, so there is no change needed there.


#### Major UI changes

Attachment links should now appear properly on the Response To Reviewers task

---

#### Code Review Tasks:

Author tasks:

- ~~[ ] If I changed the database schema, I enforced database constraints.~~

- ~~[ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)~~

If I modified any environment variables:
- ~~[ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}~~
- ~~[ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging~~
- ~~[ ] If I made any UI changes, I've let QA know.~~

If I need to migrate existing data:

- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- ~~[ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)~~
- [x] I verified the data-migration's results on a copy of production data
- ~~[ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing~~
- ~~[ ] If I created a data migration, I added pre- and post-migration assertions.~~

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
