### PR TITLE
journal is not passable to task_factory

### DIFF
--- a/spec/authorizations/reverse_query_spec.rb
+++ b/spec/authorizations/reverse_query_spec.rb
@@ -75,7 +75,7 @@ DESC
 
     context "when different tasks have the same permission such as 'be_assigned' or 'assign_others'" do
       let!(:task) { FactoryGirl.create(:task, :with_card, title: 'AwesomeSauce') }
-      let(:another_task) { FactoryGirl.create(:task, title: 'Another task', journal: my_journal) }
+      let(:another_task) { FactoryGirl.create(:task, title: 'Another task') }
       let(:my_journal) { task.journal }
       let(:reviewer) { FactoryGirl.create :user }
       let(:cover_editor) { FactoryGirl.create :user }


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10364

#### What this PR does:

Fixes a failing spec.  It is not clear why it only started failing after being merged but it is clear that journal is not something that can be passed directly to task_factory.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
