### PR TITLE
APERTA-11069 aperta_id should export the aperta ID, not the short doi 

### DIFF
--- a/app/services/router_uploader_service.rb
+++ b/app/services/router_uploader_service.rb
@@ -45,7 +45,7 @@ class RouterUploaderService
   end
 
   def aperta_id
-    @paper.id.to_s.rjust(7, '0')
+    "aperta.#{@paper.id.to_s.rjust(7, '0')}"
   end
 
   def router_payload

--- a/spec/services/router_uploader_service_spec.rb
+++ b/spec/services/router_uploader_service_spec.rb
@@ -18,8 +18,9 @@ describe RouterUploaderService do
   end
 
   describe '#aperta_id' do
-    it 'returns a 7 digit string padded with zeros' do
-      expect(@service.aperta_id).to be == paper.id.to_s.rjust(7, '0')
+    it 'returns the word aperta concatenated with a 7 digit string padded with zeros' do
+      allow(paper).to receive(:id) { '1111' }
+      expect(@service.aperta_id).to be == 'aperta.0001111'
     end
   end
 end


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11069

#### What this PR does:
It sets aperta_id to a 7 digit string padded with zeros which is then used in RouterUploaderService#router_payload


#### Special instructions for Review or PO:

Not PO testable 


#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
~I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket~ Not done based on scope of changes.
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
