### PR TITLE
APERTA-10239 Allow deletion of SimilarityCheckTask

### DIFF
--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/similarity_check_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/similarity_check_task.rb
@@ -3,8 +3,6 @@ module TahiStandardTasks
   # used by Admins and Staff Admins for running a check against the iThenticate
   # api to generate a plagiarism report.
   class SimilarityCheckTask < Task
-    has_many :ithenticate_checks, foreign_key: 'task_id', dependent: :destroy
-
     DEFAULT_TITLE = 'Similarity Check'.freeze
     DEFAULT_ROLE_HINT = 'admin'.freeze
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10239

#### What this PR does:

Prior to this PR, if a `TahiStandardTasks::SimilarityCheckTask` was throwing an error when attempting to be destroyed.  This is because there was a dependent: destroy `has_many` relationship to a model (`IthenticateCheck`) that did not exist.

This association is not used, nor needed, so this PR removes it.

#### Code Review Tasks:

Author tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
