### PR TITLE
Remove unused bower reference to TinyMCE

### DIFF
--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -76,8 +76,6 @@ module.exports = function(defaults) {
   app.import(app.bowerDirectory + '/At.js/dist/css/jquery.atwho.css');
 
   // TinyMCE
-  app.import(app.bowerDirectory + '/tinymce/plugins/codesample/css/prism.css');
-
   app.import('node_modules/tinymce/tinymce.js');
   app.import('node_modules/tinymce/themes/modern/theme.js');
   app.import('node_modules/tinymce/plugins/code/plugin.js');


### PR DESCRIPTION
# Dev ticket

#### What this PR does:

Ticket APERTA-11291 introduces a build problem for Ember that slipped by, because both my local environment and the review app had previously pulled in TinyMCE as a bower component. Since you most likely haven't, master is about to break your Ember.

This should correct that problem.
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
