### PR TITLE
APERTA-9287 Move database modifying code to before(:each)

### DIFF
--- a/spec/lib/tasks/plos_billing_rake_spec.rb
+++ b/spec/lib/tasks/plos_billing_rake_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 
 describe "plos_billing namespace rake task" do
-  before :all do
-    Rake::Task.define_task(:environment)
-    CardLoader.load("PlosBilling::BillingTask")
-  end
-
   let(:journal) { FactoryGirl.create(:journal, :with_academic_editor_role) }
   let(:paper) do
     FactoryGirl.create(
@@ -37,6 +32,7 @@ describe "plos_billing namespace rake task" do
   end
 
   before do
+    CardLoader.load("PlosBilling::BillingTask")
     paper.phases.first.tasks.push(*[billing_task,
                                     financial_disclosure_task,
                                     final_tech_check_task])


### PR DESCRIPTION

JIRA issue: https://jira.plos.org/jira/browse/APERTA-9287

#### What this PR does:

Moves database modifying code to `before(:each)`. Running in `before(:all)` means that the database cleanup is not run on that code. Also remove an apparently useless line.

Fixes the following flaky specs (order-dependent)
- `rspec ./engines/plos_billing/spec/models/billing/billing_task_spec.rb[1:1:1:1] ./spec/authorizations/requiring_certain_states_spec.rb[1:4:1:1] ./spec/features/sign_in_cas_spec.rb[1:1,1:2] ./spec/services/journal_factory_spec.rb[1:1:1,1:1:2:1,1:1:2:2,1:1:2:3,1:1:2:4,1:1:3:10:3:1,1:1:3:11:3:1,1:1:3:12:3:1,1:1:3:15:4:1] -p 30 -t ~js --seed 45381`
- `rspec ./spec/controllers/tasks_controller_spec.rb[1:7:1:1,1:7:2:1,1:7:2:2,1:7:3:1] ./spec/lib/tasks/plos_billing_rake_spec.rb[1:3:1] -p 30 -t ~js --seed 65481`
- `rspec ./spec/lib/tasks/plos_billing_rake_spec.rb[1:1:1] ./spec/models/card_content_spec.rb[1:2:1] -p 30 -t ~js --seed 26901`

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
