### PR TITLE
Display Adhoc cards for users with journal setup role

### DIFF
--- a/client/app/models/task-template.js
+++ b/client/app/models/task-template.js
@@ -9,6 +9,7 @@ export default DS.Model.extend({
   template: DS.attr(),
   title: DS.attr('string'),
   type: Ember.computed.readOnly('kind'),
+  viewable: true, // this is needed to allow us interact with task templates in the mmt view
   kind: Ember.computed.readOnly('journalTaskType.kind'),
   allSettings: DS.attr(),
   settings: Ember.computed('allSettings', function(){


### PR DESCRIPTION

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11480

#### What this PR does:

Provides a fix so that users with journal setup role can access and edit Adhoc cards.


#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
