### PR TITLE
reverse greps against invalid error line in circle yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -48,7 +48,7 @@ database:
 ## Customize test commands
 test:
   override:
-    - "set -o pipefail; cd client && ./node_modules/.bin/ember test --silent -r xunit | grep -v ^Warning > $CIRCLE_TEST_REPORTS/qunit.xml"
+    - "set -o pipefail; cd client && ./node_modules/.bin/ember test --silent -r xunit | grep -v ^Warning | grep -v '^{ \\[Error' > $CIRCLE_TEST_REPORTS/qunit.xml"
     - bundle exec rspec -p 30 -t ~js --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec-unit.xml:
         timeout: 1800
         parallel: true


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10481

#### What this PR does:

prevents invalid error line from being injected into xml on circle ci by reverse grepping for the message

invalid xml
```
{ [Error: socket hang up] code: 'ECONNRESET' }
<testsuite name="Testem Tests">
```

target xml with error grepped out of input
```
<testsuite name="Testem Tests">

```