### PR TITLE
APERTA-11700 Support REVIEWER IS paper tracker query

### DIFF
--- a/app/services/query_parser.rb
+++ b/app/services/query_parser.rb
@@ -68,6 +68,14 @@ class QueryParser < QueryLanguageParser
       .and(table['assigned_to_type'].eq('Paper'))
   end
 
+  add_simple_expression('REVIEWER IS') do |user_query|
+    user_ids = get_user_ids(user_query)
+
+    task_table = join Task
+    report_table = join ReviewerReport, "task_id", task_table.table_alias + ".id"
+    report_table[:user_id].in(user_ids)
+  end
+
   add_two_part_expression('USER', 'HAS ANY ROLE') do |user_query, _|
     user_ids = get_user_ids(user_query)
 

--- a/spec/services/query_parser_spec.rb
+++ b/spec/services/query_parser_spec.rb
@@ -291,6 +291,13 @@ describe QueryParser do
           "assignments_0"."user_id" IN (#{user.id}) AND "assignments_0"."role_id" IN (#{role2.id}) AND "assignments_0"."assigned_to_type" = 'Paper' AND "papers"."id" NOT IN (SELECT assigned_to_id FROM "assignments" WHERE "assignments"."role_id" IN (#{role.id}) AND "assignments"."assigned_to_type" = 'Paper')
         SQL
       end
+
+      it "parses REVIEWER IS" do
+        parse = QueryParser.new(current_user: user).parse "REVIEWER IS #{user_query}"
+        expect(parse.to_sql).to eq(<<-SQL.strip)
+          "reviewer_reports_1"."user_id" IN (#{user.id})
+        SQL
+      end
     end
 
     describe 'people queries' do


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11700

#### What this PR does:

Allows staff to find all papers that have a given reviewer by using `REVIEWER IS doe`

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
