### PR TITLE
APERTA-11301 Closing collaborator view raises error

### DIFF
--- a/client/app/pods/components/paper-control-bar/component.js
+++ b/client/app/pods/components/paper-control-bar/component.js
@@ -43,7 +43,7 @@ export default ControlBar.extend({
       if (this.get('submenuVisible') && this.get(`${sectionName}Visible`)) {
         this.resetSubmenuFlags();
         this.set('submenuVisible', false);
-        this.get('transitionToPaperIndex')();
+        if (this.get('versioningMode')) this.get('transitionToPaperIndex')();
       } else {
         this.showSection(sectionName);
       }

--- a/client/tests/components/paper-control-bar-test.js
+++ b/client/tests/components/paper-control-bar-test.js
@@ -98,3 +98,15 @@ test('can not view recent activity, no recent activity nav icon', function(asser
     assert.equal(this.$('#nav-recent-activity').length, 0);
   });
 });
+
+test('Toggling Collaborators from paper index does not throw an error', function(assert) {
+  const can = FakeCanService.create();
+  this.register('service:can', can.asService());
+
+  this.render(template);
+  return wait().then(() => {
+    assert.equal(this.$('#nav-collaborators').length, 1);
+    this.$('#nav-collaborators').click();
+    assert.ok(this.$('#nav-collaborators').click());
+  });
+});


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11301

#### What this PR does:

Toggling collaborators off from the paper index view throws an Ember error. The transitionToPaperIndex action that the error refers to calls code specific to the versions component from the main paper control bar, without a check that one was currently in versions view.

This PR adds a conditional to calling transitionToPaperIndex, and an Ember test to toggle Collaborators on and off from the index view, and make sure an error isn’t thrown.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
