### PR TITLE
Add allowed attributes to <a> tag in tinymce config

### DIFF
--- a/client/app/pods/components/rich-text-editor/component.js
+++ b/client/app/pods/components/rich-text-editor/component.js
@@ -4,7 +4,7 @@ const basicElements    = 'p,br,strong/b,em/i,u,sub,sup,pre';
 const basicPlugins     = '';
 const basicToolbar     = 'bold italic underline | subscript superscript | undo redo';
 
-const anchorElement      = ',a[href|rel|target|title]';
+const anchorElement    = ',a[href|rel|target|title]';
 const expandedElements = ',div,span,code,ol,ul,li,h1,h2,h3,h4,table,thead,tbody,tfoot,tr,th,td';
 const expandedPlugins  = ' code codesample link table';
 const expandedToolbar  = ' | bullist numlist | table link | codesample code | formatselect';


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-

#### What this PR does:

Add href, rel, target, title attributes to <a> in tinymce configuration. 

#### Notes

It turns out that, when you whitelist _any_ tags in tinymce, you also have to whitelist any attributes that might be allowed on those tags. 

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
