### PR TITLE
Display Similarity Checks that are still pending

### DIFF
--- a/engines/tahi_standard_tasks/client/app/templates/components/similarity-check-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/similarity-check-task.hbs
@@ -34,7 +34,7 @@
     <br>
   {{/unless}}
 
-  {{#if latestVersionHasSuccessfulChecks}}
+  {{#if latestVersionHasChecks}}
     <div class="latest-versioned-text">
       <h3>Similarity Check Report</h3>
 

--- a/engines/tahi_standard_tasks/client/test-support/integration/components/tasks/similarity-check-task-test.js
+++ b/engines/tahi_standard_tasks/client/test-support/integration/components/tasks/similarity-check-task-test.js
@@ -38,6 +38,22 @@ var paperStub = {
   manuallySimilarityChecked: false
 };
 
+var paperWithIncompleteCheck = {
+  title: 'Paper title',
+  abstract: 'Paper abstract',
+  editable: true,
+  manuallySimilarityChecked: false,
+  latestVersionedText: {
+    id: 1,
+    similarityChecks: [{
+      id: 1,
+      versioned_text_id: 1,
+      state: 'needs_upload',
+      incomplete: true
+    }]
+  }
+};
+
 moduleForComponent(
   'similarity-check-task',
   'Integration | Components | Tasks | Similarity Check Task',
@@ -103,4 +119,10 @@ test('proper state for auto check off via admin', function(assert) {
     '.auto-report-off',
     'report status disapears on confirm'
   );
+});
+
+test('Incomplete Similarity Check renders', function(assert) {
+  let task = newTask(false, paperWithIncompleteCheck);
+  setupEditableTask(this, task);
+  assert.elementFound('.similarity-check');
 });


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11080

#### What this PR does:

This reverts SimilarityCheckTask behavior to showing checks that have not yet
completed. This was inadvertently changed in 972db887fcaddbdfd4b842f57bda1bf116e0bc6c to only show checks for the current version that were successful.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

