### PR TITLE
WIP APERTA-10362 default text xml card config element

### DIFF
--- a/app/models/card_content.rb
+++ b/app/models/card_content.rb
@@ -156,6 +156,8 @@ class CardContent < ActiveRecord::Base
       render_tag(xml, 'instruction-text', instruction_text)
       render_tag(xml, 'text', text)
       render_tag(xml, 'label', label)
+      render_tag(xml, 'default-text-long', default_text_long)
+
       card_content_validations.each do |ccv|
         # Do not serialize the required-field validation, it is handled via the
         # "required-field" attribute.

--- a/app/models/concerns/attributable.rb
+++ b/app/models/concerns/attributable.rb
@@ -6,7 +6,7 @@ module Attributable
     json:    %w[possible_values],
     string:  %w[child_tag condition custom_class custom_child_class default_answer_value
                 editor_style error_message instruction_text label text value_type
-                visible_with_parent_answer wrapper_tag]
+                visible_with_parent_answer wrapper_tag default_text_long]
   }.freeze
 
   included do

--- a/app/serializers/card_content_serializer.rb
+++ b/app/serializers/card_content_serializer.rb
@@ -36,6 +36,7 @@ class CardContentSerializer < ActiveModel::Serializer
   end
 
   def default_answer_value
+    return object.default_text_long if object.default_text_long
     return object.default_answer_value == 'true' ? true : false if object.default_answer_value.present? && object.value_type == 'boolean'
     object.default_answer_value
   end

--- a/app/services/xml_card_loader.rb
+++ b/app/services/xml_card_loader.rb
@@ -128,6 +128,7 @@ class XmlCardLoader
       wrapper_tag: content.attr_value('wrapper-tag'),
       content_type: content.attr_value('content-type'),
       default_answer_value: content.attr_value('default-answer-value'),
+      default_text_long: content.tag_text('default-text-long'),
       error_message: content.attr_value('error-message'),
       ident: content.attr_value('ident'),
       required_field: content.attr_value('required-field'),

--- a/client/app/models/card-content.js
+++ b/client/app/models/card-content.js
@@ -19,6 +19,7 @@ export default DS.Model.extend({
   ident: DS.attr('string'),
   possibleValues: DS.attr(),
   defaultAnswerValue: DS.attr(),
+  defaultTextLong: DS.attr(),
   order: DS.attr('number'),
   text: DS.attr('string'),
   instructionText: DS.attr('string'),

--- a/config/card.rnc
+++ b/config/card.rnc
@@ -116,6 +116,7 @@ text-input = element content {
                  attribute default-answer-value { text }?,
                  attribute allow-annotations { "true" | "false" }?,
                  (element instruction-text { text }? &
+                  element default-text-long { text }? &
                  (element text { text }? &
                  element validation {
                   attribute validation-type { "string-match" | "string-length-minimum" | "string-length-maximum" },

--- a/config/card.rng
+++ b/config/card.rng
@@ -416,6 +416,11 @@
             <text/>
           </element>
         </optional>
+        <optional>
+          <element name="default-text-long">
+            <text/>
+          </element>
+        </optional>
         <interleave>
           <optional>
             <element name="text">


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10362

#### What this PR does:

Explain in a few sentences what functionality changed, and how. Don't be afraid
to give a little extra detail. The Reviewer is going to read the original
ticket, but this can point them in the right direction.

Can your changes be *seen* by a user? Then add a screenshot. Is it an
interaction?  Perhaps a quick recording?

#### Special instructions for Review or PO:

Is there anything out of the ordinary in how the AC for the ticket needs to be evaluated?
Does the reviewer have to run a rake task? Is there specific seed data they should use?
If PO needs specific guidance on how to evaluate this feature please add that information to the JIRA ticket itself (add a link here if needed)

#### Notes

Are there any surprises? Anything that was particularly difficult, or clever, or
made you nervous, and should get particular attention during review? Call it
out.


#### Major UI changes

Were there major UI changes? Add a screenshot here -- and please let the QA team know that changes are imminent. They would love a little extra time to prepare the QA test suite.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results with `rake db:test_migrations` (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
