### PR TITLE
Task visibility does not affect template visibility

### DIFF
--- a/client/app/pods/components/card-preview/component.js
+++ b/client/app/pods/components/card-preview/component.js
@@ -73,14 +73,15 @@ export default Ember.Component.extend({
 
   showDeleteButton: Ember.computed.and('canRemoveCard', 'notReviewerReportTask'),
 
-  notViewable: Ember.computed.not('task.viewable'),
+  notViewable: Ember.computed.not('viewable'),
+  viewable: Ember.computed.or('taskTemplate', 'task.viewable'),
 
   actions: {
     viewCard() {
-      if (!this.get('notViewable')) {
-        let action = this.get('action');
-        if (action) { action(); }
-      }
+      if (this.get('notViewable')) { return; }
+
+      let action = this.get('action');
+      if (action) { action(); }
     },
 
     promptDelete() {


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11480

#### What this PR does:
This fixes a bug in Workflow Admin where all cards in the workflow are visually disabled and ad-hoc cards cannot be edited.

This fixes the cards to not be disabled and to respond to clicks if there is an action is available.  The ticket specifically mentions that an ad-hoc card should be clickable and editable from the opened modal.

#### Notes

This looks to be a consequence of reusing a UI for both:
- manuscript workflow
- manuscript workflow admin

We should be more conscious of reviewing both screens when we make edits to the card-preview component.

#### Major UI changes
before:
![screen shot 2017-10-30 at 1 57 09 pm](https://user-images.githubusercontent.com/1165691/32195412-6b11c43e-bd7a-11e7-8fbc-292f96d4c76c.png)

after:
![screen shot 2017-10-30 at 1 56 18 pm](https://user-images.githubusercontent.com/1165691/32195434-76c32db8-bd7a-11e7-9f5c-139ee6bd8eeb.png)

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
