### PR TITLE
APERTA-10604 Fixes bug in changes for Author Card combines line items and displays html tags

### DIFF
--- a/engines/plos_bio_tech_check/client/app/components/tech-check-base.js
+++ b/engines/plos_bio_tech_check/client/app/components/tech-check-base.js
@@ -68,7 +68,7 @@ export default TaskComponent.extend({
         return !q.answerForOwner(owner).get('value') && q.get('additionalData');
       }).map(function(question) {
         return question.get('additionalData');
-      }).join('\n\n');
+      }).join('<br><br>');
 
       this.set('authorChangesLetter', text);
     }

--- a/engines/plos_bio_tech_check/client/app/templates/components/changes-for-author-task.hbs
+++ b/engines/plos_bio_tech_check/client/app/templates/components/changes-for-author-task.hbs
@@ -2,7 +2,7 @@
 
 <div class="task-main-content">
   <h3>Please address the following changes so we can process your manuscript:</h3>
-  <p class="preserve-line-breaks">{{task.body.initialTechCheckBody}}</p>
+  <p class="preserve-line-breaks">{{{task.body.initialTechCheckBody}}}</p>
 
   {{flash-messages classNames="submit-tech-changes-flash"}}
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10604

#### What this PR does:

The Changes for Author card for papers in a checking state combine all the tech check items into a single paragraph and displays html tags.

This PR fixes the bug in Changes for Author card where papers in a checking state combine all the tech check items into a single paragraph and displays html tags. 

The html tags are no longer displayed in the Changes for Author Card
The line breaks are preserved in the Changes for Author Card

#### Notes

No surprises. No rake task.

#### Major UI changes

Here are screen shots of the fixed Changes for Author card

![change for author 1](https://user-images.githubusercontent.com/5396105/27875094-e29992ae-6166-11e7-8b22-2f27bd9b763c.jpg)
![changes for author 2](https://user-images.githubusercontent.com/5396105/27875105-eccbb2ac-6166-11e7-9586-b2b6bd64d837.jpg)

---

#### Code Review Tasks:

Author tasks:

- [ ] If I changed the database schema, I enforced database constraints.

- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate existing data:

- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [x] The Product Team has reviewed and approved this feature
