### PR TITLE
Flaky spec fixes

### DIFF
--- a/spec/services/journal_factory_spec.rb
+++ b/spec/services/journal_factory_spec.rb
@@ -20,7 +20,7 @@ describe JournalFactory do
                   'edit_discussion_footer'].freeze
 
   def without_anonymous_classes(klasses)
-    klasses.select { |klass| klass.name.present? && klass.name != 'MetadataTestTask' && klass.name != 'InvitableTestTask' && klass.name != 'QueryParserSpec::FictionalReport' }
+    klasses.select { |klass| klass.name.present? && klass.name != 'MetadataTestTask' && klass.name != 'InvitableTestTask' && klass.name != 'QueryParserSpec::FictionalReport' && klass.name != 'ScheduledEventTestTask' }
   end
 
   describe '.create' do


### PR DESCRIPTION
JIRA issue: none

#### What this PR does:

Fixes a flaky spec

```
rspec ./spec/models/card_content_spec.rb[1:2:1] ./spec/services/journal_factory_spec.rb[1:1:4:13:1:1] -p 30 -t ~js --format doc --seed 20208
```

And also:
```
rspec --format doc ./spec/services/journal_factory_spec.rb[1:1:4:5:2:1,1:1:4:5:2:2,1:1:4:9:2:1,1:1:4:9:2:2,1:1:4:10:3:1,1:1:4:11:3:1,1:1:4:12:3:1,1:1:4:15:4:1] ./spec/services/scheduled_events_factory_spec.rb[1:1:3:2:2:1] -p 30 -t ~js --format doc --seed 64287
```
---

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] ~I read through the JIRA ticket's AC before doing the rest of the review~
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

