### PR TITLE
Feature/aperta 10414 prevent deletion of reviewers task card

### DIFF
--- a/client/app/pods/components/card-preview/component.js
+++ b/client/app/pods/components/card-preview/component.js
@@ -70,6 +70,8 @@ export default Ember.Component.extend({
     return taskType !== 'ReviewerReportTask';
   }),  
 
+  showDeleteButton: Ember.computed.and('canRemoveCard', 'notReviewerReportTask'),
+
   actions: {
     viewCard() {
       let action = this.get('action');

--- a/client/app/pods/components/card-preview/template.hbs
+++ b/client/app/pods/components/card-preview/template.hbs
@@ -23,6 +23,6 @@
   <span class="card-title">{{task.title}}</span>
 </a>
 
-{{#if (and canRemoveCard notReviewerReportTask)}}
+{{#if showDeleteButton}}
    <span {{action "promptDelete" bubbles=false}} class="card-remove" title="Delete Card"></span> 
 {{/if}}

--- a/client/tests/components/card-preview-test.js
+++ b/client/tests/components/card-preview-test.js
@@ -60,7 +60,7 @@ test('#unread-comments-count badge is removed when commentLooks are "read"', fun
   });
 });
 
-test('no delete button display for reviewer card', function(assert) {
+test('no delete button display for reviewer card, even if canRemoveCard is true', function(assert) {
   this.set('task', {
     title: 'Review by Reviewer User',
     type: 'ReviewerReportTask',
@@ -68,11 +68,26 @@ test('no delete button display for reviewer card', function(assert) {
   assert.expect(2);
 
   this.render(hbs`
-    {{card-preview task=task}}
+    {{card-preview task=task canRemoveCard=true}}
   `);
 
   Ember.run(this, function() {
     assert.textPresent('span.card-title', 'Review by Reviewer User');
     assert.equal(this.$('.task-disclosure-heading .card-remove').length, 0);
+  });
+});
+
+test('delete button display for any other type of task', function(assert) {
+  this.set('task', {
+    type: 'AuthorsTask',
+  });
+  assert.expect(1);
+
+  this.render(hbs`
+    {{card-preview task=task canRemoveCard=true}}
+  `);
+  
+  Ember.run(this, function() {
+    assert.equal(this.$('.task-disclosure-heading .card-remove').length, 1);
   });
 });


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10414

#### What this PR does:

We have cases where users delete the Reviewers card and we want to stop the users from doing it either by mistake or on purpose. Hence, this PR addresses the removal of the close button on reviewer cards in the workflow. 
The second AC was skipped because a foreign already exists between the reviewer report model and task model.

<img width="1280" alt="screen shot 2017-08-11 at 6 47 56 pm" src="https://user-images.githubusercontent.com/10073272/29225297-a01926e8-7ec5-11e7-9757-1073b09772e2.png">

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] If I made any UI changes, I've let QA know.
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

