### PR TITLE
Use have_current_path, which waits, instead of current_path.to eq

### DIFF
--- a/spec/features/manuscript_show_spec.rb
+++ b/spec/features/manuscript_show_spec.rb
@@ -28,8 +28,7 @@ feature 'Viewing manuscript control bar', js: true do
     scenario 'visit the paper by id instead of short_doi' do
       page = Page.new
       page.visit("/papers/#{paper.id}")
-      wait_for_ajax
-      expect(page.current_path).to eq("/papers/#{paper.short_doi}")
+      expect(page).to have_current_path("/papers/#{paper.short_doi}")
     end
   end
 end

--- a/spec/features/paper_workflow_spec.rb
+++ b/spec/features/paper_workflow_spec.rb
@@ -24,7 +24,7 @@ feature "Paper workflow", js: true, selenium: true do
       click_link paper.title
       click_link "Workflow"
 
-      expect(current_path).to eq "/papers/#{paper.short_doi}/workflow"
+      expect(page).to have_current_path("/papers/#{paper.short_doi}/workflow")
     end
   end
 

--- a/spec/features/sign_in_devise_spec.rb
+++ b/spec/features/sign_in_devise_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 feature "Devise account creation", js: true, flaky: true do
   scenario "User can create an account" do
     sign_up_page = SignUpPage.visit
-    dashboard_page = sign_up_page.sign_up_as username: 'albert',
-     first_name: 'Albert',
-     last_name: 'Einstein',
-     email: 'einstein@example.org',
-     password: 'password'
-
-   expect(page.current_path).to eq(root_path)
-   expect(dashboard_page).to have_welcome_message("Hi, Albert")
+    dashboard_page = sign_up_page.sign_up_as(
+      username: 'albert',
+      first_name: 'Albert',
+      last_name: 'Einstein',
+      email: 'einstein@example.org',
+      password: 'password'
+    )
+    expect(page).to have_current_path(root_path)
+    expect(dashboard_page).to have_welcome_message("Hi, Albert")
   end
 end
 
@@ -19,17 +20,17 @@ feature "Devise signing in", js: true, flaky: true do
   scenario "User can sign in to & out of the site using their email address" do
     sign_in_page = SignInPage.visit
     dashboard_page = sign_in_page.sign_in user
-    expect(page.current_path).to eq(root_path)
+    expect(page).to have_current_path(root_path)
     dashboard_page.sign_out
-    expect(page.current_path).to eq new_user_session_path
+    expect(page).to have_current_path(new_user_session_path)
   end
 
   scenario "User can sign in to & out of the site using their username" do
     sign_in_page = SignInPage.visit
     dashboard_page = sign_in_page.sign_in user, user.username
-    expect(page.current_path).to eq(root_path)
+    expect(page).to have_current_path(root_path)
     dashboard_page.sign_out
-    expect(page.current_path).to eq new_user_session_path
+    expect(page).to have_current_path(new_user_session_path)
   end
 end
 
@@ -41,7 +42,7 @@ feature "Devise redirect", js: true, flaky: true do
     fill_in('Password', with: 'password')
     click_on "Sign in"
     expect(page).to have_css('#profile')
-    expect(page.current_path).to eq '/profile'
+    expect(page).to have_current_path('/profile')
   end
 end
 
@@ -55,4 +56,3 @@ feature "Devise resetting password", js: true, flaky: true do
     expect(page).to have_content 'You will receive an email with instructions about how to reset your password in a few minutes.'
   end
 end
-


### PR DESCRIPTION
#### What this PR does:

Modifies our tests to use the capybara matcher `have_current_path`, which will wait until the current path is equal to something, instead of `expect(current_path).to eq(...)`, which will not wait. This is useful if we are waiting for redirects.

See https://circleci.com/gh/Tahi-project/tahi/24884#tests/containers/4 this failed test for a reason for this.

---

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good

