### PR TITLE
APERTA-10881 Discussion Participant is an MS role

### DIFF
--- a/app/services/journal_factory.rb
+++ b/app/services/journal_factory.rb
@@ -507,7 +507,7 @@ class JournalFactory
       end
     end
 
-    Role.ensure_exists(Role::DISCUSSION_PARTICIPANT, journal: @journal) do |role|
+    Role.ensure_exists(Role::DISCUSSION_PARTICIPANT, journal: @journal, participates_in: [Paper]) do |role|
       role.ensure_permission_exists(:be_at_mentioned, applies_to: DiscussionTopic)
       role.ensure_permission_exists(:reply, applies_to: DiscussionTopic)
       role.ensure_permission_exists(:view, applies_to: DiscussionTopic)


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10881

#### What this PR does:

Previously, the Discussion Participant did not participate in Paper nor
Task. This made it a journal-level role. This scoping makes sure it's
properly scoped as a manuscript role, and makes it easier to recognize
journal-level roles.

This should not change anything with the permissions since permissions
are checked against the assignments table. All permissions in the
Discussion Participant role already apply to a Discussion Topic.

#### Notes

I changed something in journal_factory. Scoped the DiscussionParticipant role under paper to distinguish it from journal-level roles which it is not. 
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

