### PR TITLE
The email widget was dropped from three of the four ad hoc card types…

### DIFF
--- a/test/frontend/test_ad_hoc.py
+++ b/test/frontend/test_ad_hoc.py
@@ -75,7 +75,11 @@ class AdHocCardTest(CommonTest):
     ad_hoc_card.card_ready()
     ad_hoc_card.validate_card_elements_styles(short_doi, ad_hoc_user)
     ad_hoc_card._get(ad_hoc_card._add_btn).click()
-    widget = random.choice(('checkbox', 'input_text', 'paragraph', 'email', 'file_upload'))
+    # By design the email widget is only available to users who can properly utilize it - staff.
+    if ad_hoc_user == 'Staff Only':
+        widget = random.choice(('checkbox', 'input_text', 'paragraph', 'email', 'file_upload'))
+    else:
+      widget = random.choice(('checkbox', 'input_text', 'paragraph', 'file_upload'))
     logging.info('Testing {0} widget'.format(widget))
     ad_hoc_card.validate_widgets_styles(widget)
     return None


### PR DESCRIPTION
… due to functionality problems with that widget for external users. The widget check is now aware of ad hoc card type.

# QA Ticket

JIRA issue: No JIRA Issue

#### What this PR does:

Originally, when the ad hoc test was developed - all the ad hoc card types (Staff, Editor, Reviewer and Author) included all widget types (checkbox, textarea, paragraph, email and attachment). The email widget never worked for any external users (Academic Editor, Reviewer or Author) so the widget was dropped from those three types in response to a bug.

This PR makes that widget check card type aware.

#### Notes

None
---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
