### PR TITLE
APERTA-11253 included permissions to status

### DIFF
--- a/engines/tahi_standard_tasks/client/app/templates/components/front-matter-reviewer-report-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/front-matter-reviewer-report-task.hbs
@@ -2,7 +2,7 @@
 
 <div class="task-main-content reviewer-form">
   <div class="reviewer-report-wrapper">
-    {{reviewer-report-status report=currentReviewerReport}}
+    {{reviewer-report-status report=currentReviewerReport canEditDueDate=(can 'edit_due_date' task)}}
     {{#if (and (can 'manage_scheduled_events' task)
                currentReviewerReport.scheduledEvents)}}
       {{scheduled-events events=currentReviewerReport.scheduledEvents


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11253

#### What this PR does:

Makes sure proper permissions needed to display the "Change Due Date" is passed into the respective component

---

#### Code Review Tasks:

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
