### PR TITLE
APERTA-11207: make sure versioned_text.file_type is always lower case

### DIFF
--- a/app/workers/process_manuscript_worker.rb
+++ b/app/workers/process_manuscript_worker.rb
@@ -35,7 +35,7 @@ class ProcessManuscriptWorker
 
   def set_file_type(manuscript_attachment)
     path = URI.parse(manuscript_attachment.pending_url).path
-    extension = Pathname.new(path).extname.delete('.')
+    extension = Pathname.new(path).extname.delete('.').downcase
     manuscript_attachment.update_column(:file_type, extension)
   end
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11207

#### What this PR does:

Prevents paper export and rendering issues by ensuring that versioned_text.file_type is always lower case.

NOTE: Please merge after code review since PO acceptance needs to be done in CI environment.
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

#### PO Acceptance
being an export ticket, this should be PO'd post-merge in CI environment