### PR TITLE
APERTA-10733 Use handling editor instead of academic editor

### DIFF
--- a/app/models/paper_context.rb
+++ b/app/models/paper_context.rb
@@ -8,6 +8,10 @@ class PaperContext < TemplateContext
     @object.academic_editors.map { |ae| UserContext.new(ae) }
   end
 
+  def handling_editors
+    @object.handling_editors.map { |he| UserContext.new(he) }
+  end
+
   def authors
     @object.authors.map { |a| AuthorContext.new(a) }
   end
@@ -17,8 +21,8 @@ class PaperContext < TemplateContext
   end
 
   def editor
-    return if @object.academic_editors.empty?
-    UserContext.new(@object.academic_editors.first)
+    return if @object.handling_editors.empty?
+    UserContext.new(@object.handling_editors.first)
   end
 
   def url

--- a/spec/models/paper_context_spec.rb
+++ b/spec/models/paper_context_spec.rb
@@ -15,6 +15,7 @@ describe PaperContext do
   end
 
   let(:academic_editor) { FactoryGirl.create(:user) }
+  let(:handling_editor) { FactoryGirl.create(:user) }
 
   context 'rendering a paper' do
     def check_render(template, expected)
@@ -91,10 +92,23 @@ describe PaperContext do
         check_render("{{ academic_editors[0].first_name }}",
                      academic_editor.first_name)
       end
+    end
+
+    context 'with a handling editor' do
+      before do
+        journal.handling_editor_role ||
+          journal.create_handling_editor_role!
+        assign_handling_editor_role(paper, handling_editor)
+      end
+
+      it 'renders handling editors' do
+        check_render("{{ handling_editors[0].first_name }}",
+                     handling_editor.first_name)
+      end
 
       it 'renders an editor' do
         check_render("{{ editor.first_name }}",
-                     academic_editor.first_name)
+                     handling_editor.first_name)
       end
     end
   end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10733

#### What this PR does:

In the templates, the signing editor should be the handling editor and *not* the academic editor.

#### Special instructions for Review or PO:

If there is a handling editor assigned to the paper, that comes up as the signing editor in the decision templates. Otherwise, "[EDITOR]" is displayed.

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient

