### PR TITLE
APERTA-9432-transitioned-toolbar-item-to-paper-index-page

### DIFF
--- a/client/app/pods/components/paper-control-bar/component.js
+++ b/client/app/pods/components/paper-control-bar/component.js
@@ -51,6 +51,7 @@ export default ControlBar.extend({
       if (this.get('submenuVisible') && this.get(`${sectionName}Visible`)) {
         this.resetSubmenuFlags();
         this.set('submenuVisible', false);
+        this.get('transitionToPaperIndex')();
       } else {
         this.showSection(sectionName);
       }

--- a/client/app/pods/paper/versions/template.hbs
+++ b/client/app/pods/paper/versions/template.hbs
@@ -45,6 +45,7 @@
                     comparisonVersion=comparisonVersion
                     submenuVisible=true
                     setQueryParam=(action "setQueryParam")
+                    transitionToPaperIndex=(route-action "exitVersions")
                     supportedDownloadFormats=supportedDownloadFormats
                     versioningMode=true
                     versionsVisible=true}}


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9432

#### What this PR does:

A blank space is left between the title and the PDF viewer after closing the "Versions" link by clicking on it. This PR solves the issue by using the same behaviour exhibited by the close button.

#### Notes

The close button return the page back to the paper.index page. To fix this, the link also returns back to the paper.index page.
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results on a copy of production data (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

