### PR TITLE
Move some gems to test group, remove auto_screenshot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,9 +109,7 @@ group :development, :test do
   gem 'quiet_assets'
   # This needs to be in the development group to make rake tasks work
   gem 'rspec-rails'
-  gem 'test_after_commit'
   gem 'awesome_print'
-  gem 'equivalent-xml'
 end
 
 group :development do
@@ -134,6 +132,7 @@ group :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'database_cleaner'
   gem 'email_spec'
+  gem 'equivalent-xml'
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'fakeredis'
@@ -147,6 +146,7 @@ group :test do
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'
   gem 'simplecov'
+  gem 'test_after_commit'
   gem 'thin'
   gem 'timecop'
   gem 'vcr'


### PR DESCRIPTION
JIRA issue: none

#### What this PR does:

Some gems were in the `development, test` group, but they are only for test. Move them to test so they don't run in development.

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

