### PR TITLE
Implement TinyMCE for email templates

### DIFF
--- a/client/app/pods/components/admin-page/email-templates/edit/component.js
+++ b/client/app/pods/components/admin-page/email-templates/edit/component.js
@@ -5,13 +5,15 @@ import Ember from 'ember';
 // new templates.
 
 export default Ember.Component.extend({
-  store: Ember.inject.service(),
   routing: Ember.inject.service('-routing'),
   disabled: Ember.computed('template.subject', 'template.body', function() {
     return !this.get('template.subject') || !this.get('template.body');
   }),
   unsaved: true,
   actions: {
+    onInputCallback: function(body){
+      this.set('template.body', body);
+    },
     save: function() {
       if (this.get('disabled') || this.get('template.isSaving')) {
         this.set('unsaved', false);

--- a/client/app/pods/components/admin-page/email-templates/edit/template.hbs
+++ b/client/app/pods/components/admin-page/email-templates/edit/template.hbs
@@ -18,7 +18,11 @@
     </div>
     <div class="form-group {{unless (or unsaved template.body) 'error'}}">
       <label for="body" class="text-bold">Body:</label>
-      {{textarea id="body" class="form-control" value=template.body autoresize=true}}
+      {{rich-text-editor
+        ident="body"
+        editorStyle='expanded'
+        value=template.body
+        onContentsChanged=(action "onInputCallback")}}
       {{#unless (or unsaved template.body)}}
         <span>{{fa-icon 'warning'}} Please enter body text</span>
       {{/unless}}

--- a/client/tests/integration/pods/components/admin-page/email-templates/edit/component-test.js
+++ b/client/tests/integration/pods/components/admin-page/email-templates/edit/component-test.js
@@ -4,6 +4,8 @@ import FactoryGuy from 'ember-data-factory-guy';
 import { manualSetup } from 'ember-data-factory-guy';
 import sinon from 'sinon';
 import Ember from 'ember';
+import {getRichText, setRichText} from 'tahi/tests/helpers/rich-text-editor-helpers';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('admin-page/email-templates/edit',
   'Integration | Component | Admin Page | Email Templates | Edit', {
@@ -17,7 +19,7 @@ moduleForComponent('admin-page/email-templates/edit',
 test('it populates input fields with model data', function(assert) {
   assert.expect(2);
 
-  let template = FactoryGuy.make('letter-template', {subject: 'foo', body: 'bar'});
+  let template = FactoryGuy.make('letter-template', {subject: 'foo', body: '<p>bar</p>'});
 
   this.set('template', template);
 
@@ -25,7 +27,7 @@ test('it populates input fields with model data', function(assert) {
     {{admin-page/email-templates/edit template=template}}
   `);
   assert.equal(this.$('#subject').val(), template.get('subject'));
-  assert.equal(this.$('#body').val(), template.get('body'));
+  assert.equal(getRichText('body'), template.get('body'));
 });
 
 test('it prevents the model from saving if a field is blank and displays validation errors', function(assert){
@@ -61,11 +63,14 @@ test('model receives save call when valid', function(assert){
     {{admin-page/email-templates/edit template=template}}
   `);
 
-  Ember.run(() => {
-    this.$('#body').val('baz').trigger('input');
+  setRichText('body', 'text');
+
+  let done = assert.async();
+  wait().then(() => {
     this.$('.button-primary').click();
+    assert.ok(template.save.called);
+    done();
   });
-  assert.equal(template.save.called, true);
 });
 
 test('after attempted save it dynamically warns user if input field has invalid content', function(assert) {


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10882

#### What this PR does:

This changes the input for editing email template bodies from text-area to tinyMCE. It doesn't seem to affect the text being saved, besides stripping out the whitespace, which seems fine unless i'm mistaken.

#### Special instructions for Review or PO:

Not much.

#### Notes

Testing this mean jumping through async hoops

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

