### PR TITLE
APERTA-9930 use tinymce on manuscript-new page

### DIFF
--- a/client/app/pods/components/manuscript-new/template.hbs
+++ b/client/app/pods/components/manuscript-new/template.hbs
@@ -5,10 +5,15 @@
     Give your paper a title
   </label>
 
-  {{format-input value=paper.title
-                 id="new-paper-title"
-                 placeholder="Crystalized Magnificence in the Modern World"
-                 displayBold=false}}
+  {{rich-text-editor
+    editorStyle='basic'
+    value=paper.title
+    ident='new-paper-title'
+    class='new-paper-title'
+    onContentsChanged=(action (mut paper.title))
+    placeholder="Crystalized Magnificence in the Modern World"
+    disabled=false
+  }}
 
   {{#if hasTitle}}
     <span class="paper-new-valid-icon animation-fade-in">{{fa-icon icon="check"}}</span>

--- a/client/app/pods/components/overlay-fullscreen/component.js
+++ b/client/app/pods/components/overlay-fullscreen/component.js
@@ -58,6 +58,15 @@ export default Ember.Component.extend({
   **/
   to: 'overlay-drop-zone',
 
+
+  /**
+   * Tells the overlay whether or not to use ember-wormhole
+   *  @property wormhole
+   *  @type Boolean
+   *  @default true
+   **/
+  wormhole: true,
+
   /**
    *  Text that will be displayed as the overlay title.
    *  This property is passed to `overlay-fullscreen-layout`.

--- a/client/app/pods/components/overlay-fullscreen/template.hbs
+++ b/client/app/pods/components/overlay-fullscreen/template.hbs
@@ -1,5 +1,17 @@
 {{#if visible}}
-  {{#ember-wormhole to=to}}
+  {{#if wormhole}}
+    {{#ember-wormhole to=to}}
+      {{#overlay-animate outAnimationComplete=(action outAnimationComplete)
+                        inAnimationComplete=(action inAnimationComplete)
+                        as |animateOut|}}
+        {{#overlay-fullscreen-layout class=overlayClass
+                                    title=title
+                                    close=(action animateOut)}}
+          {{yield (hash animateOut=animateOut)}}
+        {{/overlay-fullscreen-layout}}
+      {{/overlay-animate}}
+    {{/ember-wormhole}}
+  {{else}}
     {{#overlay-animate outAnimationComplete=(action outAnimationComplete)
                        inAnimationComplete=(action inAnimationComplete)
                        as |animateOut|}}
@@ -9,5 +21,5 @@
         {{yield (hash animateOut=animateOut)}}
       {{/overlay-fullscreen-layout}}
     {{/overlay-animate}}
-  {{/ember-wormhole}}
+  {{/if}}
 {{/if}}

--- a/client/app/pods/dashboard/index/template.hbs
+++ b/client/app/pods/dashboard/index/template.hbs
@@ -1,4 +1,5 @@
 {{#overlay-fullscreen visible=showNewManuscriptOverlay
+                      wormhole=false
                       outAnimationComplete=(action "hideNewManuscriptOverlay")
                       title="Create a New Submission"
                       as |overlay|}}


### PR DESCRIPTION
@jhaungs feel free to merge this PR into your branch if it looks alright to you.  I figure it's easier to follow than throwing a commit directly onto the integration branch.

- Adds a 'wormhole' option on `overlay-fullscreen` which defaults to 'true'.
We have to disable ember-wormhole for this use of tinymce.  Our tinymce wrapper
component will run `tinymce.init` in its `didInsertElement` hook, which runs
before `ember-wormhole`'s
[_appendToDestination](https://github.com/yapplabs/ember-wormhole/blob/master/addon/components/ember-wormhole.js#L63)
. Ember wormhole will insert content and then move that content to a new place
in the DOM.  At that point something goes awry with tinymce.

Other instances of tinymce inside ember-wormhole are also wrapped in a
`task-load` component, which defers rendering its content until a particular
task's resources have been fetched from the server.  So far that's always taken
longer than it takes for the wormhole append, so we've never had to deal with
this phenomenon before.

In the case of manuscript-new, rendering it inline (without using the wormhole)
doesn't appear to be a problem from a UI point of view - the styles apply
correctly and it behaves as expected for one of our full screen overlays.

We may want to evaluate using https://github.com/ef4/ember-elsewhere as a replacement
for ember-wormhole for cases like these
