### PR TITLE
Fix Competing Interests before we break it

### DIFF
--- a/client/app/pods/components/card-content/radio/template.hbs
+++ b/client/app/pods/components/card-content/radio/template.hbs
@@ -1,14 +1,8 @@
-{{#if isText}}
 <p class="content-text">{{{content.text}}}
   {{#if content.isRequired}}
     {{#unless answer.wasAnswered}}<span class="required-field">*</span>{{/unless}}
   {{/if}}
 </p>
-{{else}}
-  {{#if content.isRequired}}
-    {{#unless answer.wasAnswered}}<span class="required-field">*</span>{{/unless}}
-  {{/if}}
-{{/if}}
 <div>
   {{#if isText}}
     {{#each content.possibleValues as |opt index|}}


### PR DESCRIPTION
Jira issue: https://jira.plos.org/jira/browse/APERTA-11216

#### What this PR does:

The 1.49 release branch contains a change to how radio buttons are
handled in custom cards. A side effect of this was to hide the header
text on the Competing Interests hard, leaving the UI with just a yes/no
radio button and nothing else.

This reverts radio buttons to the old behavior.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

