### PR TITLE
append bundle exec to overcommit in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -143,7 +143,7 @@ Dir.chdir APP_ROOT do
   system 'mkdir -p tmp/pids'
 
   header 'setting up overcommit'
-  system 'overcommit --install'
+  system 'bundle exec overcommit --install'
 
   header 'downloading ember inspector'
   system 'cd tmp && rm -f addon-470970-latest.xpi && wget https://addons.mozilla.org/firefox/downloads/latest/ember-inspector/addon-470970-latest.xpi'


### PR DESCRIPTION
JIRA issue: none, sorry

#### What this PR does:

Updates the bin/setup script to run overcommit with bundle exec.  Not much else.

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

