### PR TITLE
APERTA-10414-continuation-of-previous-work-for-front-matter-reviewer-…

### DIFF
--- a/client/app/pods/components/card-preview/component.js
+++ b/client/app/pods/components/card-preview/component.js
@@ -67,7 +67,7 @@ export default Ember.Component.extend({
 
   notReviewerReportTask: Ember.computed('task', function() {
     let taskType = this.get('task.type');
-    return taskType !== 'ReviewerReportTask';
+    return (taskType !== 'ReviewerReportTask') && (taskType !== 'FrontMatterReviewerReportTask');
   }),  
 
   showDeleteButton: Ember.computed.and('canRemoveCard', 'notReviewerReportTask'),

--- a/client/tests/components/card-preview-test.js
+++ b/client/tests/components/card-preview-test.js
@@ -77,6 +77,23 @@ test('no delete button display for reviewer card, even if canRemoveCard is true'
   });
 });
 
+test('no delete button display for Front Matter reviewer card, even if canRemoveCard is true', function(assert) {
+  this.set('task', {
+    title: 'Review by Reviewer User',
+    type: 'FrontMatterReviewerReportTask',
+  });
+  assert.expect(2);
+
+  this.render(hbs`
+    {{card-preview task=task canRemoveCard=true}}
+  `);
+
+  Ember.run(this, function() {
+    assert.textPresent('span.card-title', 'Review by Reviewer User');
+    assert.equal(this.$('.task-disclosure-heading .card-remove').length, 0);
+  });
+});
+
 test('delete button display for any other type of task', function(assert) {
   this.set('task', {
     type: 'AuthorsTask',


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10414

#### What this PR does:

This is a hot fix from previous https://github.com/Tahi-project/tahi/pull/3333 - It addresses hiding the delete button on Front Matter Reviewer Reports card.
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

