### PR TITLE
APERTA-11350 - Stop mass emails when adding participant

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,9 +11,6 @@ class CommentsController < ApplicationController
 
   def create
     requires_user_can :edit_discussion_footer, task
-    unless current_user.can?(:administer, task.paper.journal)
-      ParticipationFactory.create(task: comment.task, assignee: current_user, assigner: current_user)
-    end
     Activity.comment_created! comment, user: current_user
     respond_with comment if CommentLookManager.sync_comment(comment)
   end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -110,7 +110,8 @@ describe CommentsController do
           )
         end
 
-        it "adds the user as a participant" do
+        # TODO: fix ParticipationFactory to not call CommentLookManager.sync_task when sends an email for every mention in the discussion
+        xit "adds the user as a participant" do
           expect(user.tasks).to_not include(task)
           do_request
           expect(user.reload.tasks).to include(task)


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11350

#### What this PR does:
This PR stops the practice of adding a user as a discussion participant when they add a comment.

When a non-admin makes their first comment on a task they are added as a discussion participant.  This has the unfortunate side effect of sending an email for every existing mention in the discussion thread.  

This is old code, but this started happening because editor are renouncing their staff admin privileges.  Admins do not get added as discussion participants when they comment.

It's especially ugly because now an editor may be added as a participant after a discussion thread has multiple messages.

#### Code Review Tasks:
**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
