### PR TITLE
WIP APERTA-10069 creates loadable preprint opt out card

### DIFF
--- a/lib/custom_card/configurations/preprint_opt_out.rb
+++ b/lib/custom_card/configurations/preprint_opt_out.rb
@@ -1,0 +1,45 @@
+module CustomCard
+  module Configurations
+    #
+    # This class defines a rake task loadable custom card that allows opting out of preprint
+    #
+    class PreprintOptOut < Base
+      def self.name
+        "Preprint Opt Out"
+      end
+
+      def self.excluded_view_permissions
+        # [Role::REVIEWER_ROLE]
+      end
+
+      def self.excluded_edit_permissions
+        # [Role::ACADEMIC_EDITOR_ROLE]
+      end
+
+      def self.publish
+        true
+      end
+
+      def self.do_not_create_in_production_environment
+        false
+      end
+
+      def self.xml_content
+        <<-XML.strip_heredoc
+          <?xml version="1.0" encoding="UTF-8"?>
+          <card required-for-submission="true" workflow-display-only="false">
+            <content content-type="display-children">
+              <content content-type="radio" value-type="text" default-answer-value="1">
+                <text>
+                  <![CDATA[Establish priority: take credit for your research and discoveries, by posting a copy of your uncorrected proof online. If you do <b>NOT</b> consent to having an early version of your paper posted online, uncheck the box below.]]>
+                </text>
+                <possible-value label="Yes, I want to accelerate research by publishing a preprint ahead of peer review" value="1"/>
+                <possible-value label="No, I do not want my article to appear online ahead of the reviewed article" value="2"/>
+              </content>
+            </content>
+          </card>
+        XML
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10069

![opt-out](https://user-images.githubusercontent.com/28537466/28730797-0f1b8f8e-7397-11e7-9e66-bb266aa865e8.png)


#### What this PR does:
Creates some card config xml for a new custom card and then puts it into a custom card class that can be loaded through a rake task.

#### Special instructions for Review or PO:

This will be difficult to test without running the rake task. You could copy the xml and put it directly in the admin xml interface

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.

If I need to migrate existing data:

- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page]


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient
