### PR TITLE
enforce population of available merge fields

### DIFF
--- a/spec/models/template_scenario_spec.rb
+++ b/spec/models/template_scenario_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe TemplateScenario do
+  describe '.merge_fields' do
+    TemplateScenario.descendants.each do |ts|
+      it "#{ts.name} presents available merge fields in the email template admin form" do
+        # Scenario merge fields contain contexts with child merge fields
+        # If we ever create a scenario with only simple merge fields this test will become inadequate
+        expect(ts.merge_fields.any? { |d| d.key?(:children) }).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What this PR does:
Adds a spec that ensures that all TemplateScenarios present merge fields in child contexts in the email template admin form.  This could be easily overlooked when creating new TemplateScenarios.

**Reviewer tasks**
- [x] I read the code; it looks good
