### PR TITLE
Extract common model scenarios

### DIFF
--- a/app/models/invitation_scenario.rb
+++ b/app/models/invitation_scenario.rb
@@ -1,0 +1,18 @@
+class InvitationScenario < PaperScenario
+  # base sceanario for invitation emails
+  def self.complex_merge_fields
+    [{ name: :invitation, context: InvitationContext },
+     { name: :journal, context: JournalContext },
+     { name: :manuscript, context: PaperContext }]
+  end
+
+  def invitation
+    @invitation ||= InvitationContext.new(@object)
+  end
+
+  private
+
+  def paper
+    @object.paper
+  end
+end

--- a/app/models/paper_scenario.rb
+++ b/app/models/paper_scenario.rb
@@ -1,0 +1,21 @@
+class PaperScenario < TemplateScenario
+  # base scenario for paper emails
+  def self.complex_merge_fields
+    [{ name: :journal, context: JournalContext },
+     { name: :manuscript, context: PaperContext }]
+  end
+
+  def journal
+    @journal ||= JournalContext.new(paper.journal)
+  end
+
+  def manuscript
+    @manuscript ||= PaperContext.new(paper)
+  end
+
+  private
+
+  def paper
+    @object
+  end
+end

--- a/app/models/reviewer_report_scenario.rb
+++ b/app/models/reviewer_report_scenario.rb
@@ -1,5 +1,5 @@
 # Provides a template context for ReviewerReport
-class ReviewerReportScenario < TemplateScenario
+class ReviewerReportScenario < PaperScenario
   def self.complex_merge_fields
     [{ name: :review, context: ReviewerReportContext },
      { name: :reviewer, context: UserContext },
@@ -15,17 +15,13 @@ class ReviewerReportScenario < TemplateScenario
     UserContext.new(reviewer_report.user)
   end
 
-  def journal
-    JournalContext.new(reviewer_report.paper.journal)
-  end
-
-  def manuscript
-    PaperContext.new(reviewer_report.paper)
-  end
-
   private
 
   def reviewer_report
     @object
+  end
+
+  def paper
+    reviewer_report.paper
   end
 end

--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/paper_reviewer_scenario.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/paper_reviewer_scenario.rb
@@ -1,22 +1,10 @@
 module TahiStandardTasks
   # Provides a template context for PaperReviewerTask
-  class PaperReviewerScenario < TemplateScenario
+  class PaperReviewerScenario < InvitationScenario
     def self.complex_merge_fields
       [{ name: :invitation, context: InvitationContext },
        { name: :journal, context: JournalContext },
        { name: :manuscript, context: PaperContext }]
-    end
-
-    def invitation
-      @invitation ||= InvitationContext.new(@object)
-    end
-
-    def journal
-      @journal ||= JournalContext.new(@object.paper.journal)
-    end
-
-    def manuscript
-      @manuscript ||= PaperContext.new(@object.paper)
     end
   end
 end

--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/preprint_descision_scenario.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/preprint_descision_scenario.rb
@@ -1,23 +1,9 @@
 module TahiStandardTasks
   # Provides a template context for PreprintDecisionTasks
-  class PreprintDecisionScenario < TemplateScenario
+  class PreprintDecisionScenario < PaperScenario
     def self.merge_field_definitions
       [{ name: :manuscript, context: PaperContext },
        { name: :journal, context: JournalContext }]
-    end
-
-    def manuscript
-      @manuscript ||= PaperContext.new(paper)
-    end
-
-    def journal
-      @journal ||= JournalContext.new(paper.journal)
-    end
-
-    private
-
-    def paper
-      @object
     end
   end
 end

--- a/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/register_decision_scenario.rb
+++ b/engines/tahi_standard_tasks/app/models/tahi_standard_tasks/register_decision_scenario.rb
@@ -1,18 +1,10 @@
 module TahiStandardTasks
   # Provides a template context for RegisterDecisionTasks
-  class RegisterDecisionScenario < TemplateScenario
+  class RegisterDecisionScenario < PaperScenario
     def self.merge_field_definitions
       [{ name: :manuscript, context: PaperContext },
        { name: :journal, context: JournalContext },
        { name: :reviews, context: ReviewerReportContext, many: true }]
-    end
-
-    def manuscript
-      @manuscript ||= PaperContext.new(paper)
-    end
-
-    def journal
-      @journal ||= JournalContext.new(paper.journal)
     end
 
     def reviews
@@ -21,12 +13,6 @@ module TahiStandardTasks
         ReviewerReportContext.new(rr)
       end
       @reviews.sort_by(&:reviewer_number)
-    end
-
-    private
-
-    def paper
-      @object
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-

#### What this PR does:

Explain in a few sentences what functionality changed, and how. Don't be afraid
to give a little extra detail. The Reviewer is going to read the original
ticket, but this can point them in the right direction.

Can your changes be *seen* by a user? Then add a screenshot. Is it an
interaction?  Perhaps a quick recording?

#### Special instructions for Review or PO:

Is there anything out of the ordinary in how the AC for the ticket needs to be evaluated?
Does the reviewer have to run a rake task? Is there specific seed data they should use?
If PO needs specific guidance on how to evaluate this feature please add that information to the JIRA ticket itself (add a link here if needed)

#### Notes

Are there any surprises? Anything that was particularly difficult, or clever, or
made you nervous, and should get particular attention during review? Call it
out.


#### Major UI changes

Were there major UI changes? Add a screenshot here -- and please let the QA team know that changes are imminent. They would love a little extra time to prepare the QA test suite.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results with `rake db:test_migrations` (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
