### PR TITLE
APERTA-10478 reset invitationsLoading flag in success callback

### DIFF
--- a/client/app/pods/dashboard/index/controller.js
+++ b/client/app/pods/dashboard/index/controller.js
@@ -93,7 +93,7 @@ export default Ember.Controller.extend({
           let msg = `Thank you for agreeing to review for ${invitation.get('journalName')}.`;
           this.flash.displayRouteLevelMessage('success', msg);
         });
-      }, () => { this.set('invitationsLoading', false); });
+      }).finally(() => { this.set('invitationsLoading', false); });
     },
 
     showNewManuscriptOverlay() {


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10478

#### What this PR does:

Fixes spinner of death in invitations (i think). gonna test a bit first but @noxmwalsh has already poked at this and I'm just trowing more ember magicks at it. 

To reproduce: go to the dashboard with a user with more than one invite, accept one, you'll be redirected to the affiliated paper, click on Your Manuscripts in the nav bar to go back to the dashboard and then view invitations again. 

#### Notes

OMG ember controllers are singletons that keep their state even after transitions. thats not very react.js-y at all. #growingpains



---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [ ] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature