### PR TITLE
APERTA-11575 Add a sleep temporarily to fix the timing error

### DIFF
--- a/app/subscribers/manuscript_attachment/process_manuscript.rb
+++ b/app/subscribers/manuscript_attachment/process_manuscript.rb
@@ -4,6 +4,14 @@ class ManuscriptAttachment::ProcessManuscript
     manuscript_attachment = event_data[:record]
     if manuscript_attachment.did_file_change?
       if manuscript_attachment.file_type == 'pdf'
+        # This is due to a subtle timing issue. We depend on slanger pushing an
+        # "update" event to the client to let the client know that there is a
+        # manuscript file that is ready for them. But we need them to subscribe
+        # to the channel for this paper first, and sometimes it takes a little
+        # longer for the subscription to happen. So just sleep here for a little
+        # bit. We will fix this when we clean up the horrendous upload logic.
+        # TODO: FIX in APERTA-11664
+        sleep(3)
         # no ihat processing required for PDFs, but in lieu of this,
         # paper.body requires updating in order to trigger versioned_text
         # creation with proper file_type (necessary for proper rendering)


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11575

#### What this PR does:

Adds a classic sleep workaround to work around a timing issue. :flushed: 

#### Major UI changes

Were there major UI changes? Add a screenshot here -- and please let the QA team know that changes are imminent. They would love a little extra time to prepare the QA test suite.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
