### PR TITLE
Amended locator for Upload Manuscript task neccesitated by the migrat…

### DIFF
--- a/test/frontend/Pages/manuscript_viewer.py
+++ b/test/frontend/Pages/manuscript_viewer.py
@@ -135,7 +135,7 @@ class ManuscriptViewerPage(AuthenticatedPage):
     self._research_reviewer_report_task = (By.CLASS_NAME, 'reviewer-report-task')
     self._front_matter_reviewer_report_task = (By.CLASS_NAME, 'front-matter-reviewer-report-task')
     self._supporting_info_task = (By.CLASS_NAME, 'supporting-info-task')
-    self._upload_manu_task = (By.CLASS_NAME, 'upload-manuscript-task')
+    self._upload_manu_task = (By.CLASS_NAME, 'task-type-upload-manuscript-task')
     # infobox
     self._question_mark_icon = (By.ID, 'submission-process-toggle')
     # While IDs are normally king, for this element, we don't hide the element, we just change


### PR DESCRIPTION
…ion of that task to card config.

# QA Ticket

JIRA issue: link-to-jira

#### What this PR does:

When the Upload Manuscript card was migrated to card config, the locator for the card in the accordion presentation changed.


#### Notes

No surprises

---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
