### PR TITLE
Also test the ci db dump when testing migrations

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -34,7 +34,7 @@ namespace :db do
 
   desc "Test migrations against all known environments"
   task test_migrations: :environment do
-    %w[prod stage rc].each do |env|
+    %w[prod stage rc ci].each do |env|
       rake_reenable_and_invoke('db:import_remote', env)
       rake_reenable_and_invoke('db:migrate')
     end


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

When running `rake db:test_migrations`, also test the ci dump.

#### Notes

Somehow this slipped by when I first implmented this rake task.

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
