### PR TITLE
APERTA-10783: fixed error messages for non-pending errors

### DIFF
--- a/app/workers/router_upload_status_worker.rb
+++ b/app/workers/router_upload_status_worker.rb
@@ -30,7 +30,7 @@ class RouterUploadStatusWorker
     when "SUCCESS"
       export_delivery.delivery_succeeded!
     else
-      export_delivery.delivery_failed!(result['job_status_description'])
+      export_delivery.delivery_failed!(result[:job_status_description])
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10783

#### What this PR does:

Fixes error message output on status polling where low level errors were replaced with "Time out waiting for export service" instead of displaying actual error.

