### PR TITLE
APERTA-10148-updated-plos-billing-job-to-send-emails-at-5AM

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,5 +9,5 @@
   plos_billing_log_export:
     # This cron syntax has seconds resolution
     # https://github.com/moove-it/sidekiq-scheduler#schedule-types
-    cron: '0 1 5 * * * America/Los_Angeles'
+    cron: '0 0 5 * * * America/Los_Angeles'
     class: PlosBillingLogExportWorker


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10148

#### What this PR does:

Currently the billing file that comes from aperta lands on sfo-reporting01.int.plos.org at 7am. The config sidekiq worker responsible for this time was adjusted to sent at 5:00am

#### Notes
I believe the cron job adjustment would surely work for 5AM but I am not sure how I am suppose to test it locally so any guide from reviewer will be helpful 

#### Major UI changes

None

---

#### Code Review Tasks:

Author tasks:

- [ ] If I changed the database schema, I enforced database constraints.

- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate existing data:

- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
