### PR TITLE
fix for test_smoke_reporting_guidelines_styles

### DIFF
--- a/test/frontend/Cards/reporting_guidelines_card.py
+++ b/test/frontend/Cards/reporting_guidelines_card.py
@@ -21,7 +21,7 @@ class ReportingGuidelinesCard(BaseCard):
 
     # Locators - instance members
     self._question_text = (By.CSS_SELECTOR, 'li.question')
-    self._select_instruction = (By.CSS_SELECTOR, 'ol + div.ember-view.card-content-view-text')
+    self._select_instruction = (By.CSS_SELECTOR, 'li div.card-content-view-text')
     self._selection_list = (By.CSS_SELECTOR, 'div.task-main-content.custom-card-task.single-column')
     self._prisma_uploaded_file_link = (By.CLASS_NAME, 'file-link')
 

--- a/test/frontend/Tasks/reporting_guidelines_task.py
+++ b/test/frontend/Tasks/reporting_guidelines_task.py
@@ -23,7 +23,7 @@ class ReportingGuidelinesTask(BaseTask):
 
     # Locators - Instance members
     self._question_text = (By.CSS_SELECTOR, 'li.question')
-    self._select_instruction = (By.CSS_SELECTOR, 'ol + div.ember-view.card-content-view-text')
+    self._select_instruction = (By.CSS_SELECTOR, 'li div.card-content-view-text')
     self._selection_list = (By.CSS_SELECTOR, 'div.task-main-content.custom-card-task.single-column')
     self._prisma_upload_button = (By.CLASS_NAME, 'fileinput-button')
     self._prisma_uploaded_file_link = (By.CLASS_NAME, 'file-link')

--- a/test/frontend/test_reporting_guidelines.py
+++ b/test/frontend/test_reporting_guidelines.py
@@ -52,7 +52,7 @@ class ReportingGuidelinesTaskTest(CommonTest):
     staff_user = random.choice(editorial_users)
     logging.info('logging in as user: {0}'.format(staff_user['name']))
     dashboard_page = self.cas_login(email=staff_user['email'])
-    dashboard_page.page_ready()
+    dashboard_page._wait_on_lambda(lambda: len(dashboard_page._gets(dashboard_page._dashboard_invite_title)) >= 1)
     dashboard_page.go_to_manuscript(short_doi)
     paper_viewer = ManuscriptViewerPage(self.getDriver())
     paper_viewer.page_ready()


### PR DESCRIPTION
# QA Ticket

JIRA issue: link-to-jira - no JIRA tickets

#### What this PR does:

Fix for ReportingGuidelinesTaskTest.test_smoke_reporting_guidelines_styles
(updated locators)
Also changed
dashboard_page.page_ready()
by
 dashboard_page._wait_on_lambda(lambda: len(dashboard_page._gets(dashboard_page._dashboard_invite_title)) >= 1)
because I got 1 failure on that line, and for users without inactive papers (for editorial users mostly do not have inactive papers) it works faster.

#### Notes

Are there any surprises? Anything that was particularly difficult, or clever, or
made you nervous, and should get particular attention during review? Call it
out. Does the reviewer have to run a rake task?

---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
