### PR TITLE
APERTA-11365 Display only published cards in choose-new-card template

### DIFF
--- a/client/app/pods/components/choose-new-card/component.js
+++ b/client/app/pods/components/choose-new-card/component.js
@@ -22,15 +22,15 @@ export default Ember.Component.extend(EscapeListenerMixin, {
 
   // card-config
   cardSort: ['name:asc'],
-  sortedCards: computed.sort('cards', 'cardSort'),
-
+  publishedCards: computed.filterBy('cards', 'state', 'published'),
+  sortedCards: computed.sort('publishedCards', 'cardSort'),
   addableCards: computed.filterBy('sortedCards', 'addable', true),
   addableWorkFlowCards: computed.filterBy('sortedCards', 'workflow_only', true),
   addableNonWorkFlowCards: computed.setDiff('sortedCards', 'addableWorkFlowCards'),
 
   // pre-card-config
   taskTypeSort: ['title:asc'],
-  
+
   // TODO: get rid of task type filtering after last legacy card ruby class is deleted
   filteredTaskTypes: computed.filter('journalTaskTypes', function(taskType) {
     let title = taskType.get ? taskType.get('title') : '';
@@ -40,7 +40,7 @@ export default Ember.Component.extend(EscapeListenerMixin, {
   authorTasks: computed.filterBy('filteredTaskTypes', 'roleHint', 'author'),
   unsortedAuthorColumn: computed.union('authorTasks', 'addableNonWorkFlowCards'),
   authorColumn: computed.sort('unsortedAuthorColumn', 'taskTypeSort'),
-  
+
   staffTasks: computed.setDiff('filteredTaskTypes', 'authorTasks'),
   unsortedStaffColumn: computed.union('staffTasks', 'addableWorkFlowCards'),
   staffColumn: computed.sort('unsortedStaffColumn', 'taskTypeSort'),

--- a/client/tests/integration/pods/components/choose-new-card/component-test.js
+++ b/client/tests/integration/pods/components/choose-new-card/component-test.js
@@ -8,7 +8,7 @@ moduleForComponent('choose-new-card', 'Integration | Component | choose new card
 });
 
 const phase = Ember.Object.create({ name: 'my phase' });
-const card = Ember.Object.create({ title: 'workflow customized card', addable: true, workflow_only: true });
+const card = Ember.Object.create({ title: 'workflow customized card', addable: true, workflow_only: true, state: 'published' });
 const draftCard = Ember.Object.create({ title: 'customized draft card', addable: false });
 const save = sinon.spy();
 const close = sinon.spy();
@@ -85,4 +85,28 @@ test('Cards with titles SUBCLASSME and "Custom Card" are not displayed', functio
 
   assert.textNotPresent('.author-task-cards label', 'Custom Card');
   assert.textNotPresent('.staff-task-cards label', 'SUBCLASSME');
+});
+
+test('Only published cards are displayed', function(assert) {
+  let unpublishedCard = Ember.Object.create({ title: 'Unpublished card', addable: true, workflow_only: true, state: 'draft' });
+
+  const authorJournalTaskType = Ember.Object.create({ title: 'author jtt', roleHint: 'author' });
+  const staffJournalTaskType = Ember.Object.create({ title: 'staff jtt', roleHint: 'staff' });
+  const journalTaskTypes = [authorJournalTaskType, staffJournalTaskType];
+  this.set('journalTaskTypes', journalTaskTypes);
+
+  this.set('phase', phase);
+  this.set('cards', [card, unpublishedCard]);
+  this.on('save', save);
+  this.on('close', close);
+
+  this.render(hbs`
+    {{choose-new-card phase=phase
+                      journalTaskTypes=journalTaskTypes
+                      cards=cards
+                      isLoading=false
+                      onSave=(action 'save')
+                      close=(action 'close')}}`);
+
+  assert.textNotPresent('.staff-task-cards label', 'Unpublished card');
 });


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11365

#### What this PR does:

It updates the choose-new-card component to filter out cards that are not published.

#### Special instructions for Review or PO:

The ticket has all the necessary reproduction steps.



---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
