### PR TITLE
Stop explicitly requiring custom_card classes

### DIFF
--- a/lib/custom_card/factory.rb
+++ b/lib/custom_card/factory.rb
@@ -1,5 +1,3 @@
-Dir[Rails.root.join("lib/custom_card/**/*.rb")].each { |f| require f }
-
 module CustomCard
   # The purpose of this class is to create a new custom Card using a
   # configuration class that is specified in lib/custom_card/configurations

--- a/lib/custom_card/loader.rb
+++ b/lib/custom_card/loader.rb
@@ -1,5 +1,3 @@
-Dir[Rails.root.join("lib/custom_card/**/*.rb")].each { |f| require f }
-
 module CustomCard
   # The purpose of this class is to provide a common interface for
   # creating custom Cards for specified Journals.

--- a/lib/tasks/custom_card/convert_legacy_task.rake
+++ b/lib/tasks/custom_card/convert_legacy_task.rake
@@ -1,5 +1,3 @@
-Dir[Rails.root.join("lib/custom_card/**/*.rb")].each { |f| require f }
-
 namespace :custom_card do
   desc 'Convert legacy tasks to custom card tasks'
   # example:  custom_card:convert_legacy_task[TahiStandardTasks::CompetingInterestsTask, Competing Interests]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,12 +16,11 @@ require 'webmock/rspec'
 require 'rake'
 require 'fakeredis/rspec'
 require Rails.root.join('lib', 'tahi_plugin')
+Dir[Rails.root.join('lib', 'custom_card', '**', '*.rb')].each { |f| require f }
 include Warden::Test::Helpers
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-require_relative '../lib/tasks/card_loading/support/card_loader'
-require_relative '../lib/custom_card/loader'
 require_relative 'support/pages/page'
 require_relative 'support/pages/overlay'
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
EMPOWERMENT

#### What this PR does:

Fixes some loading issues encountered while deploying to ci.aperta.tech. I think our manual `requiring` was getting in the way of rail's autoloader.


#### Major UI changes

_none_

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient

