### PR TITLE
APERTA-10789 Add cover letter file to router export

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -47,7 +47,7 @@ class Paper < ActiveRecord::Base
   has_many :discussion_topics, inverse_of: :paper, dependent: :destroy
   has_many :snapshots, dependent: :destroy
   has_many :notifications, inverse_of: :paper
-  has_many :answers
+  has_many :answers, inverse_of: :paper
   has_many :assignments, as: :assigned_to
   has_many :roles, through: :assignments
   has_many :related_articles, dependent: :destroy
@@ -637,10 +637,6 @@ class Paper < ActiveRecord::Base
 
   def front_matter?
     !uses_research_article_reviewer_report?
-  end
-
-  def cover_letter_files
-    question_attachments.select(&:cover_letter?)
   end
 
   private

--- a/app/models/question_attachment.rb
+++ b/app/models/question_attachment.rb
@@ -3,7 +3,16 @@
 class QuestionAttachment < Attachment
   include Readyable
   validates :filename, value: true, on: :ready
+
   self.public_resource = true
+
+  def self.cover_letter
+    joins(<<-SQL
+  INNER JOIN answers ON answers.id = attachments.owner_id
+  INNER JOIN card_contents on card_contents.id = answers.card_content_id
+  SQL
+         ).where(card_contents: { ident: "cover_letter--attachment" })
+  end
 
   def card_content
     owner.card_content
@@ -11,9 +20,5 @@ class QuestionAttachment < Attachment
 
   def answer_blank?
     filename.nil?
-  end
-
-  def cover_letter?
-    owner.card_content.ident == "cover_letter--attachment"
   end
 end

--- a/engines/tahi_standard_tasks/app/services/export_packager.rb
+++ b/engines/tahi_standard_tasks/app/services/export_packager.rb
@@ -21,7 +21,7 @@ class ExportPackager
     @zip_file ||= Tempfile.new('zip').tap do |f|
       Zip::OutputStream.open(f) do |package|
         add_figures(package)
-        add_cover_letters(package) if article_router_package?
+        add_cover_letter(package) if article_router_package?
         add_supporting_information(package)
         add_metadata(package)
         add_manuscript(package)
@@ -96,12 +96,9 @@ class ExportPackager
     end
   end
 
-  def add_cover_letters(package)
-    @paper.cover_letter_files.each do |cover_letter|
-      add_file_to_package package,
-                          cover_letter.filename,
-                          cover_letter.file.read
-    end
+  def add_cover_letter(package)
+    letter = @paper.question_attachments.cover_letter.first
+    add_file_to_package(package, letter.filename, letter.file.read) if letter
   end
 
   def add_supporting_information(package)

--- a/engines/tahi_standard_tasks/spec/services/export_packager_spec.rb
+++ b/engines/tahi_standard_tasks/spec/services/export_packager_spec.rb
@@ -207,14 +207,14 @@ describe ExportPackager do
     end
   end
 
-  describe 'add_cover_letters' do
-    let(:attachment) do
+  describe 'add_cover_letter' do
+    let(:attachment_file) do
       double('attachment_model', filename: 'cover-letter.docx',
                                  read: 'some bytes')
     end
-    let(:question_attachment) { double(QuestionAttachment, filename: 'cover-letter.docx', file: attachment) }
+    let(:question_attachment) { double(QuestionAttachment, filename: 'cover-letter.docx', file: attachment_file) }
     before do
-      allow(paper).to receive(:cover_letter_files) { [question_attachment] }
+      allow(paper).to receive_message_chain(:question_attachments, :cover_letter) { [question_attachment] }
     end
 
     it 'adds cover letter files to a zip' do

--- a/spec/models/paper_spec.rb
+++ b/spec/models/paper_spec.rb
@@ -1761,14 +1761,4 @@ describe Paper do
       expect(paper).to_not be_valid
     end
   end
-
-  describe '#cover_letter_files' do
-    it 'returns a collection of question attachments' do
-      attachment_one = double(QuestionAttachment, 'cover_letter?': false)
-      attachment_two = double(QuestionAttachment, 'cover_letter?': true)
-      allow(paper).to receive(:question_attachments) { [attachment_one, attachment_two] }
-
-      expect(paper.cover_letter_files).to be == [attachment_two]
-    end
-  end
 end

--- a/spec/models/question_attachment_spec.rb
+++ b/spec/models/question_attachment_spec.rb
@@ -32,6 +32,24 @@ describe QuestionAttachment do
     it_behaves_like 'attachment#download! when the attachment is invalid'
   end
 
+  describe 'self.cover_letter' do
+    it "returns question attachments whose answers' card contents have the 'cover_letter--attachment' ident" do
+      paper = FactoryGirl.create(:paper)
+      cover_letter_content = FactoryGirl.create(:card_content, ident: 'cover_letter--attachment')
+      answer_to_find = FactoryGirl.create(:answer,
+                                          paper: paper,
+                                          card_content: cover_letter_content)
+      other_content = FactoryGirl.create(:card_content, ident: 'foo')
+      other_answer = FactoryGirl.create(:answer, paper: paper, card_content: other_content)
+      a1 = FactoryGirl.create(:question_attachment, paper: paper, owner: answer_to_find)
+      a2 = FactoryGirl.create(:question_attachment, paper: paper, owner: other_answer)
+
+      letters = paper.reload.question_attachments.cover_letter.all
+      expect(letters).to include(a1)
+      expect(letters).to_not include(a2)
+    end
+  end
+
   describe '#paper' do
     it "returns the answer's paper" do
       expect(attachment.paper).to eq(answer.paper)
@@ -49,17 +67,6 @@ describe QuestionAttachment do
       expect(attachment.src).to eq(
         attachment.non_expiring_proxy_url
       )
-    end
-  end
-
-  describe '#cover_letter?' do
-    it 'returns true if card_content.ident is cover_letter--attachment' do
-      allow(subject.owner.card_content).to receive(:ident) { 'cover_letter--attachment' }
-      expect(subject.cover_letter?).to be_truthy
-    end
-
-    it 'returns false if card_content.ident is not cover_letter--attachment' do
-      expect(subject.cover_letter?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10789

#### What this PR does:
It includes cover letter files in the export package to router.

#### Special instructions for Review or PO:
It is not PO testable.


#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
