### PR TITLE
Fixed flaky workflow test which was testing a dashboard component unn…

### DIFF
--- a/test/frontend/test_workflow.py
+++ b/test/frontend/test_workflow.py
@@ -44,9 +44,7 @@ class ApertaWorkflowTest(CommonTest):
     workflow_user = random.choice(workflow_users)
     logging.info('Logging in as {0}'.format(workflow_user['name']))
     dashboard_page = self.cas_login(workflow_user['email'])
-    # We have to ensure there *is* a first manuscript on a users dashboard
-    manuscript_count = dashboard_page.validate_manuscript_section_main_title(workflow_user)[0]
-    logging.info(manuscript_count)
+    dashboard_page.page_ready()
     dashboard_page.click_create_new_submission_button()
     self.create_article(title='Created Document for Workflow test', journal='PLOS Wombat',
                         type_='Research', random_bit=True)


### PR DESCRIPTION
…ecessarily - dropped the validation as it has no bearing on workflow_test.

# QA Ticket

JIRA issue: No JIRA issue, but this Teamcity failure: https://teamcity.plos.org/teamcity/viewLog.html?buildId=141766&buildTypeId=Aperta_NoNoseIntegrationTestOnSfoRc&tab=buildResultsDiv#testNameId-3967978742646193013

#### What this PR does:

The workflow test was unnecessarily running a validation for dashboard content - that was failing intermittently - specifically when between loading the dashboard and checking the db, a new manuscript is created - it would lead to a failure. Given that this is pertinent and tested as part of the dashboard test, and represented unnecessary duplication withing the workflow test, I flipped that validation out for a page_ready() call.

#### Notes

No surprises

---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
