### PR TITLE
APERTA-10993 Invert the Custom Card Configuration setting

### DIFF
--- a/lib/custom_card/configurations/base.rb
+++ b/lib/custom_card/configurations/base.rb
@@ -13,11 +13,17 @@ module CustomCard
         raise NotImplementedError
       end
 
-      def self.excluded_view_permissions
+      def self.view_role_names
+        # an array of `Role.name` that should have view access to Card
+        # default: no access
+        # options: this method can also return `:all` to allow all Roles in system
         []
       end
 
-      def self.excluded_edit_permissions
+      def self.edit_role_names
+        # an array of `Role.name` that should have edit access to Card
+        # default: no access
+        # options: this method can also return `:all` to allow all Roles in system
         []
       end
 

--- a/lib/custom_card/configurations/competing_interest.rb
+++ b/lib/custom_card/configurations/competing_interest.rb
@@ -11,10 +11,29 @@ module CustomCard
         "Competing Interests"
       end
 
-      def self.excluded_view_permissions
+      def self.view_role_names
+        ["Academic Editor",
+         "Billing Staff",
+         "Collaborator",
+         "Cover Editor",
+         "Creator",
+         "Handling Editor",
+         "Internal Editor",
+         "Production Staff",
+         "Publishing Services",
+         "Reviewer",
+         "Staff Admin"]
       end
 
-      def self.excluded_edit_permissions
+      def self.edit_role_names
+        ["Collaborator",
+         "Cover Editor",
+         "Creator",
+         "Handling Editor",
+         "Internal Editor",
+         "Production Staff",
+         "Publishing Services",
+         "Staff Admin"]
       end
 
       def self.publish

--- a/lib/custom_card/configurations/preprint_opt_out.rb
+++ b/lib/custom_card/configurations/preprint_opt_out.rb
@@ -8,32 +8,26 @@ module CustomCard
         "Preprint Posting"
       end
 
-      def self.excluded_view_permissions
-        [
-          Role::DISCUSSION_PARTICIPANT,
-          Role::FREELANCE_EDITOR_ROLE,
-          Role::JOURNAL_SETUP_ROLE,
-          Role::TASK_PARTICIPANT_ROLE,
-          Role::REVIEWER_ROLE,
-          Role::REVIEWER_REPORT_OWNER_ROLE
-        ]
+      def self.view_role_names
+        ["Academic Editor",
+         "Billing Staff",
+         "Collaborator",
+         "Cover Editor",
+         "Creator",
+         "Handling Editor",
+         "Internal Editor",
+         "Production Staff",
+         "Publishing Services",
+         "Site Admin",
+         "Staff Admin"]
       end
 
-      def self.excluded_edit_permissions
-        [
-          Role::ACADEMIC_EDITOR_ROLE,
-          Role::BILLING_ROLE,
-          Role::COVER_EDITOR_ROLE,
-          Role::DISCUSSION_PARTICIPANT,
-          Role::FREELANCE_EDITOR_ROLE,
-          Role::HANDLING_EDITOR_ROLE,
-          Role::INTERNAL_EDITOR_ROLE,
-          Role::JOURNAL_SETUP_ROLE,
-          Role::TASK_PARTICIPANT_ROLE,
-          Role::PRODUCTION_STAFF_ROLE,
-          Role::REVIEWER_ROLE,
-          Role::REVIEWER_REPORT_OWNER_ROLE
-        ]
+      def self.edit_role_names
+        ["Collaborator",
+         "Creator",
+         "Publishing Services",
+         "Site Admin",
+         "Staff Admin"]
       end
 
       def self.publish

--- a/lib/custom_card/configurations/sampler.rb
+++ b/lib/custom_card/configurations/sampler.rb
@@ -11,12 +11,12 @@ module CustomCard
         "Card Configuration Sampler"
       end
 
-      def self.excluded_view_permissions
-        # [Role::REVIEWER_ROLE]
+      def self.view_role_names
+        :all
       end
 
-      def self.excluded_edit_permissions
-        # [Role::ACADEMIC_EDITOR_ROLE]
+      def self.edit_role_names
+        :all
       end
 
       def self.publish

--- a/lib/custom_card/factory.rb
+++ b/lib/custom_card/factory.rb
@@ -51,19 +51,21 @@ module CustomCard
         # set any default VIEW permissions
         set_role_permissions(card: card,
                              action: "view",
-                             excluded_role_names: configuration.excluded_view_permissions)
+                             role_names: configuration.view_role_names)
 
         # set any default EDIT permissions
         set_role_permissions(card: card,
                              action: "edit",
-                             excluded_role_names: configuration.excluded_edit_permissions)
+                             role_names: configuration.edit_role_names)
       end
     end
 
-    def set_role_permissions(card:, action:, excluded_role_names: [])
-      role_names = journal.roles.pluck(:name) - Array(excluded_role_names)
-      CardPermissions.set_roles(card, action, Role.where(name: role_names))
+    # rubocop:disable TernaryParentheses
+    def set_role_permissions(card:, action:, role_names:)
+      roles = (role_names == :all) ? Role.all : Role.where(name: Array(role_names))
+      CardPermissions.set_roles(card, action, roles.uniq(:name))
     end
+    # rubocop:enable TernaryParentheses
   end
   # rubocop:enable Style/IfUnlessModifier, Metrics/LineLength
 end

--- a/spec/lib/custom_card/factory_spec.rb
+++ b/spec/lib/custom_card/factory_spec.rb
@@ -85,42 +85,54 @@ describe CustomCard::Factory do
       FactoryGirl.create(:role, journal: journal, name: role_name)
     end
 
-    context "with no excluded permissions defined by configuration" do
+    context "with no permissions defined by configuration" do
       before do
-        allow(card_configuration).to receive(:excluded_view_permissions).and_return(nil)
-        allow(card_configuration).to receive(:excluded_edit_permissions).and_return(nil)
+        allow(card_configuration).to receive(:view_role_names).and_return(nil)
+        allow(card_configuration).to receive(:edit_role_names).and_return(nil)
       end
 
       it "has all journal permissions" do
-        expect {
-          custom_card_factory.first_or_create(card_configuration)
-        }.to change { role.permissions.count }.from(0).to(3)
+        custom_card_factory.first_or_create(card_configuration)
+        expect(role.permissions.count).to eq(0)
       end
     end
 
-    context "with excluded VIEW permissions defined by configuration" do
+    context "with :ALL permissions defined by configuration" do
       before do
-        allow(card_configuration).to receive(:excluded_view_permissions).and_return(role_name)
-        allow(card_configuration).to receive(:excluded_edit_permissions).and_return(nil)
+        allow(card_configuration).to receive(:view_role_names).and_return(:all)
+        allow(card_configuration).to receive(:edit_role_names).and_return(:all)
       end
 
-      it "has no view permissions for excluded role" do
+      it "has view and edit permissions defined" do
         custom_card_factory.first_or_create(card_configuration)
-        expect(role.permissions.where(action: "view").count).to eq(0)
+        expect(role.permissions.where(action: "view").count).to eq(2)
         expect(role.permissions.where(action: "edit").count).to eq(1)
       end
     end
 
-    context "with excluded EDIT permissions defined by configuration" do
+    context "with VIEW permissions defined by configuration" do
       before do
-        allow(card_configuration).to receive(:excluded_view_permissions).and_return(nil)
-        allow(card_configuration).to receive(:excluded_edit_permissions).and_return(role_name)
+        allow(card_configuration).to receive(:view_role_names).and_return(role_name)
+        allow(card_configuration).to receive(:edit_role_names).and_return(nil)
       end
 
-      it "has no edit permissions for excluded role" do
+      it "has only view permissions defined (one for Card, one for CardVersion)" do
         custom_card_factory.first_or_create(card_configuration)
-        expect(role.permissions.where(action: "edit").count).to eq(0)
         expect(role.permissions.where(action: "view").count).to eq(2)
+        expect(role.permissions.where(action: "edit").count).to eq(0)
+      end
+    end
+
+    context "with EDIT permissions defined by configuration" do
+      before do
+        allow(card_configuration).to receive(:view_role_names).and_return(nil)
+        allow(card_configuration).to receive(:edit_role_names).and_return(role_name)
+      end
+
+      it "has only edit permissions defined" do
+        custom_card_factory.first_or_create(card_configuration)
+        expect(role.permissions.where(action: "edit").count).to eq(1)
+        expect(role.permissions.where(action: "view").count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10993

#### What this PR does:

We initially assumed that the default behavior for Custom Cards would be
that all Roles would have read/write access.  So, the code set all Roles,
but allowed for defining an array or Roles to exclude.  (blacklisting)

This assumption turned out to be incorrect.  Most Cards will always have
a subset of Role permissions applied.  So, this PR flips the behavior
from a blacklist to a whitelist.

By default, no permissions will be assigned except for the ones defined
in the configuration `#view_role_names` and `#edit_role_names`.

In addition, you can specify the symbol of `:all` if you happen to want
all Roles to be assigned to the Card (as we do with some sample Cards).

#### Special instructions for Review or PO:

We are in a bit of a weird place right now with our release, so the easiest
way to test this code is to do the following:

1.  On the review app, create a new Journal
2.  Have a developer run `rake cards:load` on the review app
3.  Verify that the permissions on the custom Cards for the new Journal match the
permissions on the original Journal. 

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

---

**Reviewer tasks** 
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases