### PR TITLE
Autoresize tinyMCE input boxes

### DIFF
--- a/client/app/pods/components/rich-text-editor/component.js
+++ b/client/app/pods/components/rich-text-editor/component.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 
 const basicElements    = 'p,br,strong/b,em/i,u,sub,sup,pre';
 const basicFormats     = {underline: {inline : 'u'}};
-const basicPlugins     = 'code codesample paste';
+const basicPlugins     = 'code codesample paste autoresize';
 const basicToolbar     = 'bold italic underline | subscript superscript | undo redo | codesample ';
 
 const anchorElement    = ',a[href|rel|target|title]';
@@ -70,7 +70,6 @@ export default Ember.Component.extend({
     options['content_style'] = this.get('bodyCSS');
     options['formats'] = basicFormats;
     options['elementpath'] = false;
-    options['plugins'] = 'autoresize';
     options['autoresize_max_height'] = 500;
     options['autoresize_bottom_margin'] = 1;
     options['autoresize_on_init'] = true;


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10836

#### What this PR does:

This sets the tinyMCE input boxes to resize based on their content. The current settings max-out at 500px (good for small screens).

#### Special instructions for Review or PO:

The easiest place to PO this one is to create two invitations. Choose to edit the template and make a long, medium and short one. You can click 'save' and then when you click 'edit' again you'll see the boxes correctly resize.

#### Notes

There was a default 50px margin being added to the end of the input. It looked strange so I took it down to 1px.

#### Major UI changes
Nothing major UI-wise, but dynamically sizing the tinyMCE boxes now.

Long input now opens to show it all (if under 500px):
![screen shot 2017-08-09 at 3 24 37 pm](https://user-images.githubusercontent.com/164196/29140117-4fbfb9fa-7d17-11e7-9e6b-95fca9896c41.png)


Short text makes the box smaller:
![screen shot 2017-08-09 at 3 26 17 pm](https://user-images.githubusercontent.com/164196/29140078-2eedf70a-7d17-11e7-86f9-755fec190eda.png)


---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] If I made any UI changes, I've let QA know.
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

