### PR TITLE
Empowerment: Don’t lookup socket ID until connection is present

### DIFF
--- a/client/app/adapters/application.js
+++ b/client/app/adapters/application.js
@@ -6,6 +6,8 @@ const { getOwner } = Ember;
 export default ActiveModelAdapter.extend({
   namespace: 'api',
   headers: function() {
+    let pusher = getOwner(this).lookup('pusher:main');
+    let socket = pusher.connection ? pusher.get('socketId') : null;
     Ember.assert(`Can't find the pusher service.  Most likely you're seeing this error in a test environment, and
                  Ember is making an ajax request for a resource you haven't stubbed, like a permissions check for a task.
                  ----
@@ -18,13 +20,13 @@ export default ActiveModelAdapter.extend({
                    You're probably in a component integration test and you've forgotten
                    to use register a stub for the pusher service.  You can do that like this in the beforeEach hook:
                    this.registry.register('pusher:main', Ember.Object.extend({socketId: 'foo'}));
-                 `, getOwner(this).lookup('pusher:main'));
+                 `, pusher);
     return {
       namespace: 'api',
       // Weird capitalization and hyphens are intentional since this is is an
       // HTTP header name. Whatever you do, DO NOT add underscores to the header
       // name because nginx will start to ignore it.
-      'Pusher-Socket-ID': getOwner(this).lookup('pusher:main').get('socketId')
+      'Pusher-Socket-ID': socket
     };
   }.property().volatile(),
 


### PR DESCRIPTION
#### What this PR does:

This gets rid of the pesky “Cannot read property 'connection' of null”
Javascript error on first sign-on, by not looking up pusher:main’s
socket ID if the pusher.connection is falsy.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
