### PR TITLE
APERTA-10458 In migrating the reporting guidelines card, we nixed a k…

### DIFF
--- a/test/frontend/Cards/reporting_guidelines_card.py
+++ b/test/frontend/Cards/reporting_guidelines_card.py
@@ -21,7 +21,7 @@ class ReportingGuidelinesCard(BaseCard):
 
     # Locators - instance members
     self._question_text = (By.CSS_SELECTOR, 'li.question')
-    self._select_instruction = (By.CSS_SELECTOR, 'div.question-list div.card-content-view-text p')
+    self._select_instruction = (By.CSS_SELECTOR, 'ol + div.ember-view.card-content-view-text')
     self._selection_list = (By.CSS_SELECTOR, 'div.task-main-content.custom-card-task.single-column')
     self._prisma_uploaded_file_link = (By.CLASS_NAME, 'file-link')
 

--- a/test/frontend/Pages/authenticated_page.py
+++ b/test/frontend/Pages/authenticated_page.py
@@ -532,7 +532,10 @@ class AuthenticatedPage(StyledPage):
     :return: void function
     """
     self.set_timeout(15)
-    self._get(self._flash_closer).click()
+    try:
+      self._get(self._flash_closer).click()
+    except ElementDoesNotExistAssertionError:
+      logging.warning('Flash message not found to close...')
     self.restore_timeout()
 
   def close_modal(self):

--- a/test/frontend/Tasks/reporting_guidelines_task.py
+++ b/test/frontend/Tasks/reporting_guidelines_task.py
@@ -23,7 +23,7 @@ class ReportingGuidelinesTask(BaseTask):
 
     # Locators - Instance members
     self._question_text = (By.CSS_SELECTOR, 'li.question')
-    self._select_instruction = (By.CSS_SELECTOR, 'div.question-list div.card-content-view-text p')
+    self._select_instruction = (By.CSS_SELECTOR, 'ol + div.ember-view.card-content-view-text')
     self._selection_list = (By.CSS_SELECTOR, 'div.task-main-content.custom-card-task.single-column')
     self._prisma_upload_button = (By.CLASS_NAME, 'fileinput-button')
     self._prisma_uploaded_file_link = (By.CLASS_NAME, 'file-link')


### PR DESCRIPTION
…ey locator. This pull request addresses that change.

# QA Ticket

JIRA issue: APERTA-10458

#### What this PR does: 

APERTA-10458 migrated the reporting guidelines card to card-config. As a result the locators changed.

Additionally, the display of flash messages on conversion has become flaky in the application. The close function for this flash message was downgraded from an error to a warning.

#### Notes

None
---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
