### PR TITLE
Fix parens in card.rnc

### DIFF
--- a/config/card.rnc
+++ b/config/card.rnc
@@ -57,7 +57,7 @@ date-picker = element content {
                   attribute ident { text }?,
                   attribute value-type { "text" },
                   attribute content-type { "date-picker" },
-                  element text { text })
+                  element text { text }
               }
 
 # for now duplicating radio-input for dropdown
@@ -66,7 +66,7 @@ dropdown-input = element content {
                   attribute value-type { "text" | "boolean" },
                   attribute content-type { "dropdown" },
                   attribute default-answer-value { text }?,
-                  element text { text }),
+                  element text { text },
                   possible-value+,
                   content*
               }
@@ -85,11 +85,11 @@ text-input = element content {
                  attribute value-type { "text" },
                  attribute content-type { "short-input" | "paragraph-input" },
                  attribute default-answer-value { text }?,
-                 element text { text }? &
-                 element validation {
-                  attribute validation-type { "string-match" | "string-length-minimum" | "string-length-maximum" },
-                  element error-message { text },
-                  element validator { text }
+                 (element text { text }? &
+                  element validation {
+                   attribute validation-type { "string-match" | "string-length-minimum" | "string-length-maximum" },
+                   element error-message { text },
+                   element validator { text }
                 }*)
              }
 


### PR DESCRIPTION
I introduced three syntax errors into card.rnc when I removed placeholders, by not removing two parens, and removing one I should not have. This PR fixes them. 

We ran this version through trang, and the output is the same as the production XML (which was also hand-edited, but correctly).