### PR TITLE
APERTA-10080 Lock down viewing feature flags

### DIFF
--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -3,10 +3,12 @@
 # destroyed by the API; only toggled.
 #
 class FeatureFlagsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!
   respond_to :json
 
   def index
+    # must have site admin permission
+    raise AuthorizationError unless current_user.site_admin?
     render json: FeatureFlag.to_hash
   end
 

--- a/spec/controllers/feature_flags_controller_spec.rb
+++ b/spec/controllers/feature_flags_controller_spec.rb
@@ -10,11 +10,28 @@ describe FeatureFlagsController do
       get :index, format: :json
     end
 
-    it 'responds with the list of feature flags' do
-      do_request
-      expect(res_body.keys.count).to eq(2)
-      expect(res_body[feature_flag1.name]).to eq(true)
-      expect(res_body[feature_flag2.name]).to eq(true)
+    context 'when the user has no access' do
+      before do
+        stub_sign_in user
+        allow(user).to receive(:site_admin?).and_return(false)
+      end
+      it { is_expected.to responds_with(403) }
+    end
+
+    context 'when the user has access' do
+      before do
+        stub_sign_in user
+        allow(user).to receive(:site_admin?).and_return(true)
+      end
+
+      it { is_expected.to responds_with(200) }
+
+      it 'responds with the list of feature flags' do
+        do_request
+        expect(res_body.keys.count).to eq(2)
+        expect(res_body[feature_flag1.name]).to eq(true)
+        expect(res_body[feature_flag2.name]).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10080

#### What this PR does:

- Lock down the feature flag API GET as well as PUT

#### Major UI changes

None.

---

#### Code Review Tasks:

Author tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
