### PR TITLE
APERTA-11102 Revert TinyMCE in email template admin form

### DIFF
--- a/client/app/pods/components/admin-page/email-templates/edit/component.js
+++ b/client/app/pods/components/admin-page/email-templates/edit/component.js
@@ -5,15 +5,13 @@ import Ember from 'ember';
 // new templates.
 
 export default Ember.Component.extend({
+  store: Ember.inject.service(),
   routing: Ember.inject.service('-routing'),
   disabled: Ember.computed('template.subject', 'template.body', function() {
     return !this.get('template.subject') || !this.get('template.body');
   }),
   unsaved: true,
   actions: {
-    onInputCallback: function(body){
-      this.set('template.body', body);
-    },
     save: function() {
       if (this.get('disabled') || this.get('template.isSaving')) {
         this.set('unsaved', false);

--- a/client/app/pods/components/admin-page/email-templates/edit/template.hbs
+++ b/client/app/pods/components/admin-page/email-templates/edit/template.hbs
@@ -18,11 +18,7 @@
     </div>
     <div class="form-group {{unless (or unsaved template.body) 'error'}}">
       <label for="body" class="text-bold">Body:</label>
-      {{rich-text-editor
-        ident="body"
-        editorStyle='expanded'
-        value=template.body
-        onContentsChanged=(action "onInputCallback")}}
+      {{textarea id="body" class="form-control" value=template.body autoresize=true}}
       {{#unless (or unsaved template.body)}}
         <span>{{fa-icon 'warning'}} Please enter body text</span>
       {{/unless}}

--- a/client/tests/integration/pods/components/admin-page/email-templates/edit/component-test.js
+++ b/client/tests/integration/pods/components/admin-page/email-templates/edit/component-test.js
@@ -4,8 +4,6 @@ import FactoryGuy from 'ember-data-factory-guy';
 import { manualSetup } from 'ember-data-factory-guy';
 import sinon from 'sinon';
 import Ember from 'ember';
-import {getRichText, setRichText} from 'tahi/tests/helpers/rich-text-editor-helpers';
-import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('admin-page/email-templates/edit',
   'Integration | Component | Admin Page | Email Templates | Edit', {
@@ -19,7 +17,7 @@ moduleForComponent('admin-page/email-templates/edit',
 test('it populates input fields with model data', function(assert) {
   assert.expect(2);
 
-  let template = FactoryGuy.make('letter-template', {subject: 'foo', body: '<p>bar</p>'});
+  let template = FactoryGuy.make('letter-template', {subject: 'foo', body: 'bar'});
 
   this.set('template', template);
 
@@ -27,7 +25,7 @@ test('it populates input fields with model data', function(assert) {
     {{admin-page/email-templates/edit template=template}}
   `);
   assert.equal(this.$('#subject').val(), template.get('subject'));
-  assert.equal(getRichText('body'), template.get('body'));
+  assert.equal(this.$('#body').val(), template.get('body'));
 });
 
 test('it prevents the model from saving if a field is blank and displays validation errors', function(assert){
@@ -63,14 +61,11 @@ test('model receives save call when valid', function(assert){
     {{admin-page/email-templates/edit template=template}}
   `);
 
-  setRichText('body', 'text');
-
-  let done = assert.async();
-  wait().then(() => {
+  Ember.run(() => {
+    this.$('#body').val('baz').trigger('input');
     this.$('.button-primary').click();
-    assert.ok(template.save.called);
-    done();
   });
+  assert.equal(template.save.called, true);
 });
 
 test('after attempted save it dynamically warns user if input field has invalid content', function(assert) {


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11102

#### What this PR does:

Reverts the email template admin form back to a textarea from a TinyMCE form.  A WYSIWYG editor turned out to be inappropriate for editing templates with liquid control flow tags embedded.

This reverts https://github.com/Tahi-project/tahi/pull/3367
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

