### PR TITLE
APERTA-9709 Use lightweight answer serialized responses

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -16,7 +16,7 @@ class AnswersController < ApplicationController
   def update
     answer = Answer.find(params[:id])
     answer.update!(answer_params)
-    render json: answer
+    render json: answer, serializer: LightAnswerSerializer, root: 'answer'
   end
 
   def destroy

--- a/app/serializers/light_answer_serializer.rb
+++ b/app/serializers/light_answer_serializer.rb
@@ -1,0 +1,8 @@
+# Light weight serializer used to do partial update of answers
+# This was created initially to support validations, but it
+# can be used for anything that requires more discrete
+# changes to answer
+class LightAnswerSerializer < ActiveModel::Serializer
+  include ReadySerializable
+  attributes :id
+end

--- a/spec/controllers/answers_controller_spec.rb
+++ b/spec/controllers/answers_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe AnswersController do
+  let(:user) { FactoryGirl.create :user }
+  let(:card_content) { FactoryGirl.create(:card_content) }
+  let(:owner) { FactoryGirl.create(:ad_hoc_task) }
+
+  describe '#update' do
+    let!(:answer) { FactoryGirl.create(:answer, value: 'initial', card_content: card_content, owner: owner) }
+    let(:card_content) { FactoryGirl.create(:card_content) }
+
+    subject(:do_request) do
+      put_params = {
+        format: 'json',
+        id: answer.to_param,
+        card_content_id: card_content.to_param,
+        answer: {
+          value: 'after',
+          owner_id: owner.id,
+          owner_type: owner.type
+        }
+      }
+      put(:update, put_params)
+    end
+
+    it_behaves_like 'an unauthenticated json request'
+
+    context 'when the user does has access' do
+      before do
+        stub_sign_in user
+        allow(user).to receive(:can?)
+                         .with(:edit, owner)
+                         .and_return true
+      end
+
+      it 'updates the answer for the question' do
+        expect do
+          do_request
+        end.to_not change(Answer, :count)
+
+        json = JSON.parse(response.body)
+        expect(json['answer']['value']).to_not be_present
+
+        answer.reload
+        expect(answer.value).to eq('after')
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9709

#### What this PR does:

Fixes jankiness issue that would be theoretically visible in most validation cases in the user was speedy enough.  Instead of doing a 204, we'll just have it do a partial update of the answer model (ember side) that we care about and trust that the client's input value is in parity with the server.

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
