### PR TITLE
APERTA-10963 preprint doi in paper tracker requires flag

### DIFF
--- a/client/app/pods/paper-tracker/index/controller.js
+++ b/client/app/pods/paper-tracker/index/controller.js
@@ -20,6 +20,8 @@ export default Ember.Controller.extend({
   // true when naming a new saved query
   newQueryState: false,
   newQueryTitle: '',
+  featureFlag: Ember.inject.service(),
+  preprintsEnabled: Ember.computed.equal('featureFlag.PREPRINT', true),
 
   actions: {
     setPage(page) {

--- a/client/app/pods/paper-tracker/index/template.hbs
+++ b/client/app/pods/paper-tracker/index/template.hbs
@@ -41,13 +41,15 @@
                           activeOrderDir=orderDir
                           sortAction=(action "sort")}}
             </th>
-            <th class="paper-tracker-paper-preprint-id-column">
-              {{sort-link text="Manuscript Preprint ID"
-                          orderBy="preprint_doi_article_number"
-                          activeOrderBy=orderBy
-                          activeOrderDir=orderDir
-                          sortAction=(action "sort")}}
-            </th>
+            {{#if preprintsEnabled}}
+              <th class="paper-tracker-paper-preprint-id-column">
+                {{sort-link text="Pre-print DOI"
+                            orderBy="preprint_doi_article_number"
+                            activeOrderBy=orderBy
+                            activeOrderDir=orderDir
+                            sortAction=(action "sort")}}
+              </th>
+            {{/if}}
             <th class="paper-tracker-date-column">
               {{sort-link text="Version Date"
                           orderBy="submitted_at"
@@ -116,7 +118,7 @@
     <h3>Saved Searches</h3>
     <ul>
     {{#each paperTrackerQueries as |query|}}
-      <li>{{paper-tracker-query query=query}}</li>
+      <li>{{paper-tracker-query query=query preprintsEnabled=preprintsEnabled}}</li>
     {{/each}}
 
     {{#if newQueryState}}

--- a/client/app/pods/paper-tracker/row/template.hbs
+++ b/client/app/pods/paper-tracker/row/template.hbs
@@ -13,9 +13,11 @@
   <td class="paper-tracker-paper-id-column">
     {{link-to paper.manuscript_id "paper.index" paper.shortDoi}}
   </td>
-  <td class="paper-tracker-paper-preprint-id-column">
-    {{link-to paper.aarxDoi "paper.index" paper.shortDoi}}
-  </td>
+  {{#if preprintsEnabled}}
+    <td class="paper-tracker-paper-preprint-id-column">
+      {{link-to paper.aarxDoi "paper.index" paper.shortDoi}}
+    </td>
+  {{/if}}
   <td class="paper-tracker-date-column paper-version-date">
     {{format-date paper.submittedAt}}<br>
     {{relative-time time=paper.submittedAt}}

--- a/client/tests/integration/paper-tracker-test.js
+++ b/client/tests/integration/paper-tracker-test.js
@@ -45,6 +45,7 @@ module('Integration: Paper Tracker', {
     Factory.resetFactoryIds();
     App = startApp();
     server = setupMockServer();
+    $.mockjax({url: '/api/feature_flags.json', status: 200, responseText: {PREPRINT: true}});
     $.mockjax({url: '/api/paper_tracker', status: 200, responseText: payload});
     $.mockjax({url: '/api/paper_tracker_queries', status: 200, responseText: PTSortQuery});
     $.mockjax({url: '/api/admin/journals/authorization', status: 204});
@@ -101,6 +102,9 @@ test('viewing papers', function(assert) {
     );
 
     assert.elementNotFound('.paper-tracker-date-column .fa-caret-up', 'No sort is applied before using saved query');
+    assert.elementNotFound('th .paper-tracker-paper-preprint-id-column', 'Preprint doi column header is hidden without flag present');
+    assert.elementNotFound('td .paper-tracker-paper-preprint-id-column', 'Preprint doi column is hidden without flag present');
+
     click('#paper-tracker-saved-searches a');
 
     andThen(function() {


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10963

#### What this PR does:

At /paper_tracker the preprint doi column is now hidden unless the corresponding preprint flag is checked


#### Special instructions for Review or PO:

Toggle the flag checkbox, view the column


#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

