### PR TITLE
APERTA-10567 relax lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,10 +7,10 @@
     },
 
     "rules": {
-      "camelcase": "warn",
+      "camelcase": "off",
       "indent": ["error", 2],
       "eqeqeq": "error",
-      "max-len": ["warn", 120],
+      "max-len": "off",
       "semi": ["error", "always"],
       "quotes": [
         "error",

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,15 +59,7 @@ Style/StringLiteralsInInterpolation:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 120
-  Exclude:
-    # Nested questions contain, mostly, long strings of english text,
-    # which need consistent spacing.
-    - 'lib/tasks/**/*'
-
-    # The it 'some string' line of specs should be allowed to be as
-    # long as neccessary to describe the test.
-    - '**/spec/**/*'
+  Enabled: false
 
 Style/PredicateName:
   Exclude:
@@ -90,19 +82,10 @@ Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/Documentation:
-  # Class-level comments on migrations and serializers often end up being
-  # tautological
-  Exclude:
-    - '**/db/migrate/*'
-    - '**/app/serializers/*'
-    - '**/spec/**/*'
+  Enabled: false
 
 Style/WordArray:
   # If an array is *accidentally* made of single-word strings, being
   # forced to use %w means being forced to rewrite the whole array as
   # soon as one entry becomes two words
   Enabled: false
-
-Style/PredicateName:
-  Exclude:
-    - '**/spec/**/*'


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10567

- Remove line length checks.  We can police these ourselves and they're the
  leading cause of false positives.
- Class comments should be made when appropriate. We also police these
  in our reviews already
- We have some places where we need camel case in our js, and we
  already police improper usage in code reviews
- `PredicateName` was somehow defined twice in the file, I removed the extra definition.

