### PR TITLE
Generator creates configuration without migration

### DIFF
--- a/lib/generators/custom_card/configuration/USAGE
+++ b/lib/generators/custom_card/configuration/USAGE
@@ -7,7 +7,7 @@ Syntax:
   rails generate custom_card:configuration "TITLE OF NEW CARD" [legacy task class name]
 
 Example:
-    rails generate custom_card "My New Cover Letter" TahiStandardTasks::CoverLetterTask
+    rails generate custom_card:configuration "My New Cover Letter" TahiStandardTasks::CoverLetterTask
 
     This will create:
         lib/custom_card/configurations/my_new_cover_letter.rb

--- a/lib/generators/custom_card/configuration/configuration_generator.rb
+++ b/lib/generators/custom_card/configuration/configuration_generator.rb
@@ -17,12 +17,14 @@ module CustomCard
     end
 
     def warn_if_missing_production_data
-      return if legacy_task_klass_name.blank? && production_data_loaded?
+      return unless migrating_legacy_task?
+      return if production_data_loaded?
       die if no?("You do not curently have production data loaded.  Existing permissions will not be derived.  Want to continue?")
     end
 
     def exit_if_non_existent_legacy_task_klass
-      return if legacy_task_klass_name.blank? && legacy_task_exists?
+      return unless migrating_legacy_task?
+      return if legacy_task_exists?
       die("Could not find a Task with type '#{legacy_task_klass_name}'.  Ensure correct spelling and namespace.")
     end
 
@@ -36,6 +38,10 @@ module CustomCard
     end
 
     private
+
+    def migrating_legacy_task?
+      legacy_task_klass_name.present?
+    end
 
     def production_data_loaded?
       User.count > 100


### PR DESCRIPTION
#### What this PR does:

Prior to this bug fix, the custom_card:configuration rails generator did not
handle the ability to create a new `CustomCard::Configuration` file
which did not have a corresponding legacy Task that is being migrated.

This bug was introduced by @surfacedamage as part of this PR:
https://github.com/Tahi-project/tahi/pull/3355

To review, be sure that both of the following generator statements can be run successfully.

This will create just a configuration file:
```
rails generate custom_card:configuration "My New Card"
```

This will create both a configuration file and a migration:
```
rails generate custom_card:configuration "My Custom Data Availability Card" TahiStandardTasks::DataAvailabilityTask
```

---

#### Code Review Tasks:

**Reviewer tasks**
- [x] I ran the code (in the review environment or locally)
- [ ] I read the code; it looks good


