### PR TITLE
APERTA-10160: HOTFIX -- update apex_deliveries destination col with 'apex'

### DIFF
--- a/db/migrate/20170614205009_add_destination_to_apex_deliveries.rb
+++ b/db/migrate/20170614205009_add_destination_to_apex_deliveries.rb
@@ -1,6 +1,6 @@
 class AddDestinationToApexDeliveries < ActiveRecord::Migration
   def change
-    add_column :tahi_standard_tasks_apex_deliveries, :destination, :string, null: false
+    add_column :tahi_standard_tasks_apex_deliveries, :destination, :string, null: false, default: "apex"
     execute 'update tahi_standard_tasks_apex_deliveries set destination = "apex"'
   end
 end


### PR DESCRIPTION

JIRA issue: https://jira.plos.org/jira/browse/APERTA-10160

#### What this PR does:

Migration for deploy failure caused by lack of value for non-null destination column of tahi_standard_tasks_apex_deliveries. Set to "apex" for all existing records.

