### PR TITLE
Sanitizer methods are not shown in list of merge fields

### DIFF
--- a/app/models/reviewer_report_context.rb
+++ b/app/models/reviewer_report_context.rb
@@ -6,6 +6,10 @@ class ReviewerReportContext < TemplateContext
      { name: :answers, context: AnswerContext, many: true }]
   end
 
+  def self.blacklisted_merge_fields
+    ActionView::Helpers::SanitizeHelper.public_instance_methods
+  end
+
   whitelist :state, :revision, :status, :datetime, :invitation_accepted?, :due_at
 
   def reviewer


### PR DESCRIPTION
#### What this PR does:
Hides some helper methods from the "available merge fields" list.

**Reviewer tasks**
- [x] I read the code; it looks good