### PR TITLE
Add .doc extension

### DIFF
--- a/engines/tahi_standard_tasks/client/app/templates/components/cover-letter-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/cover-letter-task.hbs
@@ -38,7 +38,7 @@
       buttonText="attach file"
       ident="cover_letter--attachment"
       owner=task
-      accept=".docx,.pdf"
+      accept=".doc,.docx,.pdf"
       disabled=isNotEditable}}
   </div>
 </div>


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9881

#### What this PR does:

Allow cover letter uploader to accept `.doc` files. 

Can your changes be *seen* by a user? Then add a screenshot. Is it an
interaction?  Perhaps a quick recording?
<img width="461" alt="screen shot 2017-06-13 at 10 22 30 pm" src="https://user-images.githubusercontent.com/20759355/27105675-579818e0-5088-11e7-9e87-5b4b16698ac9.png">

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
