### PR TITLE
APERTA-9820 Remove Tags tab from card view

### DIFF
--- a/client/app/pods/components/card-editor/tab-bar/template.hbs
+++ b/client/app/pods/components/card-editor/tab-bar/template.hbs
@@ -11,10 +11,6 @@
     Permissions
   {{/link-to}}
 
-  {{#link-to "admin.cc.card.tags" card id="card-editor-tags-link"}}
-    Tags
-  {{/link-to}}
-
   {{#link-to "admin.cc.card.history" card id="card-editor-history-link"}}
     Card history
   {{/link-to}}

--- a/client/app/router.js
+++ b/client/app/router.js
@@ -50,7 +50,6 @@ Router.map(function() {
         this.route('preview', { path: '/' });
         this.route('edit');
         this.route('permissions');
-        this.route('tags');
         this.route('history');
       });
     });


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9820

#### What this PR does:

These changes remove the tag tab from the Card Config admin view.  It was originally planned as a nice-to-have feature, but it has been pushed much farther out than originally intended.

#### Major UI changes

The "Tags" tab is gone.  Nuff' said.

---

#### Code Review Tasks:

Author tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
