### PR TITLE
APERTA-9726 Only allow boolean value type in checkboxes

### DIFF
--- a/app/models/card_content.rb
+++ b/app/models/card_content.rb
@@ -46,7 +46,7 @@ class CardContent < ActiveRecord::Base
       'display-with-value': [nil],
       'field-set': [nil],
       'short-input': ['text'],
-      'check-box': ['text', 'boolean'],
+      'check-box': ['boolean'],
       'text': [nil],
       'paragraph-input': ['text', 'html'],
       'radio': ['boolean', 'text'] }.freeze.with_indifferent_access

--- a/config/card.rnc
+++ b/config/card.rnc
@@ -29,7 +29,7 @@ radio-input = element content {
 check-box-input = element content {
                 attribute ident { text }?,
                 attribute content-type { "check-box" },
-                attribute value-type { "text" | "boolean" },
+                attribute value-type { "boolean" },
                 (element label { text }? &
                 element text { text }?),
                 content*

--- a/config/card.rng
+++ b/config/card.rng
@@ -52,10 +52,7 @@
         <value>check-box</value>
       </attribute>
       <attribute name="value-type">
-        <choice>
-          <value>text</value>
-          <value>boolean</value>
-        </choice>
+        <value>boolean</value>
       </attribute>
       <interleave>
         <optional>


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9726

#### What this PR does:

I'd accidentally made it such that checkboxes were able to have text values, which makes no sense.
This is just a validation change, and doesn't require any data migrations or whatnot.
---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [ ] I like the CHANGELOG entry
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
