### PR TITLE
APERTA 10422 partials render boolean and text radio buttons

### DIFF
--- a/client/app/pods/components/card-content/radio/component.js
+++ b/client/app/pods/components/card-content/radio/component.js
@@ -15,12 +15,28 @@ export default Ember.Component.extend({
   init() {
     this._super(...arguments);
 
-    Ember.assert(
-      `the content must define an array of possibleValues
+    if(this.get('content.valueType') === 'text') {
+      Ember.assert(
+        `the content must define an array of possibleValues
       that contains at least one object with the shape { label, value } `,
-      Ember.isPresent(this.get('content.possibleValues'))
-    );
+        Ember.isPresent(this.get('content.possibleValues'))
+      );
+    }
   },
+
+  radioTemplate: Ember.computed('content.valueType', function() {
+    if(this.get('content.valueType') === 'text') {
+      return 'components/card-content/radio/radio-text';
+    }
+    else {
+      return 'components/card-content/radio/radio-boolean';
+    }
+  }),
+
+  yesValue: 't',
+  noValue: 'f',
+  yesLabel: 'Yes',
+  noLabel: 'No',
 
   actions: {
     valueChanged(newVal) {

--- a/client/app/pods/components/card-content/radio/radio-boolean/template.hbs
+++ b/client/app/pods/components/card-content/radio/radio-boolean/template.hbs
@@ -1,0 +1,16 @@
+<label class="option">
+  {{radio-button
+    selection=answer.value
+    value=yesValue
+    disabled=disabled
+    action=(action "valueChanged")}}
+  <span class="card-content-radio-label">{{{yesLabel}}}</span>
+</label>
+<label class="option">
+  {{radio-button
+    selection=answer.value
+    value=noValue
+    disabled=disabled
+    action=(action "valueChanged")}}
+  <span class="card-content-radio-label">{{{noLabel}}}</span>
+</label>

--- a/client/app/pods/components/card-content/radio/radio-text/template.hbs
+++ b/client/app/pods/components/card-content/radio/radio-text/template.hbs
@@ -1,0 +1,10 @@
+{{#each content.possibleValues as |opt|}}
+  <label class="option">
+    {{radio-button
+      selection=answer.value
+      value=opt.value
+      disabled=disabled
+      action=(action "valueChanged")}}
+    <span class="card-content-radio-label">{{{opt.label}}}</span>
+  </label>
+{{/each}}

--- a/client/app/pods/components/card-content/radio/template.hbs
+++ b/client/app/pods/components/card-content/radio/template.hbs
@@ -1,15 +1,6 @@
 <label class="content-text">{{{content.text}}}</label>
 <div>
-  {{#each content.possibleValues as |opt|}}
-    <label class="option">
-      {{radio-button
-        selection=answer.value
-        value=opt.value
-        disabled=disabled
-        action=(action "valueChanged")}}
-      <span class="card-content-radio-label">{{{opt.label}}}</span>
-    </label>
-  {{/each}}
+    {{partial radioTemplate}}
 </div>
 
 {{card-content/display-children

--- a/client/tests/components/card-content/radio/component-test.js
+++ b/client/tests/components/card-content/radio/component-test.js
@@ -10,6 +10,7 @@ moduleForComponent(
       this.set('actionStub', function() {});
       this.defaultContent = {
         text: `<b class='foo'>Foo</b>`,
+        valueType: 'text',
         possibleValues: [{ label: 'Choice 1', value: 1 }, { label: '<b>Choice</b> 2', value: 2}]
       };
     }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170606190255) do
+ActiveRecord::Schema.define(version: 20170615145227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -725,12 +725,10 @@ ActiveRecord::Schema.define(version: 20170606190255) do
     t.string   "document_s3_url"
     t.integer  "ithenticate_report_id"
     t.integer  "ithenticate_score"
-    t.integer  "versioned_text_id",                               null: false
-    t.string   "state",                                           null: false
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.string   "error_message"
-    t.boolean  "dismissed",                       default: false
+    t.integer  "versioned_text_id",               null: false
+    t.string   "state",                           null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   create_table "simple_reports", force: :cascade do |t|


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10422

#### What this PR does:

We have a current pattern of boolean radio buttons in our application. We should support this natively in the card config system. 

This feature branch:

    1) processes content-type="radio" and value-type="boolean" combination and content-type="radio" and value-type="text" combination in the XML/card config data structures
    2) natively renders a "Yes" / "No" radio button in the front-end for value-type="boolean"
    3) boolean value-type is stored using the existing t/f pattern as strings in the answers table of the database
    4) Possible-value entries default to "yes" and "no" for boolean value-type
    5) text value-type renders a custom radio selection from an array of possible value objects of the shape {label, value}

#### Notes

Review the following PR: https://github.com/Tahi-project/tahi/pull/3128. Manually run rake db:reset, db:migrate and rake cards:load.


#### Major UI changes

There were no major UI changes.
---

#### Code Review Tasks:

Author tasks:

- [ ] If I changed the database schema, I enforced database constraints.

- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate existing data:

- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
