### PR TITLE
Move card content migration earlier, reset cache

### DIFF
--- a/db/migrate/20170821210046_add_error_message_to_card_contents.rb
+++ b/db/migrate/20170821210046_add_error_message_to_card_contents.rb
@@ -1,5 +1,7 @@
 class AddErrorMessageToCardContents < ActiveRecord::Migration
   def change
     add_column :card_contents, :error_message, :string
+    Card.connection.schema_cache.clear!
+    Card.reset_column_information
   end
 end


### PR DESCRIPTION
#### What this PR does:

This moves the migration to add an error message column to card_contents
earlier in the sequence of the next release, to prevent conflicts with
card loading migrations that come later.

It also clears the schema and column info caches, which we should do
for card_contents until all the card migrations are completed.

This was tested on the current master and today's copy of production data, and allowed a db:migrate to succeed where it failed before.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I verified the data-migration's results on a copy of production data (complicated migrations should also have real specs)
- [x] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

