### PR TITLE
APERTA-7768 Fix password setting for db:dump

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -57,12 +57,11 @@ namespace :db do
   task dump: :environment do
     location = "~/aperta-#{Time.now.utc.strftime('%FT%H:%M:%SZ')}.dump"
 
-    cmd = nil
     rake_with_db_config do |host, db, user|
       raise('Backup file already exists') if File.exist?(File.expand_path(location))
       cmd = "pg_dump --host #{host} --username #{user} --verbose --clean --no-owner --no-acl --format=c #{db} > #{location}"
+      rake_system_or_abort(cmd, "Dump failed for \n #{cmd}")
     end
-    rake_system_or_abort(cmd, "Dump failed for \n #{cmd}")
   end
 
   desc "Cleans up the database dump files in ~, leaving the 2 newest"


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-7768

#### What this PR does:

I broke the `db:dump` rake task, so I fixed it here.

Testing:

- Running `rake db:dump` should *not* prompt for a password.
---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
