### PR TITLE
(against release/1.45) APERTA-10593 Wrap academic editor invite body in <p> tags

### DIFF
--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/paper_editor_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/paper_editor_task.rb
@@ -65,39 +65,34 @@ module TahiStandardTasks
     # rubocop:disable Metrics/MethodLength
     def invitation_body
       template = <<-TEXT.strip_heredoc
-        I am writing to seek your advice as the academic editor on a manuscript entitled '%{manuscript_title}'. The corresponding author is %{author_name}, and the manuscript is under consideration at %{journal_name}.
+        <p>I am writing to seek your advice as the academic editor on a manuscript entitled '%{manuscript_title}'. The corresponding author is %{author_name}, and the manuscript is under consideration at %{journal_name}.</p>
 
-        We would be very grateful if you could let us know whether or not you are able to take on this assignment within 24 hours, so that we know whether to await your comments, or if we need to approach someone else. To accept or decline the assignment via our submission system, please use the link below. If you are available to help and have no conflicts of interest, you also can view the entire manuscript via this link.
+        <p>
+We would be very grateful if you could let us know whether or not you are able to take on this assignment within 24 hours, so that we know whether to await your comments, or if we need to approach someone else. To accept or decline the assignment via our submission system, please use the link below. If you are available to help and have no conflicts of interest, you also can view the entire manuscript via this link.</p>
+        <p><a href="%{dashboard_url}">View Invitation</a></p>
 
-        <a href="%{dashboard_url}">View Invitation</a>
-
-        If you do take this assignment, and think that this work is not suitable for further consideration by %{journal_name}, please tell us if it would be more appropriate for one of the other PLOS journals, and in particular, PLOS ONE (<a href="http://plos.io/1hPjumI">http://plos.io/1hPjumI</a>). If you suggest PLOS ONE, please let us know if you would be willing to act as Academic Editor there. For more details on what this role would entail, please go to <a href="http://journals.plos.org/plosone/s/journal-information ">http://journals.plos.org/plosone/s/journal-information</a>.
-
-        I have appended further information, including a copy of the abstract and full list of authors below.
-
-        My colleagues and I are grateful for your support and advice. Please don't hesitate to contact me should you have any questions.
-
-        Kind regards,
-        [YOUR NAME]
-        %{journal_name}
-
-        ***************** CONFIDENTIAL *****************
-
-        %{paper_type}
-
-        Manuscript Title:
-        %{manuscript_title}
-
-        Authors:
-        %{authors}
-
-        Abstract:
-        %{abstract}
-
-        To view this manuscript, please use the link presented above in the body of the e-mail.
-
-        You will be directed to your dashboard in Aperta, where you will see your invitation. Selecting "yes" confirms your assignment as Academic Editor. Selecting "yes" to accept this assignment will allow you to access the full submission from the Dashboard link in your main menu.
-
+        <p>If you do take this assignment, and think that this work is not suitable for further consideration by %{journal_name}, please tell us if it would be more appropriate for one of the other PLOS journals, and in particular, PLOS ONE (<a href="http://plos.io/1hPjumI">http://plos.io/1hPjumI</a>). If you suggest PLOS ONE, please let us know if you would be willing to act as Academic Editor there. For more details on what this role would entail, please go to <a href="http://journals.plos.org/plosone/s/journal-information ">http://journals.plos.org/plosone/s/journal-information</a>.</p>
+        <p>I have appended further information, including a copy of the abstract and full list of authors below.</p>
+        <p>My colleagues and I are grateful for your support and advice. Please don't hesitate to contact me should you have any questions.</p>
+        <p>Kind regards,</p>
+        <p>[YOUR NAME]</p>
+        <p>%{journal_name}</p>
+        <p>***************** CONFIDENTIAL *****************</p>
+        <p>%{paper_type}</p>
+        <p>
+          Manuscript Title:<br>
+          %{manuscript_title}
+        </p>
+        <p>
+          Authors:<br>
+          %{authors}
+        </p>
+        <p>
+          Abstract:<br>
+          %{abstract}
+        </p>
+        <p>To view this manuscript, please use the link presented above in the body of the e-mail.</p>
+        <p>You will be directed to your dashboard in Aperta, where you will see your invitation. Selecting "yes" confirms your assignment as Academic Editor. Selecting "yes" to accept this assignment will allow you to access the full submission from the Dashboard link in your main menu.</p>
       TEXT
       template % template_data
     end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10593

Both the reviewer and academic editor invitation templates are
hard coded in their respective invitation models. This issue affected
both templates, but the reviewer template was being converted over to
liquid and the work to change it was done there coincidentally.  This
template hasn't been converted to liquid yet and it was also missed in
the initial triage.

**Before**
![screen shot 2017-07-03 at 11 56 34 am](https://user-images.githubusercontent.com/2043348/27801430-fa77a676-5feb-11e7-9e36-c373810d6f2c.png)

**After**
![screen shot 2017-07-03 at 11 56 49 am](https://user-images.githubusercontent.com/2043348/27801401-d0861eb0-5feb-11e7-857a-9f0b8850d177.png)


Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [x] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
