### PR TITLE
APERTA-11767 Downgrade Ember-data from 2.12.2 to 2.11.3

### DIFF
--- a/client/app/services/store.js
+++ b/client/app/services/store.js
@@ -48,7 +48,11 @@ export default DS.Store.extend({
   },
 
   allTaskClasses() {
-    return Object.keys(this._identityMap._map).filter((k) => {
+    var allModelClasses = _.map(this.typeMaps, function(typeMap){
+      return _.pluck(typeMap.records, 'modelName');
+    }).flatten().uniq();
+
+    return allModelClasses.filter((k) => {
       return k.match(/-task/);
     });
   },

--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
     "ember-click-outside": "^0.1.6",
     "ember-composable-helpers": "^1.1.2",
     "ember-concurrency": "^0.8.5",
-    "ember-data": "2.12.2",
+    "ember-data": "2.11.3",
     "ember-data-factory-guy": "2.13.7",
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3056,9 +3056,9 @@ ember-data-filter@1.13.0:
   dependencies:
     ember-cli-babel "^5.0.0"
 
-ember-data@2.12.2:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.12.2.tgz#45369001847b59e7d0ca8b183e9f57cb1f339260"
+ember-data@2.11.3:
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.11.3.tgz#46ba0e8411dce6dbb52cc02a29194f265b747ef9"
   dependencies:
     amd-name-resolver "0.0.5"
     babel-plugin-feature-flags "^0.2.1"


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11767

#### What this PR does:

Ember Data 2.12 introduced a bug which prevents destroys and saves 
happening within the same run loop.  We had originally updated Ember to 
2.13 and then found this issue when testing repeaters which routinely 
destroy and save within the same run loop, thus exposing the problem.

Since this bug is subtle and may be present in unknown places elsewhere
in the codebase, it was determined that downgrading to 2.11.* makes the
most sense as a temporary fix until the project can eventually be updated
to the latest version of Ember Data.

We originally attempted upgrading to several NEWER version of Ember Data
(instead of downgrading), but there were many other test failures that
showed up and not enough time to fix the root causes, so this is a 
sensible temporary fix.

bug introduced = https://github.com/emberjs/data/pull/4668
bug reported = https://github.com/emberjs/data/issues/4993
bug fixed = https://github.com/emberjs/data/pull/4994

#### Special instructions for Review or PO:

This is a regression level test.  

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good