### PR TITLE
Conditionally invoke findRecord

### DIFF
--- a/client/app/adapters/invitation-attachment.js
+++ b/client/app/adapters/invitation-attachment.js
@@ -14,11 +14,7 @@ export default ApplicationAdapter.extend(DS.BuildURLMixin, {
   urlForUpdateRecord: attachmentURL,
 
   findRecord(store, type, id, snapshot) {
-    if (snapshot.belongsTo('invitation')) {
-      return this._super(...arguments);
-    } else {
-      // this is for the case where a pusher message is received by window without the right data
-      return Ember.RSVP.resolve({'invitation-attachment': {id: id, title: 'Empty promise'}});
-    }
+    // this is for the case where a pusher message is received by window without the right data
+    return snapshot.belongsTo('invitation') ? this._super(...arguments) : Ember.RSVP.reject();
   }
 });

--- a/client/tests/unit/pods/invitation-attachment/adapter-test.js
+++ b/client/tests/unit/pods/invitation-attachment/adapter-test.js
@@ -5,11 +5,9 @@ moduleFor('adapter:invitation-attachment', 'Unit | Adapter | invitation attachme
 
 test('findRecord returns a hollow promise if it doesnt belongTo anything', function(assert) {
   assert.expect(1);
-  const invitationAttachmentId = 1;
   let adapter = this.subject();
-  let snapshot = Ember.Object.create();
-  snapshot.belongsTo = function() { return null; };
-  adapter.findRecord(null, null, invitationAttachmentId, snapshot).then((data) => {
-    assert.equal(data['invitation-attachment'].id, invitationAttachmentId);
+  let snapshot = Ember.Object.create({belongsTo() { return null; }});
+  adapter.findRecord(null, null, null, snapshot).catch(() => {
+    assert.ok(true);
   });
 });


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11060

#### What this PR does:

This one is a doozy, and probably a band-aid on a more systemic issue we might have about incompatibilities between user's browser tab behavior and our pusher implementation. If a user has a tab open without a fetched resource, it might still receive a websocket message resulting in broken behavior, like this:
![pushy](https://user-images.githubusercontent.com/5441006/30615724-a39abb72-9d44-11e7-85d8-115402915d5a.gif)

#### Special instructions for Review or PO:

View gif above for reproduction instructions

#### Notes

Uhg, pusher and ember were implemented without thinking of users having multiple tabs open. I am super open to a different solution to this if there are any other suggestions.

---

#### Code Review Tasks:
Author:
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.
- [x] Add test

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases