### PR TITLE
APERTA-11342 Bugsnag Blank Fields Contextual Information

### DIFF
--- a/app/models/letter_template.rb
+++ b/app/models/letter_template.rb
@@ -29,7 +29,9 @@ class LetterTemplate < ActiveRecord::Base
 
   def render_attr(template, context, sanitize: false, check_blanks: false)
     raw = Liquid::Template.parse(template)
-    raise BlankRenderFieldsError if check_blanks && LetterTemplateBlankValidator.blank_fields?(raw, context)
+    if check_blanks && LetterTemplateBlankValidator.blank_fields?(raw, context)
+      raise BlankRenderFieldsError, LetterTemplateBlankValidator.blank_fields(raw, context)
+    end
     raw = raw.render(context)
     if sanitize
       ActionView::Base.full_sanitizer.sanitize(raw)

--- a/app/validators/letter_template_blank_validator.rb
+++ b/app/validators/letter_template_blank_validator.rb
@@ -1,11 +1,19 @@
 class LetterTemplateBlankValidator
   class << self
     def blank_fields?(letter_template, context)
-      liquid_variables = get_liquid_variables(letter_template.root.nodelist).flatten
-      liquid_variables.any? { |node| blank_liquid_variable?(node.name.name, node.name.lookups, context) }
+      !get_blank_fields(letter_template, context).empty?
+    end
+
+    def blank_fields(letter_template, context)
+      get_blank_fields(letter_template, context).map(&:raw).map(&:strip)
     end
 
     private
+
+    def get_blank_fields(letter_template, context)
+      liquid_variables = get_liquid_variables(letter_template.root.nodelist).flatten
+      liquid_variables.select { |node| blank_liquid_variable?(node.name.name, node.name.lookups, context) }
+    end
 
     def blank_liquid_variable?(name, lookups, context)
       context = context.deep_symbolize_keys if context.is_a? Hash

--- a/spec/models/letter_template_spec.rb
+++ b/spec/models/letter_template_spec.rb
@@ -85,5 +85,22 @@ describe LetterTemplate do
         expect(letter_template.render(html_letter_context.stringify_keys).to).to eq("myemail@example.com")
       end
     end
+
+    context "with missing data" do
+      let(:letter_template) do
+        FactoryGirl.create(:letter_template,
+                           body: "Interesting text about {{ subject }} from {{ email }}")
+      end
+      let(:letter_context) do
+        {
+          subject: "",
+          email: ""
+        }
+      end
+
+      it 'adds blank fields to error object' do
+        expect { letter_template.render(letter_context.stringify_keys, check_blanks: true) }.to raise_error BlankRenderFieldsError, '["subject", "email"]'
+      end
+    end
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11342

#### What this PR does:

Puts the contextual information on Bugsnag.

This code was originally merged into 1.50, but I cannot find the branch to re-raise the PR. So this is a fresh PR from the tip of the APERTA-10946 branch on my local—with nothing changed—so this can be merged into 1.51

#### Special instructions for Review or PO:

Take a look at 10946. All code reviews and acceptance was done there. This may not need to be PO'd again

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
