### PR TITLE
temporary using only super admin in test_validate_components_styles

### DIFF
--- a/test/frontend/test_admin.py
+++ b/test/frontend/test_admin.py
@@ -43,7 +43,7 @@ class ApertaAdminTest(CommonTest):
     """
     logging.info('Test Admin::validate_components_styles')
     logging.info('Validating Admin page components and styles')
-    # Temporary excluding staff admin role unil APERTA-11756 gets resolved
+    # Temporary excluding staff admin role until APERTA-11756 gets resolved
     # user_type = random.choice(admin_users)
     user_type = super_admin_login
     logging.info('Logging in as user: {0}'.format(user_type))


### PR DESCRIPTION
# QA Ticket

JIRA issue: related to APERTA-11756, APERTA-11067

#### What this PR does:

Temporary using only super admin role for test_validate_components_styles
until APERTA-11756 gets resolved.

#### Notes

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [x] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [x] Follows first PLOS style guidelines for Python, then PEP-8
- [x] Code is implemented in a Python 2/3 agnostic way
- [x] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [x] I have moved the ticket forward in JIRA
