### PR TITLE
Fix flaky similarity check spec

### DIFF
--- a/spec/models/similarity_check_spec.rb
+++ b/spec/models/similarity_check_spec.rb
@@ -31,7 +31,8 @@ describe SimilarityCheck, type: :model, redis: true do
     let(:similarity_check) { create :similarity_check }
     let(:paper) { create :paper, :version_with_file_type, :with_creator }
     let!(:similarity_check) { create :similarity_check, versioned_text: paper.latest_version }
-    let(:stubbed_url) { paper.file.url }
+    let(:file) { double }
+    let(:stubbed_url) { Faker::Internet.url }
     let(:fake_doc_id) { Faker::Number.number(8).to_i }
     let(:fake_ithenticate_response) do
       {
@@ -47,6 +48,10 @@ describe SimilarityCheck, type: :model, redis: true do
     subject(:start_report!) { similarity_check.start_report! }
 
     before do
+      allow(similarity_check).to receive(:file).and_return(file)
+      allow(file).to receive(:[]).with(:file)
+                       .and_return("#{Faker::Lorem.word.downcase}.docx")
+      allow(file).to receive(:url).and_return(stubbed_url)
       stub_request(:get, stubbed_url).to_return(body: "turtles")
       allow(Ithenticate::Api).to receive_message_chain(:new_from_tahi_env, :error?)
                                              .and_return(false)


### PR DESCRIPTION
This spec was flaky because it would actually generate a signed URL for S3, and
then stub it out, but these URLs change every second (they are signed with a
time-limit), so if a second passed between when the URL was stubbed out and when
the code was called, the test would fail.

This is fixed by stubbing out the URL that is returned by the file object to
ensure that it does not change.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] ~I read through the JIRA ticket's AC before doing the rest of the review~
- [ ] ~I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket~
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient

