### PR TITLE
Fail when db:drop fails

### DIFF
--- a/bin/update_data
+++ b/bin/update_data
@@ -3,10 +3,20 @@
 # `set -xe` causes this whole script to immediately exit if any single command fails
 set -xe
 
+bundle exec rake db:drop
+# manually check that the DB was dropped because rake db:drop will exit with success even if it failed
+psql -l | grep tahi_development && exit 1
+
+# Get the DB up to date with master
+# If you are working on a hotfix you should get up to date with the release branch instead of master
 git checkout master
-bundle exec rake db:reset
+bundle exec rake db:setup
+
+# Go back to the feature branch
 git checkout -
+# run migrations
 bundle exec rake db:migrate
+# seed sample data
 bundle exec rake cards:load
 bundle exec rake roles-and-permissions:seed
 bundle exec rake settings:seed_setting_templates
@@ -14,4 +24,5 @@ bundle exec rake data:update_journal_task_types
 bundle exec rake institutional_accounts:add_seed_accounts
 bundle exec rake create_feature_flags
 bundle exec rake seed:letter_templates:populate
+# update schema.rb and data.yml to reflect your DB
 bundle exec rake db:data:dump


### PR DESCRIPTION
#### What this PR does:

/bin/updata_data will now exit if it can't drop the database.  Otherwise the error from rake db:drop gets lost in a wave of subsequent output and the resulting schema and data.yml can be incorrect and waste a lot of people's time.

This assumes the database is always named tahi_development.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I ran the code (in the review environment or locally).
- [ ] I read the code; it looks good

---
After this change a failure to drop the db looks like:
```bash
us-mc-00998:tahi sgatchell$ ./bin/update_data
+ bundle exec rake db:drop
PG::ObjectInUse: ERROR:  database "tahi_development" is being accessed by other users
DETAIL:  There are 2 other sessions using the database.
: DROP DATABASE IF EXISTS "tahi_development"
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:155:in `async_exec'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:155:in `block in execute'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract_adapter.rb:484:in `block in log'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activesupport-4.2.7.1/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/abstract_adapter.rb:478:in `log'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:154:in `execute'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/connection_adapters/postgresql/schema_statements.rb:86:in `drop_database'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/tasks/postgresql_database_tasks.rb:28:in `drop'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/tasks/database_tasks.rb:114:in `drop'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/tasks/database_tasks.rb:128:in `block in drop_current'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/tasks/database_tasks.rb:276:in `block in each_current_configuration'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/tasks/database_tasks.rb:275:in `each'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/tasks/database_tasks.rb:275:in `each_current_configuration'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/tasks/database_tasks.rb:127:in `drop_current'
/Users/sgatchell/.gem/ruby/2.2.6/gems/activerecord-4.2.7.1/lib/active_record/railties/databases.rake:28:in `block (2 levels) in <top (required)>'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/task.rb:248:in `call'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/task.rb:248:in `block in execute'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/task.rb:243:in `each'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/task.rb:243:in `execute'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bugsnag-5.0.1/lib/bugsnag/rake.rb:12:in `execute_with_bugsnag'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/task.rb:187:in `block in invoke_with_call_chain'
/Users/sgatchell/.rubies/ruby-2.2.6/lib/ruby/2.2.0/monitor.rb:211:in `mon_synchronize'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/task.rb:180:in `invoke_with_call_chain'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/task.rb:173:in `invoke'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:152:in `invoke_task'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:108:in `block (2 levels) in top_level'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:108:in `each'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:108:in `block in top_level'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:117:in `run_with_threads'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:102:in `top_level'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:80:in `block in run'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:178:in `standard_exception_handling'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/lib/rake/application.rb:77:in `run'
/Users/sgatchell/.gem/ruby/2.2.6/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
/Users/sgatchell/.gem/ruby/2.2.6/bin/rake:23:in `load'
/Users/sgatchell/.gem/ruby/2.2.6/bin/rake:23:in `<top (required)>'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `load'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/cli/exec.rb:27:in `run'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/cli.rb:365:in `exec'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor.rb:369:in `dispatch'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/cli.rb:22:in `dispatch'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/vendor/thor/lib/thor/base.rb:444:in `start'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/cli.rb:13:in `start'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/exe/bundle:30:in `block in <top (required)>'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/Users/sgatchell/.gem/ruby/2.2.6/gems/bundler-1.15.3/exe/bundle:22:in `<top (required)>'
/Users/sgatchell/.gem/ruby/2.2.6/bin/bundle:23:in `load'
/Users/sgatchell/.gem/ruby/2.2.6/bin/bundle:23:in `<main>'
Couldn't drop tahi_development
+ psql -l
+ grep tahi_development
 tahi_development   | tahi      | UTF8     | en_US.UTF-8 | en_US.UTF-8 | 
+ exit 1
```