### PR TITLE
Eager load custom card configurations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module Tahi
     config.autoload_paths += %W(#{config.root}/app/workers)
     config.autoload_paths += %W(#{config.root}/app/subscribers)
 
+    config.eager_load_paths += %W(#{config.root}/lib/custom_card/configurations)
+
     config.s3_bucket = ENV.fetch('S3_BUCKET', :not_set)
     config.carrierwave_storage = :fog
     config.x.admin_email = TahiEnv.admin_email

--- a/lib/custom_card/loader.rb
+++ b/lib/custom_card/loader.rb
@@ -5,6 +5,12 @@ module CustomCard
   # rubocop:disable Metrics/LineLength, Style/RedundantSelf
   class Loader
     def self.all
+      if card_configuration_klasses.empty?
+        raise <<-ERROR.strip_heredoc
+          No card configuration classes found. Either lib/custom_card/configurations/
+          is empty, or there is a class loading issue.
+        ERROR
+      end
       Journal.find_each do |journal|
         card_configuration_klasses.each do |card_configuration_klass|
           self.load(card_configuration_klass, journal: journal)


### PR DESCRIPTION
NONE

#### What this PR does:

This PR fixes some class loading that I broke in my previous PR: https://github.com/Tahi-project/tahi/pull/3295

We were dependent on some module introspection that doesn't work with just autoloading. When I took away the eager loading, the card:load task stopped thinking that there were any cards to load. In this PR, I add the configurations to the eager_load list. This almost brings us back to the state prior to #3295, but it consolidates the eager loading logic and it only loads the configurations/ directory, not the whole lib/custom_card directory. I've verified that this branch cap deploys into a VM without issues.

It also adds a sanity check to the cards:load task which will trip if there are no Configurations loaded. This should hopefully prevent an issue like this from happening in the future.

---

#### Code Review Tasks:


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient

