### PR TITLE
APERTA-7401 - Save to/subject on template change

### DIFF
--- a/client/app/pods/components/letter-template/template.hbs
+++ b/client/app/pods/components/letter-template/template.hbs
@@ -44,15 +44,15 @@
   }}
 </div>
 
- {{rich-text-editor
-    ident="decision-letter-field"
-    inputClassNames='decision-letter-field'
-    onContentsChanged=(action "updateAnswer")
-    placeholder="Please type or paste your cover letter into this text field, or attach a file below"
-    owner=task
-    value=letterValue
-    disabled=disabled
-  }}
+{{rich-text-editor
+  ident="decision-letter-field"
+  inputClassNames='decision-letter-field'
+  onContentsChanged=(action "updateAnswer")
+  placeholder="Please type or paste your cover letter into this text field, or attach a file below"
+  owner=task
+  value=letterValue
+  disabled=disabled
+}}
 
 {{#unless disabled}}
   <button class="button-primary button--green send-email-action"

--- a/engines/tahi_standard_tasks/client/app/components/register-decision-task.js
+++ b/engines/tahi_standard_tasks/client/app/components/register-decision-task.js
@@ -75,15 +75,20 @@ export default TaskComponent.extend(ValidationErrorsMixin, HasBusyStateMixin, {
               .get('answers.firstObject.value');
         template = templates.findBy('name', selectedTemplate).toJSON();
       }
-      const body = template.body;
-      const to = template.to;
-      const subject = template.subject;
+      
       const toQuestion = this.get('task').findQuestion('register_decision_questions--to-field');
       const toAnswer = toQuestion.answerForOwner(this.get('task'));
+      const to = template.to;
+      toAnswer.set('value', to);
+      toAnswer.save();
+
       const subjectQuestion = this.get('task').findQuestion('register_decision_questions--subject-field');
       const subjectAnswer = subjectQuestion.answerForOwner(this.get('task'));
-      toAnswer.set('value', to);
+      const subject = template.subject;
       subjectAnswer.set('value', subject);
+      subjectAnswer.save();
+      
+      const body = template.body;
       this.get('draftDecision').set('letter', body); // will trigger save
     }
   }

--- a/engines/tahi_standard_tasks/client/test-support/integration/components/tasks/register-decision-task-test.js
+++ b/engines/tahi_standard_tasks/client/test-support/integration/components/tasks/register-decision-task-test.js
@@ -61,8 +61,12 @@ moduleForComponent(
 
       this.set('task', task);
 
+      $.mockjax({url: /api\/nested_questions\/1\/answers/, type: 'PUT', status: 204, responseText: '[]'});
+      $.mockjax({url: '/api/nested_questions/1/answers', type: 'POST', status: 201, responseText: {nested_question_answer: {id: 1}}});
+      $.mockjax({url: /api\/nested_questions\/2\/answers/, type: 'PUT', status: 204, responseText: '[]'});
+      $.mockjax({url: '/api/nested_questions/2/answers', type: 'POST', status: 201, responseText: {nested_question_answer: {id: 2}}});
       $.mockjax({url: /api\/nested_questions\/3\/answers/, type: 'PUT', status: 204, responseText: '[]'});
-      $.mockjax({url: '/api/nested_questions/3/answers', type: 'POST', status: 201, responseText: {nested_question_answer: {id: 1}}});
+      $.mockjax({url: '/api/nested_questions/3/answers', type: 'POST', status: 201, responseText: {nested_question_answer: {id: 3}}});
       $.mockjax({url: /\/api\/decisions\/[0-9]+/, type: 'PUT', status: 204, responseText: '[]'});
 
       this.selectDecision = function(decision) {


### PR DESCRIPTION

JIRA issue: https://jira.plos.org/jira/browse/APERTA-7401

#### What this PR does:
When the decision letter template is changed it updates the to, subject, and body.  It forgot to persist the to and subject fields.  This fix persists those fields.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
