### PR TITLE
APERTA-10092 Rebuild card content boundary columns

### DIFF
--- a/db/migrate/20170523163648_rebuild_card_content_boundaries.rb
+++ b/db/migrate/20170523163648_rebuild_card_content_boundaries.rb
@@ -1,0 +1,3 @@
+class RebuildCardContentBoundaries < DataMigration
+  RAKE_TASK_UP = 'data:migrate:cards:rebuild_card_content_boundaries'.freeze
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20170504132418) do
+ActiveRecord::Schema.define(version: 20170523163648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/tasks/data-migrations/APERTA-10092-rebuild-card-content-boundaries.rake
+++ b/lib/tasks/data-migrations/APERTA-10092-rebuild-card-content-boundaries.rake
@@ -1,0 +1,11 @@
+namespace :data do
+  namespace :migrate do
+    desc <<-DESC
+      Rebuilds card content boundary columns that got disjointed.
+      see https://github.com/collectiveidea/awesome_nested_set#conversion-from-other-trees
+    DESC
+    task rebuild_card_content_boundaries: :environment do
+      CardContent.rebuild!(false)
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10092

#### What this PR does:

This PR handles the rebuilding of Card Content boundaries that got mismatched from an (as of 05-23-17) unknown cause.  The mismatching of boundaries resulted in Card Content getting moved from the Front Matter Reviewer Report to the Additional Information, resulting in the breaking of both cards.   

#### Notes

The primary thing to look at is the migration and its associated rake task.

#### Major UI changes

Hopefully not, but a thing to look at is to make sure the order of questions is still the same.

---

#### Code Review Tasks:

Author tasks:

- [ ] If I changed the database schema, I enforced database constraints.

- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate existing data:

- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
