### PR TITLE
npm install twice on CircleCI to avoid timeout errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,7 @@ database:
     - bundle exec rake db:create db:schema:load
   post:
     # npm install here so that it is cached by circle for parallel tests
-    - bundle exec rake ember:install
+    - cd client && npm install && cd .. && bundle exec rake ember:install
 
 
 ## Customize test commands


### PR DESCRIPTION
Jira issue: none (empowerment)

## What this PR does

This reverts a recent change which gets rid of a duplicative npm install.
ember:install should trigger an npm install, but apparently it takes too
long and it's too quiet to circle kills it

#### Notes

Are there any surprises? Anything that was particularly difficult, or clever, or
made you nervous, and should get particular attention during review? Call it
out. 

---

#### Code Review Tasks:
**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I gave it a huge thumbs-up
