### PR TITLE
APERTA-11052: Align radio buttons in Competing Interests

### DIFF
--- a/app/assets/stylesheets/components/card-content/radio.scss
+++ b/app/assets/stylesheets/components/card-content/radio.scss
@@ -2,6 +2,7 @@
   margin-top: 15px;
   .option {
     display: block;
+    margin-left: 2.7rem;
     input {
       margin: 0px 5px;
       vertical-align: -1px;


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11052

#### What this PR does:

It adds left margin to radio buttons in card-content/radio.

#### Major UI changes
No major UI changes, just make sure the radio buttons under the Competing Interests tasks are align with the text.

![radio-buttons](https://user-images.githubusercontent.com/30911/29672106-ecef3472-88b0-11e7-8ebc-6ed804eab954.png)

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

