### PR TITLE
simple_format the comment body

### DIFF
--- a/app/views/user_mailer/mention_collaborator.html.erb
+++ b/app/views/user_mailer/mention_collaborator.html.erb
@@ -15,7 +15,7 @@
   "<%= @paper.display_title(sanitized: false) %>".
 </p>
 
-<p><%= @comment.body %></p>
+<p><%= simple_format @comment.body %></p>
 
 <%= render partial: 'email/journal_signature', locals: { journal: @paper.journal } %>
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10278

#### What this PR does:

zee comment body must be html-ified.

#### Special instructions for Review or PO:

Mention someone in a task card discussion to trigger email, throw in a couple of line returns between sentences for good measure

#### Notes

Is this supposed to be html in the db? There's also a race condition where the mailer is run before the comment is saved, which is silly. Luckily sidekiq re-runs it, but thats sloppy.

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

