### PR TITLE
Move complexity of to: field out of template

### DIFF
--- a/app/models/paper_context.rb
+++ b/app/models/paper_context.rb
@@ -32,6 +32,10 @@ class PaperContext < TemplateContext
     @object.corresponding_authors.map { |ca| AuthorContext.new(ca) }
   end
 
+  def corresponding_author_emails
+    corresponding_authors.map(&:email).join(',')
+  end
+
   def editor
     return if @object.handling_editors.empty?
     UserContext.new(@object.handling_editors.first)

--- a/lib/tasks/seed_letter_templates.rake
+++ b/lib/tasks/seed_letter_templates.rake
@@ -5,7 +5,7 @@ namespace :seed do
   namespace :letter_templates do
 
     def author_emails
-      '{% assign emails = manuscript.corresponding_authors | map: "email" %}{{ emails | join "," }}'
+      '{{ manuscript.corresponding_author_emails }}'
     end
 
     def greeting


### PR DESCRIPTION
#### What this PR does:
Move the comma-delimited emails from liquid template logic into a context.

**Reviewer tasks** 
- [ ] I read the code; it looks good

