### PR TITLE
APERTA-11065 adds a link for each attachment

### DIFF
--- a/app/services/jira_integration_service.rb
+++ b/app/services/jira_integration_service.rb
@@ -58,7 +58,7 @@ class JIRAIntegrationService
     def attachment_urls(feedback_params)
       result = ''
       feedback_params.dig(:screenshots).each do |screenshot|
-        result = screenshot[:url] + "\n"
+        result += screenshot[:url] + "\n"
       end
       result
     end

--- a/spec/services/jira_integration_service_spec.rb
+++ b/spec/services/jira_integration_service_spec.rb
@@ -16,7 +16,7 @@ describe JIRAIntegrationService do
       expect(payload.dig(:fields, :description)).to eq('talks')
     end
 
-    context 'with attachments' do
+    context 'with one attachment' do
       let(:params) do
         {
           remarks: 'talks',
@@ -25,9 +25,27 @@ describe JIRAIntegrationService do
           ]
         }
       end
-      it 'should attach the links to the attachments' do
+      it 'should attach a link to the attachment' do
         payload = subject.build_payload('tim', params)
         expect(payload.dig(:fields, :description)).to match(/awesomeness\.gif/)
+      end
+    end
+
+    context 'with multiple attachments' do
+      let(:params_with_multiple_attachments) do
+        {
+          remarks: 'talks',
+          screenshots: [
+            { url: 'http://example.com/file?name=awesomeness.gif', name: 'Awesomeness' },
+            { url: 'http://example.com/file?name=ssenemosewa.gif', name: 'ssenemosewA' }
+          ]
+        }
+      end
+
+      it 'should attach the links to the attachments' do
+        payload = subject.build_payload('tim', params_with_multiple_attachments)
+        expect(payload.dig(:fields, :description)).to match(/awesomeness\.gif/)
+        expect(payload.dig(:fields, :description)).to match(/ssenemosewa\.gif/)
       end
     end
   end


### PR DESCRIPTION
Instead of concatenating the links to the other attachments in the list,
I was replacing it. This fixes the issue.

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11065

#### What this PR does:

Ensures that the links to all attachments are in the JIRA issue raised

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
~~I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket~~ I'm not sure where to access the generated tickets.  This fix is trivial and and is passing tests.
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases