### PR TITLE
APERTA-10626 missing abstract status line in invitation emails

### DIFF
--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/paper_reviewer_task.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/paper_reviewer_task.rb
@@ -62,7 +62,7 @@ module TahiStandardTasks
     def invitation_body_template
       template = <<-TEXT.strip_heredoc
 <p>You've been invited as a Reviewer on "{{ manuscript.title }}", for {{ journal.name }}.</p>
-<p>The abstract is included below. We would ideally like to have reviews returned to us within {{ invitation.due_in_days | default 10}} days. If you require additional time, please do let us know so that we may plan accordingly.</p>
+<p>The abstract is included below. We would ideally like to have reviews returned to us within {{ invitation.due_in_days | default: 10}} days. If you require additional time, please do let us know so that we may plan accordingly.</p>
 <p>Please only accept this invitation if you have no conflicts of interest. If in doubt, please feel free to contact us for advice. If you are unable to review this manuscript, we would appreciate suggestions of other potential reviewers.</p>
 <p>We look forward to hearing from you.</p>
 <p>Sincerely,</p>
@@ -76,7 +76,7 @@ module TahiStandardTasks
 {{ forloop.index }}. {{ author.last_name }}, {{ author.first_name }}<br>
 {% endfor %}</p>
 <p>Abstract:<br>
-{{ manuscript.abstract | default 'Abstract is not available' }}</p>
+{{ manuscript.abstract | default: 'Abstract is not available' }}</p>
 TEXT
       # Note that this will become a LetterTemplate. When that
       # happens, the rendering part below simplifies to a call on the


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10626

#### What this PR does:

This PR ensures that we are adding missing abstract to invitation emails or defaulting to 'Abstract not available if not'. Noticed the bug affected the number of days as well and fixed it.

We were not using the correct liquid syntax for default string, all it took was one colon and 3 days ... (fun times) 


#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

