### PR TITLE
Add missing rake tasks to heroku deploy

### DIFF
--- a/lib/tasks/heroku_deploy.rake
+++ b/lib/tasks/heroku_deploy.rake
@@ -37,7 +37,9 @@ namespace :heroku do
         'cards:load',
         'roles-and-permissions:seed',
         'data:update_journal_task_types',
-        'create_feature_flags'
+        'create_feature_flags',
+        'settings:seed_setting_templates',
+        'seed:letter_templates:populate'
       ].each do |task|
         Rake::Task[task].invoke
       end


### PR DESCRIPTION

#### What this PR does:

Our POs are sad pandas when there's a change to a setting or letter template but they cant see it because these tasks aren't run :(  does this seem like a good fix? @slimeate mostly to match deploy.rb

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

