### PR TITLE
APERTA-11291 Serve TinyMCE locally instead of from CDN

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -14,7 +14,6 @@
     "underscore": "1.7.0",
     "jt.timepicker": "^1.11.11",
     "autosize": "^4.0.0",
-    "keyevent": "^1.0.0",
-    "tinymce": "4.4.3"
+    "keyevent": "^1.0.0"
   }
 }

--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -25,7 +25,7 @@ module.exports = function(defaults) {
       enabled: EmberApp.env() === 'production'
     },
     fingerprint: {
-      exclude: ['skins/lightgray/fonts', 'skins/lightgray', 'plugins/codesample/css']
+      exclude: ['skins', 'plugins']
     }
   };
 
@@ -78,28 +78,22 @@ module.exports = function(defaults) {
   // TinyMCE
   app.import(app.bowerDirectory + '/tinymce/plugins/codesample/css/prism.css');
 
-  app.import(app.bowerDirectory + '/tinymce/tinymce.min.js');
-  app.import(app.bowerDirectory + '/tinymce/themes/modern/theme.min.js');
-  app.import(app.bowerDirectory + '/tinymce/plugins/code/plugin.min.js');
-  app.import(app.bowerDirectory + '/tinymce/plugins/codesample/plugin.min.js');
-  app.import(app.bowerDirectory + '/tinymce/plugins/paste/plugin.min.js');
-  app.import(app.bowerDirectory + '/tinymce/plugins/table/plugin.min.js');
-  app.import(app.bowerDirectory + '/tinymce/plugins/link/plugin.min.js');
-  app.import(app.bowerDirectory + '/tinymce/plugins/autoresize/plugin.min.js');
+  app.import('node_modules/tinymce/tinymce.js');
+  app.import('node_modules/tinymce/themes/modern/theme.js');
+  app.import('node_modules/tinymce/plugins/code/plugin.js');
+  app.import('node_modules/tinymce/plugins/codesample/plugin.js');
+  app.import('node_modules/tinymce/plugins/paste/plugin.js');
+  app.import('node_modules/tinymce/plugins/table/plugin.js');
+  app.import('node_modules/tinymce/plugins/link/plugin.js');
+  app.import('node_modules/tinymce/plugins/autoresize/plugin.js');
 
-  var tinymceFonts = new Funnel(app.bowerDirectory + '/tinymce/skins/lightgray/fonts', {
+  var tinymceSkins = new Funnel('node_modules/tinymce/skins/lightgray', {
     srcDir: '/',
-    include: ['*.woff', '*.ttf'],
-    destDir: '/assets/skins/lightgray/fonts'
-  });
-
-  var tinymceCSS = new Funnel(app.bowerDirectory + '/tinymce/skins/lightgray/', {
-    srcDir: '/',
-    include: ['*.css'],
+    include: ['fonts/*.woff', 'fonts/*.ttf', '*.css'],
     destDir: '/assets/skins/lightgray'
   });
 
-  var prism = new Funnel(app.bowerDirectory + '/tinymce/plugins/codesample/css', {
+  var prism = new Funnel('node_modules/tinymce/plugins/codesample/css', {
     srcDir: '/',
     include: ['*.css'],
     destDir: '/assets/plugins/codesample/css'
@@ -109,5 +103,5 @@ module.exports = function(defaults) {
     app.import('vendor/pusher-test-stub.js', { type: 'test' });
   }
 
-  return app.toTree([select2Assets, tinymceFonts, tinymceCSS, prism]);
+  return app.toTree([select2Assets, tinymceSkins, prism]);
 };

--- a/client/package.json
+++ b/client/package.json
@@ -86,6 +86,7 @@
     "loader.js": "^4.2.3",
     "npm-install-retry": "^1.0.2",
     "pusher-js": "^4.1.0",
+    "tinymce": "4.4.3",
     "yuidocjs": "^0.10.2"
   },
   "ember-addon": {


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11291

#### What this PR does:

When the TinyMCE CDN is down, all rich-text-editor components will render as plain textareas. This disables loading TinyMCE from the CDN, and uses the Ember asset pipeline via a new bower tinymce component.

Reviewer: This doesn't change any app code, so I think the existing Capybara and Ember tests for the editor arel be sufficient, since there isn't any new UI or backend behavior being added.

#### Special instructions for Review or PO:

Do a "smoke test" of TinyMCE behavior, by finding both legacy and custom card tasks which use TinyMCE editors, and make sure everything works as expected.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

