### PR TITLE
APERTA-11267 hook up tinymce on init

### DIFF
--- a/client/app/pods/components/rich-text-editor/component.js
+++ b/client/app/pods/components/rich-text-editor/component.js
@@ -72,7 +72,7 @@ export default Ember.Component.extend({
     if (!this.get('disabled')) {
       Ember.run.scheduleOnce('afterRender', this, this.postRender);
     }
-  }),
+  }).on('init'),
 
   pastePostprocess(editor, fragment) {
     function deleteEmptyParagraph(elem) {

--- a/client/tests/integration/pods/components/rich-text-editor/component-test.js
+++ b/client/tests/integration/pods/components/rich-text-editor/component-test.js
@@ -84,11 +84,13 @@ test(`it sends 'onContentsChanged' after keyed input`, function(assert) {
 
 
 test('checking the focusOut action triggers after editor is disabled', function(assert) {
+  var focusOutCount = 0;
   this.set('focusOutStub', function() {
-    this.set('value', 'new value');
+    focusOutCount = focusOutCount + 1;
   });
   this.set('saveContents', function() {});
 
+  this.set('disabled', false);
   let template = hbs`{{rich-text-editor
                   value=value
                   ident='test-editor'
@@ -97,16 +99,15 @@ test('checking the focusOut action triggers after editor is disabled', function(
                   focusOut=(action focusOutStub)}}`;
   this.render(template);
 
-  // The focusOut passed action to the component is not attached to the editor
-  // until the postRender method is called. This call only happens when the editor
-  // is enabled, in other words when the disabled attribute is set to false.
+  // When 'disabled' is toggled to true, the tinymce component is swapped out for a plain
+  // text field. The focusOut action has to be reattached when 'disabled' is toggled back to false
   editorFireEvent('test-editor', 'blur');
-  assert.equal(this.get('value'), undefined, 'Value is not set on focusOut action call');
+  assert.equal(focusOutCount, 1, 'focusOut was called when the editor was initialized in an enabled state');
 
   this.set('disabled', true);
   this.set('disabled', false);
   // The focusOut passed in handler function is now attached to the rich text editor blur event.
   editorFireEvent('test-editor', 'blur');
 
-  assert.equal(this.get('value'), 'new value', 'Value was set on blur');
+  assert.equal(focusOutCount, 2, 'focusOut was called again after reenabling the editor');
 });


### PR DESCRIPTION

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11267

#### What this PR does:

Before this change, if the rich-text-editor was initialized with 'disabled=false'
then it would never allow tinymce to save its content.  In most cases disabled
is calculated from a permission fetched asynchronously from the server - it
starts out true, then once the ajax request for the permission completes it
toggles back to false and runs the observer.  There are some cases (like if the
rich-text-editor is rendered inside an 'if' block) where the editor may
initially be rendered with 'disabled=false' and never trigger the observer.  For
things like this we add .on('init') to the observer to make sure it fires right
when the component is initialized. See https://guides.emberjs.com/v2.15.0/object-model/observers/#toc_observers-and-object-initialization for more detail


#### Special instructions for Review or PO:

The rich text editor nested inside the 'if' block in this xml should work correctly:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<card required-for-submission="false" workflow-display-only="false">
  <content content-type="display-children">
    <content content-type="if" condition="isEditable">
      <content content-type="paragraph-input" value-type="html">
        <text>This is the THEN branch of an IF condition.</text>
      </content>    
      <content content-type="short-input" value-type="text">
        <text>This is the ELSE branch of an IF condition.</text>
      </content>
    </content>
  </content>
</card>
```


#### Major UI changes

None
---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

