### PR TITLE
Mailer does not rely on names which can change

### DIFF
--- a/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
+++ b/engines/tahi_standard_tasks/app/mailers/tahi_standard_tasks/reviewer_mailer.rb
@@ -81,22 +81,22 @@ module TahiStandardTasks
     end
 
     def remind_before_due(reviewer_report_id:)
-      reminder_notice(template_name: 'Review Reminder - Before Due', reviewer_report_id: reviewer_report_id)
+      reminder_notice(letter_template_ident: 'review-reminder-before-due', reviewer_report_id: reviewer_report_id)
     end
 
     def first_late_notice(reviewer_report_id:)
-      reminder_notice(template_name: 'Review Reminder - First Late', reviewer_report_id: reviewer_report_id)
+      reminder_notice(letter_template_ident: 'review-reminder-first-late', reviewer_report_id: reviewer_report_id)
     end
 
     def second_late_notice(reviewer_report_id:)
-      reminder_notice(template_name: 'Review Reminder - Second Late', reviewer_report_id: reviewer_report_id)
+      reminder_notice(letter_template_ident: 'review-reminder-second-late', reviewer_report_id: reviewer_report_id)
     end
 
     def thank_reviewer(reviewer_report_id:)
       @reviewer_report = ReviewerReport.find(reviewer_report_id)
       @paper = @reviewer_report.paper
       @journal = @paper.journal
-      @letter_template = @journal.letter_templates.find_by(name: 'Reviewer Appreciation')
+      @letter_template = @journal.letter_templates.find_by(ident: 'reviewer-appreciation')
       begin
         @letter_template.render(ReviewerReportScenario.new(@reviewer_report), check_blanks: true)
         @subject = @letter_template.subject
@@ -110,11 +110,11 @@ module TahiStandardTasks
 
     private
 
-    def reminder_notice(template_name:, reviewer_report_id:)
+    def reminder_notice(letter_template_ident:, reviewer_report_id:)
       @reviewer_report = ReviewerReport.find(reviewer_report_id)
       @paper = @reviewer_report.paper
       @journal = @paper.journal
-      @letter_template = @journal.letter_templates.find_by(name: template_name)
+      @letter_template = @journal.letter_templates.find_by(ident: letter_template_ident)
       begin
         @letter_template.render(ReviewerReportScenario.new(@reviewer_report), check_blanks: true)
         @subject = @letter_template.subject

--- a/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/reviewer_mailer_spec.rb
+++ b/engines/tahi_standard_tasks/spec/mailers/tahi_standard_tasks/reviewer_mailer_spec.rb
@@ -278,7 +278,8 @@ describe TahiStandardTasks::ReviewerMailer do
   describe 'reminder emails' do
     before do
       report.paper.journal.letter_templates.create!(
-        name: template_name,
+        ident: template_ident,
+        name: template_ident,
         scenario: 'ReviewerReportScenario',
         subject: 'review {{ journal.name }}',
         body: '<p>Dear Dr. {{ reviewer.last_name }}, review {{ manuscript.title }} on {{ review.due_at }} </p>'
@@ -290,7 +291,7 @@ describe TahiStandardTasks::ReviewerMailer do
 
     describe '.remind_before_due' do
       subject(:email) { described_class.remind_before_due(reviewer_report_id: report.id) }
-      let(:template_name) { 'Review Reminder - Before Due' }
+      let(:template_ident) { 'review-reminder-before-due' }
 
       it 'is to the reviewer' do
         expect(email.to).to eq([report.user.email])
@@ -317,7 +318,7 @@ describe TahiStandardTasks::ReviewerMailer do
 
     describe '.first_late_notice' do
       subject(:email) { described_class.first_late_notice(reviewer_report_id: report.id) }
-      let(:template_name) { 'Review Reminder - First Late' }
+      let(:template_ident) { 'review-reminder-first-late' }
 
       it 'is to the reviewer' do
         expect(email.to).to eq([report.user.email])
@@ -344,7 +345,7 @@ describe TahiStandardTasks::ReviewerMailer do
 
     describe '.second_late_notice' do
       subject(:email) { described_class.second_late_notice(reviewer_report_id: report.id) }
-      let(:template_name) { 'Review Reminder - Second Late' }
+      let(:template_ident) { 'review-reminder-second-late' }
 
       it 'is to the reviewer' do
         expect(email.to).to eq([report.user.email])

--- a/spec/factories/letter_template_factory.rb
+++ b/spec/factories/letter_template_factory.rb
@@ -43,6 +43,7 @@ FactoryGirl.define do
     end
 
     trait(:thank_reviewer) do
+      ident 'reviewer-appreciation'
       name 'Reviewer Appreciation'
       subject 'Thank you for reviewing {{ journal.name }}'
       body <<-LETTER.strip_heredoc


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11081

#### What this PR does:
Changes the ReviewerMailer to refer to letter templates by their idents, which do not change.  

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
