### PR TITLE
Correct schema date

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170832210046) do
+ActiveRecord::Schema.define(version: 20170823210046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
I had to manually rename a migration in 6eefcb93630a87c259338a2952522c48582bc44e
and I screwed up the schema date.
