### PR TITLE
APERTA-10934-adjusted-font-size-for-title-and-abstract

### DIFF
--- a/app/assets/stylesheets/components/_title-and-abstract.scss
+++ b/app/assets/stylesheets/components/_title-and-abstract.scss
@@ -13,3 +13,11 @@
       font-weight: bold;
     }
 }
+
+.article-abstract-input {
+  p {
+    // important had to be as it was still
+    // reflecting the .form-group style
+    font-size: 14px !important;
+  }
+}

--- a/engines/tahi_standard_tasks/client/app/templates/components/title-and-abstract-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/title-and-abstract-task.hbs
@@ -25,7 +25,7 @@
     <div class="form-group qa-paper-abstract">
        <h3 class="title-and-abstract-header">Abstract </h3>
         {{rich-text-editor
-          editorStyle='inline'
+          editorStyle='basic'
           value=task.paperAbstract
           ident='article-abstract-input'
           class='article-abstract-input'


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10934

#### What this PR does:

Reducing the _Title and Abstract_ font size in the card to the same as the body text and making sure same font-size is rendered in emails that contains the manuscript title and abstract.

#### Notes

The emails which include paper title and abstract are the **Reviewers and Editor invitation emails**, they were both cross-checked and the text size were perfect i.e 14px
The reason why the large text style were not reflected in these emails was because there's a different templates that renders the emails and the styling of the erb files that render the emails used *14px*.

<img width="660" alt="screen shot 2017-09-27 at 3 52 07 pm" src="https://user-images.githubusercontent.com/10073272/30920434-ddf704f8-a39b-11e7-8a8d-d39d5115fe9b.png">

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] If I made any UI changes, I've let QA know.
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
