### PR TITLE
fail-gracefully-on-non-existent-card-migration

### DIFF
--- a/lib/custom_card/migrator.rb
+++ b/lib/custom_card/migrator.rb
@@ -17,8 +17,13 @@ module CustomCard
 
     # rubocop:disable Metrics/AbcSize
     def migrate
-      old_card_version = Card.find_by!(name: legacy_class_name)
-        .latest_published_card_version
+      old_card_version = Card.find_by(name: legacy_class_name)
+        .try(:latest_published_card_version)
+
+      unless old_card_version
+        Rails.logger.info "card: #{legacy_class_name} could not be found: migration skipped"
+        return
+      end
 
       Card.transaction do
         Journal.pluck(:id).each do |journal_id|


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11194

#### What this PR does:
After dropping my db and trying to get it up to date, when run with an empty db my migrations were failing when the card migrator tried to act on a legacy card class that didn't exist. This is an attempt at handling this in a way that allows migrations to continue in this case.

Not really sure if this approach makes sense so I hope to get @surfacedamage 's thoughts

---

#### Code Review Tasks:


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

