### PR TITLE
APERTA-9731 added title and caption for value-type=attachments

### DIFF
--- a/app/serializers/typesetter/task_answer_serializer.rb
+++ b/app/serializers/typesetter/task_answer_serializer.rb
@@ -32,7 +32,7 @@ module Typesetter
       tasks.each do |task|
         answers = task.answers
         answers.each do |answer|
-          next answer.card_content.ident.blank?
+          next if answer.card_content.ident.blank?
           if answer.card_content.value_type == 'attachment'
             question_answers[answer.card_content.ident.to_s] = process_file_attachments(answer)
           else


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9731

#### What this PR does:

This fix deals with a custom card field of content-type=file-uploader and value-type='attachment'. It adds a { title: title, caption: caption } hash to an array for each attachment on a custom card task.

#### Special instructions for Review or PO:

None.

#### Notes

None.

#### Major UI changes

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient
