### PR TITLE
APERTA-10956 remove duplicate property on ember component

### DIFF
--- a/client/app/pods/components/card-content/short-input/component.js
+++ b/client/app/pods/components/card-content/short-input/component.js
@@ -4,7 +4,6 @@ import ValidateTextInput from 'tahi/mixins/validate-text-input';
 
 export default Ember.Component.extend(ValidateTextInput, {
   classNames: ['card-content-short-input'],
-  classNameBindings: ['answer.hasErrors:has-error'],
   attributeBindings: ['isRequired:required', 'aria-required'],
   'aria-required': Ember.computed.reads('isRequiredString'),
   hasErrors: Ember.computed.notEmpty('answer.readyIssuesArray.[]'),


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10956

#### What this PR does:

IE11 loses its marbles if we accidentally define a duplicate property on an object:

![ie11 - win7 running 2017-08-09 16-57-00](https://user-images.githubusercontent.com/916368/29148661-cd1e1458-7d23-11e7-848e-c51cff8897d4.png)

They seemed mostly redundant but I chose to remove the first one on the basis that it's the one that would be ignored on more lenient browsers.

This is not the first time this has happened. It should be easy to check in a linter so we should set up something that validates we aren't adding duplicate props.

#### Major UI changes

UI should appear for IE11 users again.

---

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

