### PR TITLE
Setup installs mailcatcher

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -96,6 +96,10 @@ Dir.chdir APP_ROOT do
     f.puts "RAILS_SECRET_TOKEN=#{SecureRandom.hex(64)}"
   end
 
+  header 'Installing mailcatcher'
+  system 'gem install mailcatcher'
+  puts 'Run in the console `mailcatcher` to start the daemon. For more information check http://mailcatcher.me/'
+
   header 'Ensuring PostgreSQL tahi role exists'
   # NOTE rolname is not a typo
   # http://stackoverflow.com/questions/8546759/how-to-check-if-a-postgres-user-exists


### PR DESCRIPTION
#### What this PR does:
Installs the mailcatcher gem during setup.

#### Notes

I considered updating our Procfile to start the mailcatcher daemon but I decided against it because I was worried about the possibility of it running in non-development environments.  Instead I copied the relevant section from Tahi's README into Confluence:
https://confluence.plos.org/confluence/display/TAHI/Emails+from+Aperta


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I ran the code (in the review environment or locally).
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient

