### PR TITLE
Hack to make empty p tags show as new lines

### DIFF
--- a/app/assets/stylesheets/_dumping-ground.scss
+++ b/app/assets/stylesheets/_dumping-ground.scss
@@ -58,7 +58,11 @@
 }
 
 .preserve-line-breaks {
-  white-space: pre-line;
+  p:after {
+    content:"";
+    display:inline-block;
+    width:0px;
+  }
 }
 
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10635

@ramzizaz @slimeate 
#### What this PR does:
The input fields record new lines as empty p tags, which get swallowed by browsers.
<img width="1205" alt="ptaghack" src="https://user-images.githubusercontent.com/5441006/27937810-c19f3a64-626e-11e7-903c-0aacd4644b5f.png"> (red dots to highlight). we shouldnt need the whitespace thingy anymore either after html normalization.

some background lit:
https://stackoverflow.com/questions/14848326/empty-paragraph-tags-should-i-allow-in-html-editor-or-not
https://stackoverflow.com/questions/12378288/html-empty-p-p-tag-show-no-line-break

```console
________
|       |
| I really love
| CSS   |
|_______|
```




---

#### Code Review Tasks:

Author tasks:

- [ ] If I made any UI changes, I've let QA know.

Reviewer tasks:

- [ ] I skimmed the code; it makes sense
- [x] I read the code; it looks good
- [ ] I ran the code (in the review environment or locally)
- [ ] I performed a 5 minute walkthrough of the site looking for oddities
- [ ] I have found the tests to be sufficient
- [ ] I agree the code fulfills the Acceptance Criteria
- [ ] I agree the author has fulfilled their tasks

#### After the Code Review:

Author tasks:

- [ ] The Product Team has reviewed and approved this feature