### PR TITLE
Updated locator for Discussion Participant elements to be unique afte…

### DIFF
--- a/test/frontend/Cards/basecard.py
+++ b/test/frontend/Cards/basecard.py
@@ -33,15 +33,18 @@ class BaseCard(AuthenticatedPage):
     self._manuscript_icon = (By.CLASS_NAME, 'manuscript-icon')
     self._close_button = (By.CSS_SELECTOR, 'a.overlay-close-button')
     self._card_heading = (By.CSS_SELECTOR, 'h1.overlay-body-title')
-
+    self._card_assingment_label = (By.CSS_SELECTOR, 'div.overlay-assignable-user > span')
+    self._card_assignment_button = (By.CSS_SELECTOR, 'div.overlay-assignable-user '
+                                                     '> div.add-participant-button')
     self._notepad_textarea = (By.CSS_SELECTOR, 'textarea.notepad')
     self._notepad_toggle_icon = (
         By.XPATH, '//span[contains(text(), "Your notepad")]/preceding-sibling::i')
 
     self._discussion_div = (By.CLASS_NAME, 'overlay-discussion-board')
     self._add_comment = (By.CLASS_NAME, 'new-comment-field')
-    self._following_label = (By.CLASS_NAME, 'participant-selector-label')
-    self._add_participant_btn = (By.CLASS_NAME, 'add-participant-button')
+    self._following_label = (By.CSS_SELECTOR, '.overlay-footer > div '
+                                              '> span.participant-selector-label')
+    self._add_participant_btn = (By.CSS_SELECTOR, '.overlay-footer > div > .add-participant-button')
     self._message_comment = (By.CLASS_NAME, 'message-comment')
     self._completion_button = (By.CSS_SELECTOR, 'button.task-completed')
     self._bottom_close_button = (By.CSS_SELECTOR, 'footer.overlay-footer > a')
@@ -253,6 +256,7 @@ class BaseCard(AuthenticatedPage):
     assert expected_text.strip() in message_comment.text, (expected_text.strip(),
                                                            message_comment.text)
     # Check footer
+    self._scroll_into_view(self._get(self._following_label))
     following_label = self._get(self._following_label)
     assert following_label.text == 'Following:', following_label.text
     self._wait_for_element(self._get(self._add_participant_btn))


### PR DESCRIPTION
…r the APERTA-10960 made them non-unique.

# QA Ticket

JIRA issue: link-to-jira: https://jira.plos.org/jira/browse/APERTA-10960

#### What this PR does:

The work done for APERTA-10960 made the locator for the card-based discussion participant label and button non-unique - that is, they now share the previously defined locators with the card assignment label and button - when that element in shown.

This ticket adds two new locators for the card assignment label and button, and makes the locators between card assignment label and button, and card discussion participant label and button unique.

#### Notes

Extending the base card test to cover actual testing of card assignment is beyond the scope of this PR.

---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
