### PR TITLE
Empowerment: only serialize required-field for inputs

### DIFF
--- a/app/models/card_content.rb
+++ b/app/models/card_content.rb
@@ -121,7 +121,6 @@ class CardContent < ActiveRecord::Base
         'ident' => ident,
         'content-type' => content_type,
         'value-type' => value_type,
-        'required-field' => required_field,
         'visible-with-parent-answer' => visible_with_parent_answer,
         'default-answer-value' => default_answer_value
       }.merge(additional_content_attrs).compact
@@ -133,7 +132,8 @@ class CardContent < ActiveRecord::Base
       {
         'allow-multiple-uploads' => allow_multiple_uploads,
         'allow-file-captions' => allow_file_captions,
-        'allow-annotations' => allow_annotations
+        'allow-annotations' => allow_annotations,
+        'required-field' => required_field
       }
     when 'if'
       {
@@ -142,11 +142,17 @@ class CardContent < ActiveRecord::Base
     when 'short-input', 'paragraph-input'
       {
         'editor-style' => editor_style,
-        'allow-annotations' => allow_annotations
+        'allow-annotations' => allow_annotations,
+        'required-field' => required_field
       }
     when 'radio', 'check-box', 'dropdown', 'tech-check'
       {
-        'allow-annotations' => allow_annotations
+        'allow-annotations' => allow_annotations,
+        'required-field' => required_field
+      }
+    when 'date-picker'
+      {
+        'required-field' => required_field
       }
     else
       {}


### PR DESCRIPTION


This PR makes sure that the required-field attribute only gets rendered
into the xml for content types that have a 'required-field' attribute
present in the card.rnc file
before (look at 'display-children'):
![screen shot 2017-08-22 at 10 08 44 am](https://user-images.githubusercontent.com/2043348/29570496-9a188c0e-8724-11e7-9a7f-a052f1432c75.png)

after:
![screen shot 2017-08-22 at 10 27 57 am](https://user-images.githubusercontent.com/2043348/29570510-a94b30f0-8724-11e7-9982-f11f1f8b0053.png)
