### PR TITLE
APERTA-10956 get rid of a syntactically incorrect comma

### DIFF
--- a/app/views/shared/_bugsnag_javascript.html.erb
+++ b/app/views/shared/_bugsnag_javascript.html.erb
@@ -1,5 +1,5 @@
 <% if ENV['BUGSNAG_JAVASCRIPT_API_KEY'] %>
-  <script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js", data-apikey="<%= ENV['BUGSNAG_JAVASCRIPT_API_KEY'] %>"></script>
+  <script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js" data-apikey="<%= ENV['BUGSNAG_JAVASCRIPT_API_KEY'] %>"></script>
   <script type="text/javascript">
     Bugsnag.releaseStage = "<%= Rails.env %>";
     Bugsnag.notifyReleaseStages = ["staging", "production"];


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-

#### What this PR does:

get rid of a comma which doesn't belong. It was causing IE11 to lose its marbles.

This is an ancient syntax error, however, it seems to be currently glossed over in production. On www.aperta.tech, the page source looks like this in IE11:

![ie11 - win7 running 2017-08-09 16-43-38](https://user-images.githubusercontent.com/916368/29148407-f5bf3830-7d21-11e7-802b-c5448e8c47d4.png)

but suddenly, on ci.aperta.tech it looks like this in IE11:

![ie11 - win7 running 2017-08-09 16-46-39](https://user-images.githubusercontent.com/916368/29148453-55901a5e-7d22-11e7-9976-39e356467960.png)

Rather than figure out why it's suddenly causing a problem. I'm just fixing the syntax error.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

