### PR TITLE
Remove “Custom Card” from JournalTaskTypes

### DIFF
--- a/db/migrate/20170817150242_remove_custom_card_from_journal_task_types.rb
+++ b/db/migrate/20170817150242_remove_custom_card_from_journal_task_types.rb
@@ -1,0 +1,3 @@
+class RemoveCustomCardFromJournalTaskTypes < DataMigration
+  RAKE_TASK_UP = 'data:migrate:aperta_11027_remove_custom_card_from_journal_task_types'.freeze
+end

--- a/lib/tasks/data-migrations/APERTA_11027_remove_custom_card_from_journal_task_types.rake
+++ b/lib/tasks/data-migrations/APERTA_11027_remove_custom_card_from_journal_task_types.rake
@@ -1,0 +1,25 @@
+namespace :data do
+  namespace :migrate do
+    desc <<-DESC
+      APERTA-11027: Remove "Custom Card" from the card picker in the admin workflow editor
+
+      After the CustomCardTask model was added to the codebase, "rake data:update_journal_task_types"
+      would ensure that a corresponding JournalTaskType row was added. Release 1.47 fixes the rake
+      task so that it no longer attempts to add rows for CustomCardTask, however the old row still
+      needs to be deleted so that "Custom Card" stops appearing in the picker.
+    DESC
+
+    task aperta_11027_remove_custom_card_from_journal_task_types: :environment do
+      tasks = JournalTaskType.where(title: "Custom Card")
+      if tasks.empty?
+        raise Exception, "No matching journal task types were found."
+      end
+      JournalTaskType.transaction do
+        tasks.each(&:delete)
+        if JournalTaskType.where(title: "Custom Card").count > 0
+          raise Exception "Failed to delete Custom Cards from JournalTaskTypes"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
APERTA-11027

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11027

#### What this PR does:

The card picker currently has an errant “Custom Card” option under staff
cards, which this data migration removes. Release 1.47 includes a patch
to prevent this task type from being re-added.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I need to migrate existing data:
- [x] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [x] I verified the data-migration's results on a copy of production data (complicated migrations should also have real specs)
- [x] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [x] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

