### PR TITLE
Put base jira link in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-JIRA issue: link-to-jira
+JIRA issue: https://jira.plos.org/jira/browse/APERTA-
 
 #### What this PR does:
 


### PR DESCRIPTION
#### What this PR does:

This just adds the base URL to the ```jira:``` link in the PR template.

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good


