### PR TITLE
Aperta 11153 fix update

### DIFF
--- a/client/app/pods/components/correspondence-list/component.js
+++ b/client/app/pods/components/correspondence-list/component.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 export default Ember.Component.extend({
   isRecordLost: Ember.computed('submittedAt', function() {
-    let dateSubmitted = moment(this.get('paper').get('submittedAt'));
+    let dateSubmitted = moment(this.get('paper').get('firstSubmittedAt'));
     let dateChanged = moment('February 1, 2017');
     return dateSubmitted < dateChanged;
   })

--- a/client/tests/components/correspondence-list-test.js
+++ b/client/tests/components/correspondence-list-test.js
@@ -32,7 +32,7 @@ let template = hbs`
 `;
 
 test('can manage workflow, list appears', function(assert) {
-  let paper = FactoryGuy.make('paper', { publishingState: 'submitted', submittedAt: '2016-09-28T13:54:58.028Z'});
+  let paper = FactoryGuy.make('paper', { publishingState: 'submitted', firstSubmittedAt: '2016-09-28T13:54:58.028Z'});
   let correspondence = FactoryGuy.make('correspondence', { paper: paper });
   const can = FakeCanService.create().allowPermission('manage_workflow', paper);
   this.register('service:can', can.asService());


### PR DESCRIPTION
#### What this PR does:

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11153

What this PR does:

This is an updated PR for this previous [PR](https://github.com/Tahi-project/tahi/pull/3551) that has been merged. Updated submittedAt to firstSubmittedAt because we have cases where submittedAt returns nil but firstSubmittedAt doesn't always return a nil value on our production stage

#### Special instructions for Review or PO:
The submittedAt field for the papers in our seed data used in our review app has their firstSubmittedAt return null so the review app might not be the best way to test the new update. Kindly communicate with Ramzi on how to proceed.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
