### PR TITLE
Fix Title and Abstract card editable state

### DIFF
--- a/engines/tahi_standard_tasks/client/app/components/title-and-abstract-task.js
+++ b/engines/tahi_standard_tasks/client/app/components/title-and-abstract-task.js
@@ -2,7 +2,6 @@ import TaskComponent from 'tahi/pods/components/task-base/component';
 import Ember from 'ember';
 
 export default TaskComponent.extend({
-  paperNotEditable: Ember.computed.not('task.paper.editable'),
   isNotEditable: Ember.computed.alias('task.completed'),
 
   actions: {

--- a/engines/tahi_standard_tasks/client/test-support/integration/components/tasks/title-and-abstract-task-test.js
+++ b/engines/tahi_standard_tasks/client/test-support/integration/components/tasks/title-and-abstract-task-test.js
@@ -20,26 +20,8 @@ test('User can edit the title and abstract', function(assert) {
   assert.ok(abstract);
 });
 
-test('Title/abstract not editable when paper is not', function(assert) {
-  var task = newTask(false, false);
-  setupEditableTask(this, task);
-  let title = findEditor('article-title-input');
-  let abstract = findEditor('article-abstract-input');
-  assert.ok(!title);
-  assert.ok(!abstract);
-});
-
 test('Title/abstract not editable when task is complete', function(assert) {
   var task = newTask(true, true);
-  setupEditableTask(this, task);
-  let title = findEditor('article-title-input');
-  let abstract = findEditor('article-abstract-input');
-  assert.ok(!title);
-  assert.ok(!abstract);
-});
-
-test('Title/abstract not editable when task is complete and paper not editable', function(assert) {
-  var task = newTask(true, false);
   setupEditableTask(this, task);
   let title = findEditor('article-title-input');
   let abstract = findEditor('article-abstract-input');
@@ -78,4 +60,3 @@ var setupEditableTask = function(context, task) {
 
   context.render(template);
 };
-


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10615

#### What this PR does:

Fixes the code so that editing fields for Title and Abstract on the `Title and Abstract` card are displayed if the paper has not been submitted or the task is not completed

Can your changes be *seen* by a user? Then add a screenshot. Is it an
interaction?  Perhaps a quick recording?
<img width="1280" alt="screen shot 2017-07-05 at 7 13 44 pm" src="https://user-images.githubusercontent.com/20759355/27878695-0006553e-61b7-11e7-9535-c81a4d3adf37.png">

#### Code Review Tasks:

Reviewer tasks:

- [x] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [x] I ran the code (in the review environment or locally)
- [x] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [x] I agree the code fulfills the Acceptance Criteria
- [x] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature
