### PR TITLE
Empowerment: rake task to print scenarios

### DIFF
--- a/lib/tasks/reports/print_letter_template_scenarios.rake
+++ b/lib/tasks/reports/print_letter_template_scenarios.rake
@@ -1,0 +1,17 @@
+def print_merge_fields(fields, level = 1)
+  fields.each do |field|
+    print '  ' * level, field[:name]
+    print '[]' if field[:many]
+    print "\n"
+    print_merge_fields(field[:children], level + 1) if field[:children]
+  end
+end
+
+namespace :reports do
+  task print_letter_template_scenarios: :environment do
+    TemplateScenario.descendants.each do |scenario|
+      puts scenario
+      print_merge_fields(scenario.merge_fields)
+    end
+  end
+end


### PR DESCRIPTION
#### What this PR does:

This adds a rake task to print out the available scenarios the their merge fields. I expect to use this on occasion to see what's available in the system already (perhaps post a snapshot on confluence).

#### Special instructions for Review or PO:

This is just for reporting -- there is no end-user visible changes.

Run it with `rake reports:print_letter_template_scenarios`

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
