### PR TITLE
APERTA-10858 fix funder role question

### DIFF
--- a/engines/tahi_standard_tasks/client/app/templates/components/funder-dataset.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/funder-dataset.hbs
@@ -62,18 +62,20 @@
     </p>
 
     <div class="form-group">
-      <span class="text-field-title">Role of sponsors or funders</span>
-      {{input
-        type="text"
-        name="additional_comments"
-        ident="funder--had_influence--role_description"
-        owner=model
-        value=model.funderInfluenceDescription
-        class="form-control tall-text-field"
-        placeholder="Description"
-        displayQuestionText=false
-        disabled=disabled
-      }}
+      <div class="inset-form-control">
+        <div class="inset-form-control-text">
+          <label>Role of sponsors or funders</label>
+        </div>
+        {{nested-question-input
+          type="text"
+          ident="funder--had_influence--role_description"
+          owner=model
+          displayQuestionText=false
+          placeholder="Description"
+          inputClassNames="form-control tall-text-field"
+          disabled=disabled
+        }}
+      </div>
     </div>
   {{/if}}
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10858

**:fire: RC PR :fire:**

#### What this PR does:

There was a mixup in the HTML normalization branch and this input in the "Financial Disclosure" card wound up getting disconnected from reality. This commit reverts the component to a nested-question-input and updates the HTML to use what's apparently the more current solution for displaying inputs.

I'm sorry to say there's no tests around this, especially since this is a case study for why happy path tests are useful. I'd add some, but there isn't a good entry point, and time seems to be a constraint here since we want to get this into the RC.

##### Reproducing:

- As any role, fill out the Financial Disclosure card. 
- Answer "Yes" to the final question. 
- Type something in the "role of sponsors or funder" box.
- Refresh the page

Expected behavior: 
You'll continue to see what you typed in the "role of sponsors or funder" box.

What was happening before:
Aperta has forgotten what you typed in that box.

#### Special instructions for Review or PO:

_none_

#### Notes

_none_
 
#### Major UI changes

_none_

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient

