### PR TITLE
APERTA-11298 Dont serialize card content or xml for available_cards route

### DIFF
--- a/app/controllers/available_cards_controller.rb
+++ b/app/controllers/available_cards_controller.rb
@@ -16,7 +16,7 @@ class AvailableCardsController < ApplicationController
 
   def index
     requires_user_can(:manage_workflow, paper)
-    respond_with paper.journal.cards, root: "cards"
+    respond_with paper.journal.cards, root: "cards", include_content: false
   end
 
   private

--- a/app/serializers/card_serializer.rb
+++ b/app/serializers/card_serializer.rb
@@ -10,6 +10,17 @@ class CardSerializer < ActiveModel::Serializer
     object.content_root_for_version(:latest)
   end
 
+  # include_*? is a method that we can define for a given attribute that will
+  # cause the serializer to omit the attribute if the method returns true. See
+  # https://github.com/rails-api/active_model_serializers/tree/0-8-stable#attributes
+  def include_content?
+    @options[:include_content] != false
+  end
+
+  def include_xml?
+    @options[:include_content] != false
+  end
+
   def state
     object.state.camelize(:lower)
   end


### PR DESCRIPTION
https://jira.plos.org/jira/browse/APERTA-11298

When a user hits 'add new card' on a workflow, the dialog that displays
the list of cards is currently slow.  When we fetch 'availableCards' for
a paper, those cards are serialized with all of their content and xml,
even though we never access that information.

This change only affects the available_cards route at this point.  All
other behavior remains the same (include_content defaults to true).  We only access `availableCards` when we try to show the list of cards to add to the workflow.

Speed difference for 'available_cards' route on my machine:
Before
~4seconds
After
~146ms

This is the screen
![screen shot 2017-09-20 at 11 35 17 am](https://user-images.githubusercontent.com/2043348/30653033-f39e466c-9df7-11e7-8dbf-aa62b52b1016.png)

In this screenshot the 'after' requests are first, then the 'before' requests are further down
![screen shot 2017-09-20 at 11 35 02 am](https://user-images.githubusercontent.com/2043348/30653035-f3b73a28-9df7-11e7-821d-37b8416f22bc.png)

**Reviewer checklist**
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
