### PR TITLE
Include passive state events when rescheduling in factory

### DIFF
--- a/app/services/scheduled_events_factory.rb
+++ b/app/services/scheduled_events_factory.rb
@@ -9,14 +9,14 @@ class ScheduledEventFactory
 
   def schedule_events
     return unless due_datetime
-    return schedule_new_events unless owned_active_events.exists?
+    return schedule_new_events unless owned_serviceable_events.exists?
     update_scheduled_events
   end
 
   private
 
-  def owned_active_events
-    due_datetime.scheduled_events.active
+  def owned_serviceable_events
+    due_datetime.scheduled_events.where(state: ['passive', 'active'])
   end
 
   def dispatch_date(event)

--- a/spec/services/scheduled_events_factory_spec.rb
+++ b/spec/services/scheduled_events_factory_spec.rb
@@ -109,6 +109,14 @@ describe ScheduledEventFactory do
 
         it_behaves_like 'templated scheduled events', ScheduledEventTestTask::SCHEDULED_EVENTS_TEMPLATE
       end
+
+      context 'when all scheduled events are in the passive state' do
+        it 'should not change the event count' do
+          reviewer_report.due_datetime.scheduled_events.each(&:switch_off!)
+          DueDatetime.set_for(reviewer_report, length_of_time: 10.days)
+          expect { subject }.to change { ScheduledEvent.count }.by(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9689

#### What this PR does:

There a potential bug introduced in #3524 where if a user untoggles all of the scheduled events, the factory reads the absence of active events as a cue to make new events. I guess thats not right. Check out this sweet screencast from QA: https://www.screencast.com/t/2lSIRQVZTn

#### Special instructions for Review or PO:

Make sure the DUE flags are on.

#### Notes

I'm worried that the expectations about functionality are a bit undefined and have edge cases...

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases