### PR TITLE
APERTA-11315 Order Paper Types in New Manuscript Dropdown

### DIFF
--- a/client/app/pods/components/manuscript-new/component.js
+++ b/client/app/pods/components/manuscript-new/component.js
@@ -21,6 +21,43 @@ export default Ember.Component.extend(EscapeListenerMixin, {
   journalEmpty: computed.empty('paper.journal.content'),
   hasTitle: computed.notEmpty('paper.title'),
 
+  orderedPaperTypeNames: [
+    'Research Article',
+    'Short Reports',
+    'Methods and Resources',
+    'Meta-Research Article',
+    'Essay',
+    'Perspective',
+    'Community Page',
+    'Unsolved Mystery',
+    'Primer (invitation only)',
+    'Research Matters (invitation only)',
+    'Formal Comment (invitation only)',
+    'Editorial (staff use only)',
+    'Open Highlights (staff use only)'
+  ],
+
+  // This is a short-term solution for ordering paper types based entirely on
+  // PLOS Biology's needs. We expect to replace this with something more
+  // user configurable in the future. APERTA-11315
+  orderedPaperTypes: Ember.computed('orderedPaperTypeNames.[]', 'paper.journal.manuscriptManagerTemplates.[]', function() {
+    const orderedPaperTypes = Ember.A();
+    return this.get('paper.journal').then((journal) => {
+      if (!journal) { return orderedPaperTypes; }
+      const mmts = journal.get('manuscriptManagerTemplates').copy();
+      this.get('orderedPaperTypeNames').forEach((name) => {
+        const match = mmts.find((mmt) => {
+          return mmt.paper_type === name;
+        });
+        if (match) {
+          orderedPaperTypes.push(match);
+          mmts.removeObject(match);
+        }
+      });
+      return orderedPaperTypes.pushObjects(mmts.sortBy('paper_type'));
+    });
+  }),
+
   actions: {
     titleChanged(contents) {
       this.set('paper.title', contents);

--- a/client/app/pods/components/manuscript-new/template.hbs
+++ b/client/app/pods/components/manuscript-new/template.hbs
@@ -55,7 +55,7 @@
                   class="paper-new-select"
                   triggerClass="paper-new-select-trigger"
                   dropdownClass="paper-new-select-dropdown"
-                  options=paper.journal.manuscriptManagerTemplates
+                  options=orderedPaperTypes
                   selected=template
                   onchange=(action "selectPaperType")
                   searchEnabled=false

--- a/client/tests/integration/pods/components/manuscript-new/component-test.js
+++ b/client/tests/integration/pods/components/manuscript-new/component-test.js
@@ -1,0 +1,27 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { make, manualSetup }  from 'ember-data-factory-guy';
+import Ember from 'ember';
+import { clickTrigger } from 'tahi/tests/helpers/ember-power-select';
+
+moduleForComponent('manuscript-new', 'Integration | Component | manuscript new', {
+  integration: true,
+
+  beforeEach: function () {
+    manualSetup(this.container);
+  }
+});
+
+test('it renders article types in the correct order', function(assert) {
+  const paperTypeNames = ['Pickachu', 'Research Article', 'Bulbasaur', 'Methods and Resources'];
+  const expectedOrder = ['Research Article', 'Methods and Resources', 'Bulbasaur', 'Pickachu'];
+  const manuscriptManagerTemplates = Ember.A($.map(paperTypeNames, (n) => {
+    return {paper_type: n};
+  }));
+  this.paper = make('paper', { journal: { manuscriptManagerTemplates }});
+  this.render(hbs`{{manuscript-new paper=paper}}`);
+  clickTrigger('#paper-new-paper-type-select');
+  const options = $('.ember-power-select-option');
+  const values = $.map(options, (o) => { return o.textContent.trim(); });
+  assert.deepEqual(values, expectedOrder);
+});


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11315

#### What this PR does:

Orders paper types in the manuscript-new dropdown (when an author first creates a paper). Ordering is based off of hard-coded names and is entirely based on the names of the PLOS Biology paper types. We're considering this to be a short-term solution. The UX team is working on a more general approach which would accommodate different journals and allow user configuration.

So that's my excuse for this looking crazy.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
