### PR TITLE
pass id instead of object

### DIFF
--- a/app/models/reviewer_report.rb
+++ b/app/models/reviewer_report.rb
@@ -170,7 +170,7 @@ class ReviewerReport < ActiveRecord::Base
   end
 
   def thank_reviewer
-    TahiStandardTasks::ReviewerMailer.thank_reviewer(reviewer_report: self).deliver_later
+    TahiStandardTasks::ReviewerMailer.thank_reviewer(reviewer_report_id: id).deliver_later
   end
 
   def cancel_reminders

--- a/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
+++ b/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
@@ -92,15 +92,16 @@ module TahiStandardTasks
       reminder_notice(template_name: 'Review Reminder - Second Late', reviewer_report_id: reviewer_report_id)
     end
 
-    def thank_reviewer(reviewer_report:)
-      @paper = reviewer_report.paper
+    def thank_reviewer(reviewer_report_id:)
+      @reviewer_report = ReviewerReport.find(reviewer_report_id)
+      @paper = @reviewer_report.paper
       @journal = @paper.journal
       @letter_template = @journal.letter_templates.find_by(name: 'Reviewer Appreciation')
       begin
-        @letter_template.render(ReviewerReportScenario.new(reviewer_report), check_blanks: true)
+        @letter_template.render(ReviewerReportScenario.new(@reviewer_report), check_blanks: true)
         @subject = @letter_template.subject
         @body = @letter_template.body
-        @to = reviewer_report.user.email
+        @to = @reviewer_report.user.email
         mail(to: @to, subject: @subject)
       rescue BlankRenderFieldsError => e
         Bugsnag.notify(e)

--- a/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/reviewer_mailer_spec.rb
+++ b/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/reviewer_mailer_spec.rb
@@ -371,7 +371,7 @@ describe TahiStandardTasks::ReviewerMailer do
   end
 
   describe '.thank_reviewer' do
-    subject(:email) { described_class.thank_reviewer(reviewer_report: report) }
+    subject(:email) { described_class.thank_reviewer(reviewer_report_id: report.id) }
     let(:appreciation_email) { FactoryGirl.create(:letter_template, :thank_reviewer) }
 
     before { report.paper.journal.letter_templates << appreciation_email }


### PR DESCRIPTION
#### What this PR does:
`ReviewerMailer.thank_reviewer` accepts ids instead of objects, conforming to the rest of the mailer methods. These emails can be serialized into a redis queue for asynchronous email delievery, so the argument should be looked up instead of serialized.

**Reviewer tasks** 
- [ ] I read the code; it looks good
