### PR TITLE
Ensure that CardContentSerializer serializes correct attributes

### DIFF
--- a/app/serializers/card_content_serializer.rb
+++ b/app/serializers/card_content_serializer.rb
@@ -11,7 +11,7 @@ class CardContentSerializer < ActiveModel::Serializer
              :text,
              :value_type,
              :editor_style,
-             :allow_annotations
+             :allow_annotations,
              # when visible_with_parent_answer is set,
              # if the parent's answer is equal to this value
              # then render this content's children

--- a/spec/serializers/card_content_serializer_spec.rb
+++ b/spec/serializers/card_content_serializer_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe do
+  subject(:serializer) { CardContentSerializer.new(card_content) }
+  let(:card_content) do
+    FactoryGirl.create(:card_content,
+                       allow_annotations: true,
+                       allow_file_captions: true,
+                       allow_multiple_uploads: true,
+                       content_type: "radio",
+                       editor_style: "basic",
+                       ident: "ident",
+                       instruction_text: "instruction",
+                       label: "label",
+                       possible_values: ["possible"],
+                       text: "text",
+                       value_type: "boolean",
+                       visible_with_parent_answer: true)
+  end
+
+  describe '#as_json' do
+    let(:json) { serializer.as_json }
+
+    it 'serializes attributes' do
+      aggregate_failures('json') do
+        card_content_json = json[:card_content]
+        expect(card_content_json).to include(id: card_content.id)
+        expect(card_content_json).to include(allow_annotations: card_content.allow_annotations)
+        expect(card_content_json).to include(allow_file_captions: card_content.allow_file_captions)
+        expect(card_content_json).to include(allow_multiple_uploads: card_content.allow_multiple_uploads)
+        expect(card_content_json).to include(content_type: card_content.content_type)
+        expect(card_content_json).to include(editor_style: card_content.editor_style)
+        expect(card_content_json).to include(ident: card_content.ident)
+        expect(card_content_json).to include(instruction_text: card_content.instruction_text)
+        expect(card_content_json).to include(label: card_content.label)
+        expect(card_content_json).to include(possible_values: card_content.possible_values)
+        expect(card_content_json).to include(text: card_content.text)
+        expect(card_content_json).to include(value_type: card_content.value_type)
+        expect(card_content_json).to include(visible_with_parent_answer: card_content.visible_with_parent_answer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: NONE

#### What this PR does:

This PR fixes an existing bug where toggling of dynamic fields in a custom card is broken.

This was due to a missing comma in the CardContent serializer which was keeping the `visible_with_parent_answer` attribute from serializing.

You can ignore the weird gray shadowing in the animated screenshots below.  That was introduced by my screen recorder after recording.

#### Before

![toggle-before](https://user-images.githubusercontent.com/18446/28689116-78493598-72e2-11e7-9965-3c1710bc2a16.gif)


#### After:

![toggle-after](https://user-images.githubusercontent.com/18446/28689123-7f1904a2-72e2-11e7-81e2-e47283c15f2d.gif)


#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient

