### PR TITLE
APERTA-11090 Use latest published version for snapshots

### DIFF
--- a/app/models/card_version.rb
+++ b/app/models/card_version.rb
@@ -18,6 +18,7 @@ class CardVersion < ActiveRecord::Base
   has_one :content_root, -> { roots }, class_name: 'CardContent'
   scope :required_for_submission, -> { where(required_for_submission: true) }
   scope :published, -> { where.not(published_at: nil) }
+  scope :unpublished, -> { where(published_at: nil) }
 
   validates_uniqueness_of_without_deleted :version,
     scope: :card_id,

--- a/app/serializers/snapshot/base_serializer.rb
+++ b/app/serializers/snapshot/base_serializer.rb
@@ -62,10 +62,8 @@ class Snapshot::BaseSerializer
   # without idents, but for now it's been changed around to keep the same
   # semantics as it had with nested questions
   def snapshot_card_content
-    if model.try(:card).present?
-      card_contents = model.card
-                           .content_root_for_version(:latest)
-                           .children.order('lft')
+    if model.try(:card_version).present?
+      card_contents = model.card_version.content_root.children.order('lft')
 
       card_contents.map do |question|
         Snapshot::CardContentSerializer.new(question, model).as_json

--- a/spec/factories/card_factory.rb
+++ b/spec/factories/card_factory.rb
@@ -36,7 +36,12 @@ FactoryGirl.define do
       after(:build) do |card|
         card.state = "published_with_changes"
         card.card_versions << build(:card_version, version: card.latest_version, published_at: Time.current, history_entry: "entry") if card.card_versions.count.zero?
-        card.card_versions << build(:card_version, version: card.latest_version + 1, published_at: nil)
+        # TODO: we should probably remove :latest_version from Card all
+        # together. currently the XMLCardLoader handles incrementing it, which
+        # is just an opportunity to let it get out of sync with the actual
+        # latest CardVersion.version.
+        card.increment(:latest_version)
+        card.card_versions << build(:card_version, version: card.latest_version, published_at: nil)
       end
     end
 

--- a/spec/serializers/snapshot/base_serializer_spec.rb
+++ b/spec/serializers/snapshot/base_serializer_spec.rb
@@ -25,4 +25,27 @@ describe Snapshot::BaseSerializer do
       ])
     end
   end
+
+  context "with multiple versions" do
+    subject(:serializer) { Snapshot::BaseSerializer.new(model) }
+
+    # task with card that has two different card versions,
+    # one that is published, one that is draft
+    let(:card) { FactoryGirl.create(:card, :published_with_changes) }
+    let(:published_card_version) { card.card_versions.published.first }
+    let(:unpublished_card_version) { card.card_versions.unpublished.first }
+    let!(:unpublished_child) { FactoryGirl.create(:card_content, card_version: unpublished_card_version, parent: unpublished_card_version.content_root) }
+    let!(:published_child) { FactoryGirl.create(:card_content, card_version: published_card_version, parent: published_card_version.content_root) }
+
+    # custom card task where the card version it is using is the published one
+    let(:model) { FactoryGirl.create(:custom_card_task, card_version: published_card_version) }
+
+    it "snapshots only the latest published version" do
+      aggregate_failures do
+        expect(serializer.as_json[:children].length).to eq(2)
+        expect(serializer.as_json[:children][0][:name]).to eq(published_child.ident)
+        expect(serializer.as_json[:children][1][:name]).to eq("id")
+      end
+    end
+  end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11090

#### What this PR does:

When serializing any model children for snapshotting, ensure that the latest published version is used (not just the latest version).  This fixes a nasty bug where a Card has an unpublished version that is being mistakenly picked up by the serializer.

See the JIRA ticket for more detail and testing procedures.

#### Notes

Until this PR gets merged, if an admin makes xml changes to a card that is currently being used, but does not publish them, the snapshot diffs for that card will be wrong.

---

#### Code Review Tasks:

**Author tasks** =

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases