### PR TITLE
APERTA-11322 - Make diff work in the Financial Disclosure card

### DIFF
--- a/client/app/pods/components/funder-snapshot/component.js
+++ b/client/app/pods/components/funder-snapshot/component.js
@@ -4,9 +4,31 @@ import {
 } from 'tahi/lib/snapshots/snapshot-named-computed-property';
 
 export default Ember.Component.extend({
-  snapshot: null,
-  name: namedComputedProperty('snapshot', 'name'),
-  grantNumber: namedComputedProperty('snapshot', 'grant_number'),
-  website: namedComputedProperty('snapshot', 'website'),
-  influence: namedComputedProperty('snapshot', 'funder_had_influence')
+  viewing: null,
+  comparison: null,
+  viewingName: namedComputedProperty('viewing', 'name'),
+  viewingGrantNumber: namedComputedProperty('viewing', 'grant_number'),
+  viewingWebsite: namedComputedProperty('viewing', 'website'),
+  viewingInfluence: Ember.computed('viewing.children.[]', function() {
+    let children = this.get('viewing.children');
+    if (children) return children.findBy('name', 'funder--had_influence');
+  }),
+  viewingFunderLine: Ember.computed('viewingName', 'viewingWebsite', function() {
+    let web = this.get('viewingWebsite'),
+      name = this.get('viewingName');
+    return web ? `${name} (${web})` : name;
+  }),
+
+  comparisonName: namedComputedProperty('comparison', 'name'),
+  comparisonGrantNumber: namedComputedProperty('comparison', 'grant_number'),
+  comparisonWebsite: namedComputedProperty('comparison', 'website'),
+  comparisonInfluence: Ember.computed('comparison.children.[]', function() {
+    let children = this.get('comparison.children');
+    if (children) return children.findBy('name', 'funder--had_influence');
+  }),
+  comparisonFunderLine: Ember.computed('comparisonName', 'comparisonWebsite', function() {
+    let web = this.get('comparisonWebsite'),
+      name = this.get('comparisonName');
+    return web ? `${name} (${web})` : name;
+  })
 });

--- a/client/app/pods/components/funder-snapshot/template.hbs
+++ b/client/app/pods/components/funder-snapshot/template.hbs
@@ -1,11 +1,9 @@
 <div class="snapshot-funder">
   <div>
