### PR TITLE
Revert "Features/aperta 9909 remove iframe title from tinymce"

### DIFF
--- a/client/app/pods/components/rich-text-editor/component.js
+++ b/client/app/pods/components/rich-text-editor/component.js
@@ -48,21 +48,9 @@ export default Ember.Component.extend({
 
 /* eslint-enable camelcase */
 
-  stripTitles() {
-    let editors = window.tinymce.editors;
-    for (let id of Object.keys(editors)) {
-      let editor = editors[id];
-      if (editor) {
-        let ifr = window.tinymce.DOM.get(id + '_ifr');
-        editor.dom.setAttrib(ifr, 'title', '');
-      }
-    }
-  },
-
   configureCommon(hash) {
     hash['menubar'] = false;
     hash['content_style'] = this.get('bodyCSS');
-    Ember.run.schedule('afterRender', this.stripTitles);
     return hash;
   },
 

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
-    "ember-cli-tinymce": "0.1.6",
+    "ember-cli-tinymce": "^0.1.6",
     "ember-click-outside": "^0.1.6",
     "ember-composable-helpers": "^1.1.2",
     "ember-concurrency": "^0.8.5",


### PR DESCRIPTION
Reverts Tahi-project/tahi#3151

I'm reverting this since it was merged into `master` accidentally instead of `release/1.45`

The PR that implements this on the correct branch is here:
https://github.com/Tahi-project/tahi/pull/3188