### PR TITLE
APERTA-10711 hook debounced save to onChange event

### DIFF
--- a/client/app/models/task.js
+++ b/client/app/models/task.js
@@ -4,6 +4,7 @@ import CardThumbnailObserver from 'tahi/mixins/models/card-thumbnail-observer';
 import Answerable from 'tahi/mixins/answerable';
 import NestedQuestionOwner from 'tahi/models/nested-question-owner';
 import Snapshottable from 'tahi/mixins/snapshottable';
+import { timeout, task as concurrencyTask } from 'ember-concurrency';
 
 export default NestedQuestionOwner.extend(Answerable, CardThumbnailObserver, Snapshottable, {
   attachments: DS.hasMany('adhoc-attachment', {
@@ -53,6 +54,7 @@ export default NestedQuestionOwner.extend(Answerable, CardThumbnailObserver, Sna
   title: DS.attr('string'),
   type: DS.attr('string'),
   assignedToMe: DS.attr(),
+  debouncePeriod: 200, // ms
 
   componentName: Ember.computed('type', function() {
     return Ember.String.dasherize(this.get('type'));
@@ -83,5 +85,10 @@ export default NestedQuestionOwner.extend(Answerable, CardThumbnailObserver, Sna
       // non-custom card (legacy) tasks will display on sidebar conditionally
       return this.get('assignedToMe') || this.get('isSubmissionTask');
     }
-  })
+  }),
+
+  debouncedSave: concurrencyTask(function * () {
+    yield timeout(this.get('debouncePeriod'));
+    return yield this.save();
+  }).restartable()
 });

--- a/engines/tahi_standard_tasks/client/app/components/title-and-abstract-task.js
+++ b/engines/tahi_standard_tasks/client/app/components/title-and-abstract-task.js
@@ -7,14 +7,12 @@ export default TaskComponent.extend({
   actions: {
     titleChanged(contents) {
       this.set('task.paperTitle', contents);
+      this.get('task.debouncedSave').perform();
     },
 
     abstractChanged(contents) {
       this.set('task.paperAbstract', contents);
-    },
-
-    focusOut() {
-      return this.get('task').save();
+      this.get('task.debouncedSave').perform();
     }
   }
 });


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10711

#### What this PR does:

The title and abstract card would only persist data do the backend on blur, which was no longer tied into the rich text component after the mce. Now its tied into onCHange. Thoughts?

#### Notes

Are there any surprises? Anything that was particularly difficult, or clever, or
made you nervous, and should get particular attention during review? Call it
out. 


#### Major UI changes

Were there major UI changes? Add a screenshot here -- and please let the QA team know that changes are imminent. They would love a little extra time to prepare the QA test suite.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I might need to write some tests?

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient

