### PR TITLE
bug/APERTA-10857 Do not override base task permissions

### DIFF
--- a/engines/tahi_standard_tasks/client/app/components/title-and-abstract-task.js
+++ b/engines/tahi_standard_tasks/client/app/components/title-and-abstract-task.js
@@ -7,10 +7,6 @@ const taskValidations = {
 };
 
 export default TaskComponent.extend({
-  paperNotEditable: Ember.computed.not('task.paper.editable'),
-  isNotEditable: Ember.computed('task.completed', 'paperNotEditable', function () {
-    return this.get('task.completed') || (this.get('paperNotEditable') && !this.get('currentUser.siteAdmin'));
-  }),
   validations: taskValidations,
 
   validateData() {


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10857

**:fire: RC PR :fire:**

#### What this PR does:
Allows staff admin and editors to edit the Title and Abstract card, much the same as they can the Cover Letter Card.

This fix removes code that overrode the default task permissions.  The Title and Abstract card should now allow editing the same as the Cover Letter card, which does not override the the default task permissions.  No tests were broken with the removal of this code.

QA: The RC should satisfy all of the ACs of APERTA-10221.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient

