### PR TITLE
temporarily commented users with non-ascii characters: APERTA-11437

### DIFF
--- a/test/Base/Resources.py
+++ b/test/Base/Resources.py
@@ -617,9 +617,9 @@ users = [creator_login1,
          creator_login7,
          creator_login8,
          creator_login9,
-         creator_login10,
+         # creator_login10, # temporarily commented username with non ascii characters due to APERTA-11437
          creator_login11,
-         creator_login12,
+         # creator_login12, # temporarily commented username with non ascii characters due to APERTA-11437
          creator_login13,
          creator_login14,
          creator_login15,
@@ -698,9 +698,9 @@ all_orcid_users = [
                    creator_login7,
                    creator_login8,
                    creator_login9,
-                   creator_login10,
+                   # creator_login10, # temporarily commented username with non-ascii characters due to APERTA-11437
                    creator_login11,
-                   creator_login12,
+                   # creator_login12, # temporarily commented username with non-ascii characters due to APERTA-11437
                    creator_login13,
                    creator_login14,
                    creator_login15,


### PR DESCRIPTION
related to JIRA issue: https://jira.plos.org/jira/browse/APERTA-11437

#### What this PR does:

Temporarily commented users with non-ascii characters (hgrœnßmøñé and Öxfjørd) due to APERTA-11437

#### Special instructions for Review or PO:


#### Notes




#### Major UI changes

Were there major UI changes? Add a screenshot here -- and please let the QA team know that changes are imminent. They would love a little extra time to prepare the QA test suite.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results with `rake db:test_migrations` (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
