### PR TITLE
Add .ignore file

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,10 @@
+public/assets/
+log/
+tmp/
+tags
+client/dist/
+client/tmp/
+client/npm-shrinkwrap.json
+client/yarn.lock
+client/node_modules/
+client/bower_components


### PR DESCRIPTION
#### What this PR does:

For `ag` 2.0, it uses .ignore instead of .agignore. Other searchers also
read and use the .ignore file. This is set to be the same as .agignore.

---

#### Code Review Tasks:

Empowerment
