### PR TITLE
Remove need for alias

### DIFF
--- a/app/models/reviewer_report.rb
+++ b/app/models/reviewer_report.rb
@@ -104,7 +104,7 @@ class ReviewerReport < ActiveRecord::Base
     Card.find_by(name: name)
   end
 
-  def computed_status
+  def status
     case aasm.current_state
     when STATE_INVITATION_NOT_ACCEPTED
       compute_invitation_state
@@ -116,8 +116,8 @@ class ReviewerReport < ActiveRecord::Base
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  def computed_datetime
-    case computed_status
+  def datetime
+    case status
     when "pending"
       invitation.accepted_at
     when "invitation_invited"
@@ -135,7 +135,6 @@ class ReviewerReport < ActiveRecord::Base
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def display_status
-    status = computed_status
     inactive = ["not_invited", "invitation_declined", "invitation_rescinded"]
     return :minus if inactive.include? status
     return :active_check if status == "completed"

--- a/app/models/reviewer_report_context.rb
+++ b/app/models/reviewer_report_context.rb
@@ -5,14 +5,7 @@ class ReviewerReportContext < TemplateContext
      { name: :answers, context: AnswerContext, many: true }]
   end
 
-  def self.blacklisted_merge_fields
-    [:computed_status, :computed_datetime]
-  end
-
-  whitelist :state, :revision, :computed_status, :computed_datetime, :invitation_accepted?, :due_at
-
-  alias status computed_status
-  alias datetime computed_datetime
+  whitelist :state, :revision, :status, :datetime, :invitation_accepted?, :due_at
 
   def reviewer
     UserContext.new(@object.user)

--- a/app/serializers/reviewer_report_serializer.rb
+++ b/app/serializers/reviewer_report_serializer.rb
@@ -20,10 +20,10 @@ class ReviewerReportSerializer < ActiveModel::Serializer
   end
 
   def status
-    object.computed_status
+    object.status
   end
 
   def status_datetime
-    object.computed_datetime
+    object.datetime
   end
 end

--- a/spec/models/reviewer_report_spec.rb
+++ b/spec/models/reviewer_report_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 describe ReviewerReport do
   subject(:paper) { FactoryGirl.create(:paper, :submitted_lite) }
   subject(:task) { FactoryGirl.create(:reviewer_report_task, paper: paper) }
@@ -67,36 +68,36 @@ describe ReviewerReport do
     end
   end
 
-  describe "#computed_status" do
+  describe "#status" do
     it "has status 'not_invited' without an invitation" do
-      expect(subject.computed_datetime).to be_nil
-      expect(subject.computed_status).to eq("not_invited")
+      expect(subject.datetime).to be_nil
+      expect(subject.status).to eq("not_invited")
     end
 
     it "has status 'invitation_invited' if invited" do
       add_invitation(:invited)
-      expect(subject.computed_datetime).to eq(subject.invitation.invited_at)
-      expect(subject.computed_status).to eq("invitation_invited")
+      expect(subject.datetime).to eq(subject.invitation.invited_at)
+      expect(subject.status).to eq("invitation_invited")
     end
 
     it "has status 'invitation_declined' if declined" do
       add_invitation(:declined)
-      expect(subject.computed_datetime).to eq(subject.invitation.declined_at)
-      expect(subject.computed_status).to eq("invitation_declined")
+      expect(subject.datetime).to eq(subject.invitation.declined_at)
+      expect(subject.status).to eq("invitation_declined")
     end
 
     it "has status 'invitation_rescinded' if rescinded" do
       add_invitation(:rescinded)
-      expect(subject.computed_datetime).to eq(subject.invitation.rescinded_at)
-      expect(subject.computed_status).to eq("invitation_rescinded")
+      expect(subject.datetime).to eq(subject.invitation.rescinded_at)
+      expect(subject.status).to eq("invitation_rescinded")
     end
 
     it "has status 'pending' if invite accepted" do
       add_invitation(:accepted)
       subject.accept_invitation
 
-      expect(subject.computed_datetime).to eq(subject.invitation.accepted_at)
-      expect(subject.computed_status).to eq("pending")
+      expect(subject.datetime).to eq(subject.invitation.accepted_at)
+      expect(subject.status).to eq("pending")
     end
 
     it "has status 'complete' if invite accepted and report submitted" do
@@ -104,7 +105,7 @@ describe ReviewerReport do
       subject.accept_invitation
       subject.submit
 
-      expect(subject.computed_status).to eq("completed")
+      expect(subject.status).to eq("completed")
     end
   end
 


### PR DESCRIPTION
Removes a couple of aliases so they don't need to be explicitly blacklisted in templates

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good

