### PR TITLE
Only load record if already in store

### DIFF
--- a/client/app/pods/application/route.js
+++ b/client/app/pods/application/route.js
@@ -107,7 +107,7 @@ export default Ember.Route.extend({
         return;
       }
 
-      this.store.findRecord(payload.type, payload.id, { reload: true });
+      Ember.tryInvoke(this.store.peekRecord(payload.type, payload.id), 'reload');
     },
 
     updated(payload) {


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11060

#### What this PR does:

Here's an alternate solution to #3505 which takes a bit blunter and assumptive of an approach. Basically pusher should only reload a record if its already there in the store. Are there any cases where we want pusher message to create a brand new object in the ember store?

#### Special instructions for Review or PO:

see #3505 

#### Notes

Labeling this as wip, I was a bit too excited about this solution.


---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
