### PR TITLE
APERTA-10789 rename cover letter file

### DIFF
--- a/engines/tahi_standard_tasks/app/services/export_packager.rb
+++ b/engines/tahi_standard_tasks/app/services/export_packager.rb
@@ -88,6 +88,11 @@ class ExportPackager
     "#{@paper.manuscript_id}.#{extension}"
   end
 
+  def cover_letter_filename
+    extension = @paper.file.filename.split('.').last
+    "aperta-cover-letter-#{@paper.short_doi}.#{extension}"
+  end
+
   def add_figures(package)
     @paper.figures.each do |figure|
       add_file_to_package package,
@@ -98,7 +103,7 @@ class ExportPackager
 
   def add_cover_letter(package)
     letter = @paper.question_attachments.cover_letter.first
-    add_file_to_package(package, letter.filename, letter.file.read) if letter
+    add_file_to_package(package, cover_letter_filename, letter.file.read) if letter
   end
 
   def add_supporting_information(package)

--- a/engines/tahi_standard_tasks/app/services/tahi_standard_tasks/export_service.rb
+++ b/engines/tahi_standard_tasks/app/services/tahi_standard_tasks/export_service.rb
@@ -75,11 +75,6 @@ module TahiStandardTasks
       "#{paper.manuscript_id}.zip"
     end
 
-    def router_package_filename
-      fail_unless_manuscript_id
-      "aperta-cover-letter-#{paper.manuscript_id}.zip"
-    end
-
     def manifest_filename
       fail_unless_manuscript_id
       "#{paper.manuscript_id}.man.json"
@@ -104,7 +99,7 @@ module TahiStandardTasks
         destination: destination,
         email_on_failure: staff_emails,
         file_io: packager.zip_file,
-        final_filename: router_package_filename,
+        final_filename: package_filename,
         filenames: packager.manifest.file_list,
         paper: paper,
         url: router_url,

--- a/engines/tahi_standard_tasks/spec/services/export_packager_spec.rb
+++ b/engines/tahi_standard_tasks/spec/services/export_packager_spec.rb
@@ -220,8 +220,9 @@ describe ExportPackager do
     it 'adds cover letter files to a zip' do
       zip_io = ExportPackager.create_zip(paper, destination: 'not-apex')
 
-      expect(zip_filenames(zip_io)).to include('cover-letter.docx')
-      contents = read_zip_entry(zip_io, 'cover-letter.docx')
+      cover_letter_name = "aperta-cover-letter-#{paper.short_doi}.docx"
+      expect(zip_filenames(zip_io)).to include(cover_letter_name)
+      contents = read_zip_entry(zip_io, cover_letter_name)
       expect(contents).to eq('some bytes')
     end
   end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10789?focusedCommentId=184928&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-184928
This ticket was kicked back per the comments in the above link, and this PR includes the fixes.

#### What this PR does:

- The cover letter upload needs to have 'aperta-cover-letter-{paper.short_doi}-'
  appended to it as per the AC of the ticket
- I'm pretty sure the intent of the AC wasn't to rename the overall file name of
  the package when being sent to the router, rather just to rename the cover
  letter file itself, so I've changed the final filename back to what it was
  previously.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
