### PR TITLE
APERTA-10560 stop setting PUSHER_URL ourselves in heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -212,6 +212,7 @@
     "scheduler:standard",
     "sendgrid:starter",
     "papertrail:choklad",
+    "pusher:sandbox",
     "heroku-postgresql:hobby-dev",
     "rediscloud:30"
   ],


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10560

#### What this PR does:

Makes our review apps use the pusher heroku addon instead of our weird ec2 slanger install. In particular, this PR stops the propagation of the PUSHER_URL env var in heroku. The addon insists on setting this value.

---

#### Code Review Tasks:
Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
