### PR TITLE
APERTA-10416 Fix Attachment Reports

### DIFF
--- a/lib/tahi_reports/analyze_attachment_failures_report.rb
+++ b/lib/tahi_reports/analyze_attachment_failures_report.rb
@@ -112,10 +112,17 @@ module TahiReports
       end
     end
 
+    def clean_message(message)
+      if message
+        message.gsub("\n", "  ").gsub(/(identify)[^']+'/, '\1 <file-path-extracted>')
+      else
+        "[no error message]"
+      end
+    end
+
     def print_number_of_attachments_per_error_breakdown
       output.puts "Number of #{attachment_klass.name}(s) per error"
       output.puts "-------------------------------------------"
-      attachments_stuck_in_errored = {}
       TIMEFRAMES.each_pair.with_index do |(human_readable_timeframe, timeframe), i|
         output.puts unless i == 0
         output.puts "Errors #{human_readable_timeframe}"
@@ -123,7 +130,7 @@ module TahiReports
           attachments_by_error = attachments_errored.where(
             updated_at: (timeframe.ago.beginning_of_day.utc..Time.now.end_of_day.utc)
           ).each do |a|
-            a.error_message = a.error_message.gsub("\n", "  ").gsub(/(identify)[^']+'/, '\1 <file-path-extracted>')
+            a.error_message = clean_message(a.error_message)
           end
 
           if attachments_by_error.empty?
@@ -139,7 +146,7 @@ module TahiReports
           attachments_by_error = attachments_errored.where(
             updated_at: (timeframe.ago.beginning_of_day.utc..TIMEFRAMES.values[i-1].ago.end_of_day.utc)
           ).each do |a|
-            a.error_message = a.error_message.gsub("\n", "  ").gsub(/(identify)[^']+'/, '\1 <file-path-extracted>')
+            a.error_message = clean_message(a.error_message)
           end
 
           if attachments_by_error.empty?

--- a/spec/lib/tahi_reports/analyze_attachment_failures_report_spec.rb
+++ b/spec/lib/tahi_reports/analyze_attachment_failures_report_spec.rb
@@ -30,17 +30,17 @@ describe TahiReports::AnalyzeAttachmentFailuresReport do
     let!(:processing_attachment_from_a_month_ago) { FactoryGirl.create(:attachment, :processing, updated_at: 1.month.ago) }
     let!(:processing_attachment_from_a_year_ago) { FactoryGirl.create(:attachment, :processing, updated_at: 1.year.ago) }
 
-    let!(:errored_attachment_from_today) { FactoryGirl.create(:attachment, :errored, updated_at: Date.today) }
+    let!(:errored_attachment_from_today) { FactoryGirl.create(:attachment, :errored, updated_at: Time.zone.today, error_message: nil) }
     let!(:errored_attachment_from_a_week_ago) { FactoryGirl.create(:attachment, :errored, updated_at: 1.week.ago, error_message: "Failed because of A") }
     let!(:errored_attachment_from_a_month_ago) { FactoryGirl.create(:attachment, :errored, updated_at: 1.month.ago) }
     let!(:errored_attachment_from_a_year_ago) { FactoryGirl.create(:attachment, :errored, updated_at: 1.year.ago, error_message: "Failed because of B") }
 
-    let!(:completed_attachment_from_today) { FactoryGirl.create(:attachment, :completed, updated_at: Date.today) }
+    let!(:completed_attachment_from_today) { FactoryGirl.create(:attachment, :completed, updated_at: Time.zone.today) }
     let!(:completed_attachment_from_a_week_ago) { FactoryGirl.create(:attachment, :completed, updated_at: 1.week.ago) }
     let!(:completed_attachment_from_a_month_ago) { FactoryGirl.create(:attachment, :completed, updated_at: 1.month.ago) }
     let!(:completed_attachment_from_a_year_ago) { FactoryGirl.create(:attachment, :completed, updated_at: 1.year.ago) }
 
-    let!(:unknown_state_attachment_from_today) { FactoryGirl.create(:attachment, :unknown_state, updated_at: Date.today) }
+    let!(:unknown_state_attachment_from_today) { FactoryGirl.create(:attachment, :unknown_state, updated_at: Time.zone.today) }
     let!(:unknown_state_attachment_from_a_week_ago) { FactoryGirl.create(:attachment, :unknown_state, updated_at: 1.week.ago) }
     let!(:unknown_state_attachment_from_a_month_ago) { FactoryGirl.create(:attachment, :unknown_state, updated_at: 1.month.ago) }
     let!(:unknown_state_attachment_from_a_year_ago) { FactoryGirl.create(:attachment, :unknown_state, updated_at: 1.year.ago) }
@@ -52,7 +52,7 @@ describe TahiReports::AnalyzeAttachmentFailuresReport do
 
     it 'prints a summary' do
       run_report
-      expect(report_contents).to include "Below is the results of running the Attachment analysis report run on #{Date.today}."
+      expect(report_contents).to include "Below is the results of running the Attachment analysis report run on #{Time.zone.today}."
       expect(report_contents).to include <<-STRING.strip_heredoc
         Total count of Attachment(s): 16
         -------------------------------------------
@@ -125,11 +125,11 @@ describe TahiReports::AnalyzeAttachmentFailuresReport do
       run_report
       expect(report_contents).to include <<-STRING.strip_heredoc
         Errors today
-          1 failed with error: Failed for some reason
+          1 failed with error: [no error message]
           ids=[#{errored_attachment_from_today.id}]
 
         Errors since yesterday
-          1 failed with error: Failed for some reason
+          1 failed with error: [no error message]
           ids=[#{errored_attachment_from_today.id}]
 
         Errors in the past week


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10416

#### What this PR does:

This fixes the reporting to complete and send out a regular attachment report.

It looks like the failures were due to a nil error message. When running against production data, the rake task would fail when trying to manipulate a nil error message.  That case is now handled and nil messages are resolved to be '[no error message]'.

#### Special instructions for Review or PO:

The rake task generating the messages can run on the command line.  `bundle exec rake reports:analyze_attachments:run` will show the output that ends up in the emails. 

#### Notes

Any nil message will become '[no error message]' in the report.

This was debugged and resolved against production data.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

~- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT~. (This needs to be checked on the command-line)

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

