### PR TITLE
Features/aperta 9171 pusher overwhelming

### DIFF
--- a/client/app/mixins/controllers/pusher-concerns.js
+++ b/client/app/mixins/controllers/pusher-concerns.js
@@ -6,21 +6,11 @@ export default Ember.Mixin.create({
   pusher: Ember.inject.service('pusher'),
   flash: Ember.inject.service('flash'),
 
-  pusherIsDisconnected: Ember.computed.alias('pusher.isDisconnected'),
   pusherConnectionState: Ember.computed.alias('pusher.connection.connection.state'),
 
   handlePusherConnectionStatusChange: concurrencyTask(function*() {
-    let state = null;
-    switch (this.get('pusherConnectionState')) {
-    case 'failed':
-      state = 'failed';
-      break;
-    case 'unavailable':
-    case 'disconnected':
-      state = 'unavailable';
-    }
-
-    if (state) {
+    let state = this.get('pusherConnectionState');
+    if(['unavailable', 'failed', 'disconnected'].includes(state)) {
       this.updatePusherConnectionMessage(state);
     }
   }).drop(),
@@ -40,6 +30,10 @@ export default Ember.Mixin.create({
             to attempt to re-establish the connection`,
     failed: `Aperta is having trouble establishing a live connection with your browser
               due to lack of browser support for required software.
-              <a href="http://browsehappy.com/">Please update your browser to the current version</a>`
+              <a href="http://browsehappy.com/">Please update your browser to the current version</a>`,
+    disconnected: `Aperta\'s live connection with your browser has been dropped. 
+            This could impact updates to the interface,
+            and we recommend you <a href="#" onclick="window.location.reload(false)">reload this page</a> 
+            to attempt to re-establish the connection.`
   }
 });

--- a/client/app/pods/application/controller.js
+++ b/client/app/pods/application/controller.js
@@ -19,7 +19,7 @@ export default Ember.Controller.extend(pusherConcerns, {
     this.get('healthCheck').start();
   },
 
-  pusherConnectionStatusChanged: Ember.on('init', Ember.observer('pusherIsDisconnected', function() {
+  pusherConnectionStatusChanged: Ember.on('init', Ember.observer('pusherConnectionState', function() {
     this.get('handlePusherConnectionStatusChange').perform();
   })),
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9171

#### What this PR does:

Prevents "unavailable connection" flash messages from piling up for users who are having trouble connecting to slanger.

#### Special instructions for Review or PO:

You need to simulate a spotty connection to slanger to reproduce this.  I just stopped my local instance of aperta repeatedly but I'm not sure how you'd do it in PO.  There is an ember test to simulate it.

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