-    <span class="snapshot-question-label">Funder: </span>{{name}}   {{#if website}}({{website}}){{/if}}
+    <span class="snapshot-question-label">Funder: </span>{{text-diff viewingText=viewingFunderLine comparisonText=comparisonFunderLine}}
   </div>
   <div>
-    <span class="snapshot-question-label">Grant #: </span>{{grantNumber}}
+    <span class="snapshot-question-label">Grant #: </span>{{text-diff viewingText=viewingGrantNumber comparisonText=comparisonGrantNumber}}
   </div>
-  {{#if influence.value.answer}}
-    {{nested-snapshot snapshot=influence}}
-  {{/if}}
+  {{nested-snapshot snapshot1=viewingInfluence snapshot2=comparisonInfluence}}
 </div>

--- a/client/app/pods/components/nested-snapshot/template.hbs
+++ b/client/app/pods/components/nested-snapshot/template.hbs
@@ -58,7 +58,7 @@
   {{/if}}
 
   {{#if funder}}
-    {{funder-snapshot snapshot=snapshot1}}
+    {{funder-snapshot viewing=snapshot1 comparison=snapshot2}}
   {{/if}}
 
 {{/if}}

--- a/client/tests/components/snapshots/financial-disclosure-snapshot-test.js
+++ b/client/tests/components/snapshots/financial-disclosure-snapshot-test.js
@@ -1,0 +1,126 @@
+import {moduleForComponent, test} from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import registerDiffAssertions from 'tahi/tests/helpers/diff-assertions';
+
+moduleForComponent('nested-snapshot',
+  'Integration | Component | Financial disclosure snapshot',
+  {integration: true, beforeEach: registerDiffAssertions});
+
+var snapshot1 = function() {
+  return {
+    name: 'financial-disclosure-task',
+    type: 'properties',
+    children: [
+      {
+        name: 'financial_disclosures--author_received_funding',
+        type: 'question',
+        value: {
+          title: 'author funding',
+          answer_type: 'boolean',
+          answer: true
+        }
+      },
+      {
+        name: 'funder',
+        type: 'properties',
+        children: [
+          {
+            name: 'funder--had_influence',
+            type: 'question',
+            value: {
+              title: 'had influence',
+              answer_type: 'boolean',
+              answer: false
+            },
+            children: [
+              {
+                name: 'funder--had_influence--role_description',
+                type: 'question',
+                value: {
+                  title: 'role',
+                  answer_type: 'text',
+                  answer: ''
+                }
+              }
+            ]
+          },
+          { name: 'name', type: 'text', value: 'Jedi Academy' },
+          { name: 'grant_number', type: 'text', value: '12345' },
+          { name: 'website', type: 'text', value: 'jedi.edu' },
+          { name: 'additional_comments', type: 'text', value: 'Additional comments go here.' }
+        ]
+      }
+    ]
+  };
+};
+
+var snapshot2 = function() {
+  return {
+    name: 'financial-disclosure-task',
+    type: 'properties',
+    children: [
+      {
+        name: 'financial_disclosures--author_received_funding',
+        type: 'question',
+        value: {
+          title: 'author funding',
+          answer_type: 'boolean',
+          answer: true
+        }
+      },
+      {
+        name: 'funder',
+        type: 'properties',
+        children: [
+          {
+            name: 'funder--had_influence',
+            type: 'question',
+            value: {
+              title: 'had influence',
+              answer_type: 'boolean',
+              answer: true
+            },
+            children: [
+              {
+                name: 'funder--had_influence--role_description',
+                type: 'question',
+                value: {
+                  title: 'role',
+                  answer_type: 'text',
+                  answer: 'Recruited participants'
+                }
+              }
+            ]
+          },
+          { name: 'name', type: 'text', value: 'Jedi Academy' },
+          { name: 'grant_number', type: 'text', value: '12345' },
+          { name: 'website', type: 'text', value: 'jedi.edu' },
+          { name: 'additional_comments', type: 'text', value: 'Additional comments go here.' }
+        ]
+      }
+    ]
+  };
+};
+
+var template = hbs`{{nested-snapshot snapshot1=viewing snapshot2=comparison}}`;
+
+test('no diff, no added or removed', function(assert){
+  this.set('viewing', snapshot1());
+  this.set('comparison', snapshot1());
+
+  this.render(template);
+  assert.equal(this.$('.added').length, 0, 'Has added diff spans');
+  assert.equal(this.$('.removed').length, 0, 'Has removed diff spans');
+});
+
+test('Has added and removed diff', function(assert){
+  this.set('viewing', snapshot2());
+  this.set('comparison', snapshot1());
+
+  this.render(template);
+  assert.equal(this.$('.added').length, 2, 'Wrong number of added diff spans');
+  assert.equal(this.$('.removed').length, 1, 'Wrong number of removed diff spans');
+  assert.textPresent('.added', 'Recruited participants');
+  assert.textPresent('.added', 'Yes');
+  assert.textPresent('.removed', 'No');
+});


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11322

#### What this PR does:

The "funder-shapshot" component previously just displayed the viewing version's financial disclosure information. This adds proper diffing between the viewing and comparison versions.

Before:

![before](https://user-images.githubusercontent.com/2135631/30774581-c1cf4156-a052-11e7-86ff-ed38378ef310.png)

After:

![wip](https://user-images.githubusercontent.com/2135631/30774582-c84eebee-a052-11e7-888a-e7536d9915c5.png)


#### Special instructions for Review or PO:

Is there anything out of the ordinary in how the AC for the ticket needs to be evaluated?
Does the reviewer have to run a rake task? Is there specific seed data they should use?
If PO needs specific guidance on how to evaluate this feature please add that information to the JIRA ticket itself (add a link here if needed)

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
