### PR TITLE
APERTA-10272 Relax xml schema to allow multiple validations

### DIFF
--- a/config/card.rnc
+++ b/config/card.rnc
@@ -75,11 +75,13 @@ text-input = element content {
                  attribute default-answer-value { text }?,
                  (element placeholder { text }? &
                   element text { text }? &
-                  element validation {
-                   attribute validation-type { "string-match" },
-                   element error-message { text },
-                   element validator { text }
-                 }?)
+                  validation*)
+             }
+
+validation = element validation {
+                 attribute validation-type { "string-match" },
+                 element error-message { text },
+                 element validator { text }
              }
 
 # Contents

--- a/config/card.rng
+++ b/config/card.rng
@@ -216,20 +216,23 @@
             <text/>
           </element>
         </optional>
-        <optional>
-          <element name="validation">
-            <attribute name="validation-type">
-              <value>string-match</value>
-            </attribute>
-            <element name="error-message">
-              <text/>
-            </element>
-            <element name="validator">
-              <text/>
-            </element>
-          </element>
-        </optional>
+        <zeroOrMore>
+          <ref name="validation"/>
+        </zeroOrMore>
       </interleave>
+    </element>
+  </define>
+  <define name="validation">
+    <element name="validation">
+      <attribute name="validation-type">
+        <value>string-match</value>
+      </attribute>
+      <element name="error-message">
+        <text/>
+      </element>
+      <element name="validator">
+        <text/>
+      </element>
     </element>
   </define>
   <!-- Contents -->

--- a/spec/services/xml_card_loader_spec.rb
+++ b/spec/services/xml_card_loader_spec.rb
@@ -122,6 +122,10 @@ describe XmlCardLoader do
                 <error-message>First Validation</error-message>
                 <validator>/test-one/</validator>
               </validation>
+              <validation validation-type='string-match'>
+                <error-message>Second Validation</error-message>
+                <validator>/second-one/</validator>
+              </validation>
             </content>
           </content>
         </card>
@@ -130,10 +134,15 @@ describe XmlCardLoader do
 
     it 'creates string match card content validations' do
       xml_card_loader.load(xml)
-      expect(validations.count).to eq(1)
+      expect(validations.count).to eq(2)
+
       expect(validations.first.validation_type).to eq 'string-match'
       expect(validations.first.error_message).to eq 'First Validation'
       expect(validations.first.validator).to eq '/test-one/'
+
+      expect(validations.second.validation_type).to eq 'string-match'
+      expect(validations.second.error_message).to eq 'Second Validation'
+      expect(validations.second.validator).to eq '/second-one/'
     end
   end
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10272

#### What this PR does:

This commit will allow multiple `<validation>` nodes to be applied to a single `<content>` node.

I also pulled the validation schema out into its own local variable so that it more closely adhered to the rest of the `.rnc` style.

This is a very straightforward change.  There are no major UI changes.

---

#### Code Review Tasks:

Author tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
