### PR TITLE
Remove 'Make changes to this Task' button from reviewer-report and from reviewer report task

### DIFF
--- a/engines/tahi_standard_tasks/client/app/components/front-matter-reviewer-report-task.js
+++ b/engines/tahi_standard_tasks/client/app/components/front-matter-reviewer-report-task.js
@@ -11,6 +11,9 @@ export default TaskComponent.extend({
       return this.get('task.reviewerReports');
     }
   }),
+  // this property is responsible for displaying (or not) the 'Make changes to this Task' button.
+  // It can later be modified to depend on permissions
+  taskStateToggleable: false,
 
   actions: {
     confirmSubmission() {

--- a/engines/tahi_standard_tasks/client/app/components/reviewer-report-task.js
+++ b/engines/tahi_standard_tasks/client/app/components/reviewer-report-task.js
@@ -11,6 +11,9 @@ export default TaskComponent.extend({
       return this.get('task.reviewerReports');
     }
   }),
+  // this property is responsible for displaying (or not) the 'Make changes to this Task' button.
+  // It can be modified later to depend on permissions
+  taskStateToggleable: false,
 
   actions: {
     confirmSubmission() {


### PR DESCRIPTION

JIRA issue: https://jira.plos.org/jira/browse/APERTA-9414

#### What this PR does:

This PR removes the 'Make changes to this Task' button from the `ReviewerReportTask` and the `FrontMatterReviewerReportTask` cards. The aim is to make sure that the state of the task can not be accidentally modified once it has been completed.

Can your changes be *seen* by a user? Then add a screenshot. Is it an
interaction?  Perhaps a quick recording?
![screen shot 2017-07-18 at 1 54 44 pm](https://user-images.githubusercontent.com/20759355/28786883-8c1888ca-7612-11e7-9e2e-a70d014d4ece.png)
![screen shot 2017-07-18 at 1 55 07 pm](https://user-images.githubusercontent.com/20759355/28786898-9bee6d82-7612-11e7-8a85-8c5f74fa0232.png)
<img width="1280" alt="screen_shot_2017-07-31_at_4_53_33_pm" src="https://user-images.githubusercontent.com/20759355/28786914-ade2f1de-7612-11e7-8cb3-0bbead0ba4de.png">
<img width="593" alt="screen_shot_2017-07-31_at_4_53_57_pm" src="https://user-images.githubusercontent.com/20759355/28786915-ae051782-7612-11e7-9aad-5f7a2af0707d.png">


#### Special instructions for Review or PO:

~~Is there anything out of the ordinary in how the AC for the ticket needs to be evaluated?
Does the reviewer have to run a rake task? Is there specific seed data they should use?
If PO needs specific guidance on how to evaluate this feature please add that information to the JIRA ticket itself (add a link here if needed)~~

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient

