### PR TITLE
Prevent rake job from changing custom card titles

### DIFF
--- a/app/services/journal_services/create_default_task_types.rb
+++ b/app/services/journal_services/create_default_task_types.rb
@@ -6,7 +6,7 @@ module JournalServices
     def self.call(journal)
       Rails.logger.info "Processing journal: #{journal.name}..."
       with_noisy_errors do
-        Task.descendants.each do |klass|
+        (Task.descendants - [CustomCardTask]).each do |klass|
           jtt = journal.journal_task_types.find_or_initialize_by(kind: klass)
           jtt.title = klass::DEFAULT_TITLE
           jtt.role_hint = klass::DEFAULT_ROLE_HINT

--- a/app/services/journal_services/update_default_tasks.rb
+++ b/app/services/journal_services/update_default_tasks.rb
@@ -3,7 +3,7 @@ module JournalServices
   # default values defined in the task class, except for Ad-hoc tasks
   class UpdateDefaultTasks < BaseService
     def self.call
-      Task.descendants.each(&:restore_defaults)
+      (Task.descendants - [CustomCardTask]).each(&:restore_defaults)
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10097

#### What this PR does:

The `data:update_journal_task_types` rake task resets existing tasks back to their default titles. This was causing converted Competing Interests cards to have their titles set to "Custom Card".

This excludes custom cards from that rake task.

#### Special instructions for Review or PO:

PO-ing this will be a bit of a drag, and will involve going to a rails console, to a shell, and back to rails.

From rails:

`Task.where(type: CustomCardTask).last.update(title: "Competing Interests")`

From shell:

`rake data:update_journal_task_types`

From rails:

`Task.where(type: CustomCardTask).last.title`

If the title is still "Competing Interests", then this worked. If it got overwritten and is now "Custom Card", then this did not work.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

