### PR TITLE
Use redirect stored in session rather than cas callback url param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,7 +79,7 @@ class ApplicationController < ActionController::Base
 
   # to redirect a user to the requested page after login
   def store_location_for_login_redirect
-    store_location_for(:user, request.referer)
+    store_location_for(:user, request.url) if session["user_return_to"].blank?
   end
 
   def cas_logout_url

--- a/app/controllers/tahi_devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/tahi_devise/omniauth_callbacks_controller.rb
@@ -20,8 +20,6 @@ module TahiDevise
       user.ned_id = ned[:nedId]
       user.auto_generate_password
       user.save!
-      # now supports redirect urls with q params
-      store_location_for(:user, params[:url])
 
       sign_in_and_redirect(user, event: :authentication)
     end

--- a/app/controllers/token_invitations_controller.rb
+++ b/app/controllers/token_invitations_controller.rb
@@ -134,6 +134,7 @@ class TokenInvitationsController < ApplicationController
       cas_uri = URI.parse(TahiEnv.cas_phased_signup_url)
 
       cas_uri.query = { token: jwt_encoded_payload }.to_query
+      store_location_for(:user, akita_invitation_accept_url(new_user: true))
       redirect_to cas_uri.to_s
     end
   end

--- a/spec/controllers/token_invitations_controller_spec.rb
+++ b/spec/controllers/token_invitations_controller_spec.rb
@@ -385,8 +385,11 @@ describe TokenInvitationsController do
           expect_any_instance_of(TahiEnv).to receive(:cas_phased_signup_url).and_return(dummy_cas_url)
           expect(OpenSSL::PKey::EC).to receive(:new).and_return(dummy_key)
         end
-        it 'redirects user to akita host with only a token param' do
+        it 'sets the redirect session value and redirects user to akita host with only a token param' do
           do_request
+          stored_uri = URI(controller.send(:akita_invitation_accept_url, new_user: true))
+          # stored_location_for retrieves path and query params
+          expect(controller.send(:stored_location_for, :user)).to eq("#{stored_uri.path}?#{stored_uri.query}")
           redirect_uri = URI.parse(response['Location'])
           expect(redirect_uri.host).to eq(URI.parse(dummy_cas_url).host)
           expect(redirect_uri.query.starts_with?('token=')).to be true


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10953

Okay, bit of a mea culpa here, and some explanation:

On my initial implementation of #3152 I was looking at the cas callback and when `TahiDevise::OmniauthCallbacksController#cas` was being executed, it seemed strip out my `?new_user=true` from the redirect `params[:url]` and it was a real head scratcher. It turned out that `params[:url]` doesn't get used at all and instead it was being retrieved from `stored_location_for` (see [here](https://github.com/plataformatec/devise/blob/88724e10adaf9ffd1d8dbfbaadda2b9d40de756a/lib/devise/controllers/store_location.rb#L16). That `url` query param threw me off coming from an OAuth background, I assumed it was our redirect. The missing query param issue was due to it being set in `before_action :store_location_for_login_redirect, unless: :devise_controller?` at the `ApplicationController` level. 

tagging @noxmwalsh @egh @sgatchell to make sure i'm not digging myself a deeper hole, also I'm still testing it on my machine, will remove wip tag when its verified as working locally.

#### What this PR does:

It reverts changes from #3348 and changes to `TahiDevise::OmniauthCallbacksController#cas` from #3152 and implements the redirect for the phased login with the `store_location_for` method. 

#### Special instructions for Review or PO:

This requires cas to be setup. 

DEV: grep whatever env vars have CAS or NED from aperta@aperta-frontend-201:/var/www/tahi/current/env

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases