### PR TITLE
Bugs/aperta 10097 competing interests permissions and question values

### DIFF
--- a/lib/custom_card/configurations/competing_interest.rb
+++ b/lib/custom_card/configurations/competing_interest.rb
@@ -47,22 +47,20 @@ module CustomCard
           <?xml version="1.0" encoding="UTF-8"?>
           <card required-for-submission="true" workflow-display-only="false">
             <content content-type="display-children">
-              <content content-type="radio" value-type="text" ident="competing_interests--has_competing_interests">
+              <content content-type="radio" value-type="boolean" ident="competing_interests--has_competing_interests">
                 <text>
                   <![CDATA[<ol class="question-list"><li class="question"><div class="question-text"><p>You are responsible for recognizing and disclosing on behalf of all authors any competing interest that could be perceived to bias their work, acknowledging all financial support and any other relevant financial or non-financial competing interests.</p>Do any authors of this manuscript have competing interests (as described in the <a target="_blank" href="http://journals.plos.org/plosbiology/s/competing-interests">PLOS Policy on Declaration and Evaluation of Competing Interests</a>)?</div></li>]]>
                 </text>
-                <possible-value label="Yes" value="t"/>
-                <possible-value label="No" value="f"/>
-                <content content-type="display-with-value" visible-with-parent-answer="t">
+                <content content-type="display-with-value" visible-with-parent-answer="true">
                   <content content-type="field-set">
-                    <content content-type="paragraph-input" value-type="html" ident="competing_interests--statement">
+                    <content content-type="paragraph-input" value-type="html" editor-style="basic" ident="competing_interests--statement">
                       <text>
                         <![CDATA[Please provide details about any and all competing interests in the box below. Your response should begin with this statement: "I have read the journal's policy and the authors of this manuscript have the following competing interests."<br><br>Please note that if your manuscript is accepted, this statement will be published.]]>
                       </text>
                     </content>
                   </content>
                 </content>
-                <content content-type="display-with-value" visible-with-parent-answer="f">
+                <content content-type="display-with-value" visible-with-parent-answer="false">
                   <content content-type="field-set">
                     <content content-type="text">
                       <text>Your competing interests statement will appear as: "The authors have declared that no competing interests exist."


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10097

#### What this PR does:

1.  Changes the permissions that are assigned to the Competing Interests Custom Card to match production (see screenshots below)

2.  Changes the answer values for the two questions being asked from "text" with two possible answers to a boolean.

3.  Changes the editor type to be "basic" html

### Permission Changes

@egh ran this query against production data:

```
Permission.where(applies_to:"TahiStandardTasks::CompetingInterestsTask", action:['view','edit']).map {|p| [p.action, p.roles.map{|r| r.name }.join(", ") ] }

# resulting in...

"view": Creator, Collaborator, Cover Editor, Reviewer, Staff Admin, Internal Editor, Handling Editor, Production Staff, Publishing Services, Academic Editor, Billing Staff
"edit": Staff Admin, Internal Editor, Production Staff, Publishing Services, Creator, Collaborator, Cover Editor, Handling Editor
```

So, here is what it looks like locally after running this change:

![aperta 2017-08-11 18-38-38](https://user-images.githubusercontent.com/18446/29234841-e4e8cc18-7ec7-11e7-936c-e93c61a8c67b.png)

#### Code Review Tasks:

**Author tasks** 
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks**
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good