### PR TITLE
APERTA-11268 Disallow SUBCLASSME card titles on Choose New Card

### DIFF
--- a/client/app/pods/components/choose-new-card/component.js
+++ b/client/app/pods/components/choose-new-card/component.js
@@ -28,7 +28,12 @@ export default Ember.Component.extend(EscapeListenerMixin, {
 
   // pre-card-config
   taskTypeSort: ['title:asc'],
-  sortedTaskTypes: computed.sort('journalTaskTypes', 'taskTypeSort'),
+  // TODO: get rid of task type filtering after last legacy card ruby class is deleted
+  filteredTaskTypes: computed.filter('journalTaskTypes', function(taskType) {
+    let title = taskType.get ? taskType.get('title') : '';
+    return title !== 'SUBCLASSME' && title !== 'Custom Card';
+  }),
+  sortedTaskTypes: computed.sort('filteredTaskTypes', 'taskTypeSort'),
   authorTasks: computed.filterBy('sortedTaskTypes', 'roleHint', 'author'),
   staffTasksUnsorted: computed.setDiff('sortedTaskTypes', 'authorTasks'),
   staffTasks: computed.sort('staffTasksUnsorted', 'taskTypeSort'),

--- a/client/tests/integration/pods/components/choose-new-card/component-test.js
+++ b/client/tests/integration/pods/components/choose-new-card/component-test.js
@@ -81,3 +81,26 @@ test('it makes call to save all selected cards', function(assert) {
 
   assert.ok(save.calledWith(phase, [authorJournalTaskType, staffJournalTaskType, card]), 'Should call save action');
 });
+
+test('Cards with titles SUBCLASSME and "Custom Card" are not displayed', function(assert) {
+  this.set('phase', phase);
+  this.set('cards', [card]);
+  this.on('save', save);
+  this.on('close', close);
+
+  const authorJournalTaskType = Ember.Object.create({ title: 'Custom Card', roleHint: 'author' });
+  const staffJournalTaskType = Ember.Object.create({ title: 'SUBCLASSME', roleHint: 'staff' });
+  const journalTaskTypes = [authorJournalTaskType, staffJournalTaskType];
+  this.set('journalTaskTypes', journalTaskTypes);
+
+  this.render(hbs`
+    {{choose-new-card phase=phase
+                      journalTaskTypes=journalTaskTypes
+                      cards=cards
+                      isLoading=false
+                      onSave=(action 'save')
+                      close=(action 'close')}}`);
+
+  assert.textNotPresent('.author-task-cards label', 'Custom Card');
+  assert.textNotPresent('.staff-task-cards label', 'SUBCLASSME');
+});


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11268

#### What this PR does:

While we are converting legacy cards to custom cards, cards with the
titles “SUBCLASSME” and “Custom Card” will continue to sneak into the
JournalTaskTypes table between the time that a card is converted to a
custom card, and the time when the legacy ruby class is actually
deleted. Trying to add either of those card types to a workflow or paper
will result in undefined behavior or an error.

This filters out cards with those titles from the choose-new-card Ember
component, with a TODO of removing card title filtering once all legacy
cards have been successfully converted to custom cards.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
