### PR TITLE
A fix I had put in on a previous pr, got nicked somewhere - reimpleme…

### DIFF
--- a/test/frontend/test_title_abstract_card.py
+++ b/test/frontend/test_title_abstract_card.py
@@ -129,16 +129,10 @@ class TitleAbstractTest(CommonTest):
     paper_viewer = ManuscriptViewerPage(self.getDriver())
     paper_viewer._wait_for_element(paper_viewer._get(paper_viewer._upload_manu_task))
     paper_viewer.click_task('Upload Manuscript')
-    upms = UploadManuscriptTask(self.getDriver())
-    upms._wait_for_element(upms._get(upms._completion_button))
-    completed = upms.completed_state()
-    if completed:
-      upms.click_completion_button()
-    upms._wait_for_element(upms._get(upms._upload_manuscript_replace_btn))
-    upms.upload_manuscript()
-    upms.validate_ihat_conversions_success(timeout=45)
-    upms.check_for_flash_error()
-    upms.logout()
+    paper_viewer.complete_task('Upload Manuscript')
+    paper_viewer.validate_ihat_conversions_success(timeout=45)
+    paper_viewer.check_for_flash_error()
+    paper_viewer.logout()
 
     # log back in as editor to validate T&A card state reset
     staff_user = random.choice(editorial_users)


### PR DESCRIPTION
…nted that previous fix - in a slightly different way.

# QA Ticket

JIRA issue: None

#### What this PR does:

Corrects a routine that completes the Upload Manuscript task as part of a test for the title and abstract card. I had a fix like this in a previous PR, but it looks like it got overwritten.

#### Notes

None

---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
