### PR TITLE
APERTA-11065 added attachments to the JIRA issue

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -3,7 +3,7 @@ class FeedbackController < ApplicationController
 
   def create
     FeedbackMailer.contact(current_user, feedback_params).deliver_later
-    JIRAIntegrationWorker.perform_async(current_user.full_name, feedback_params[:remarks]) if FeatureFlag[:JIRA_INTEGRATION]
+    JIRAIntegrationWorker.perform_async(current_user.full_name, feedback_params) if FeatureFlag[:JIRA_INTEGRATION]
     render json: {}, status: :created
   end
 

--- a/app/workers/jira_integration_worker.rb
+++ b/app/workers/jira_integration_worker.rb
@@ -1,7 +1,7 @@
 class JIRAIntegrationWorker
   include Sidekiq::Worker
 
-  def perform(user_full_name, remarks)
-    JIRAIntegrationService.create_issue(user_full_name, remarks)
+  def perform(user_full_name, feedback_params)
+    JIRAIntegrationService.create_issue(user_full_name, feedback_params)
   end
 end

--- a/spec/services/jira_integration_service_spec.rb
+++ b/spec/services/jira_integration_service_spec.rb
@@ -9,10 +9,26 @@ describe JIRAIntegrationService do
   end
 
   describe '#build_payload' do
+    let(:params) { { remarks: 'talks' } }
     it 'should return a properly formatted hash' do
-      payload = subject.build_payload('tim', 'talks')
+      payload = subject.build_payload('tim', params)
       expect(payload.dig(:fields, :summary)).to match(/tim/)
       expect(payload.dig(:fields, :description)).to eq('talks')
+    end
+
+    context 'with attachments' do
+      let(:params) do
+        {
+          remarks: 'talks',
+          screenshots: [
+            { url: 'http://example.com/file?name=awesomeness.gif', name: 'Awesomeness' }
+          ]
+        }
+      end
+      it 'should attach the links to the attachments' do
+        payload = subject.build_payload('tim', params)
+        expect(payload.dig(:fields, :description)).to match(/awesomeness\.gif/)
+      end
     end
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11065

#### What this PR does:

Adds attachments to the JIRA report.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases