### PR TITLE
Guards for missing due_at

### DIFF
--- a/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
+++ b/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
@@ -67,8 +67,7 @@ module TahiStandardTasks
       @reviewer_report =
         ReviewerReport.where(user: @assignee,
                              decision: @paper.draft_decision).first
-      @review_due_at = @reviewer_report.due_at.strftime("%B %-d, %Y %H:%M %Z") if @reviewer_report.due_at
-
+      @review_due_at = @reviewer_report.due_at || 10.days.from_now
       mail(
         to: @assignee.try(:email),
         subject: "Thank you for agreeing to review for #{@journal.name}")

--- a/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/reviewer_mailer/welcome_reviewer.html.erb
+++ b/engines/tahi_standard_tasks/app/views/tahi_standard_tasks/reviewer_mailer/welcome_reviewer.html.erb
@@ -16,7 +16,7 @@
 
 <p>
   In the interest of returning timely decisions to the authors,
-  please return your review by <%= @review_due_at %>.
+  please return your review by <%= @review_due_at.strftime("%B %-d, %Y %H:%M %Z") %>.
   Please do let us know if you wish to request additional
   time to review this manuscript, so that we may plan accordingly.
 </p>


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11184

#### What this PR does:

`@reviewer_report.due_at` will be nil if it was created while `REVIEW_DUE_DATE` feature flag is false. This guards against that while defaulting to our usual value. 

#### Special instructions for Review or PO:

Accept an invite while the aforementioned flag is off and check the email. 

#### Notes

Do we want to revert back to the language from: https://github.com/Tahi-project/tahi/commit/4577907ce3558e2784071ebcb0f3bf7050616b99#diff-6623534169348462527257c17ba86b5f ?

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
