### PR TITLE
APERTA-11792 prevent clobbering user changes in rich-text-editor

### DIFF
--- a/client/app/pods/components/rich-text-editor/component.js
+++ b/client/app/pods/components/rich-text-editor/component.js
@@ -68,11 +68,26 @@ export default Ember.Component.extend({
     /* eslint-enable camelcase */
   },
 
+  hasFocus: false,
+
+  init() {
+    this._super(...arguments);
+    this.set('editorValue', this.get('value'));
+  },
+
   editorIsEnabled: Ember.observer('disabled', function() {
     if (!this.get('disabled')) {
       Ember.run.scheduleOnce('afterRender', this, this.postRender);
     }
   }).on('init'),
+
+  // This prevents upstream changes from clobbering something that
+  // a user is actively editing.
+  updateEditorValueIfNotActive: Ember.observer('value', function() {
+    if (!this.get('hasFocus')) {
+      this.set('editorValue', this.get('value'));
+    }
+  }),
 
   pastePostprocess(editor, fragment) {
     function deleteEmptyParagraph(elem) {
@@ -85,7 +100,7 @@ export default Ember.Component.extend({
 
     deleteEmptyParagraph(fragment.node);
 
-    if(Ember.isBlank(this.get('value'))) this.set('value', fragment.node.innerHTML);
+    if(Ember.isBlank(this.get('editorValue'))) this.set('editorValue', fragment.node.innerHTML);
   },
 
   postRender() {
@@ -94,6 +109,8 @@ export default Ember.Component.extend({
     document.querySelector(iframeSelector).removeAttribute('title');
     let callback = this.get('focusOut');
     if (callback) editor.on('blur', callback);
+    editor.on('focus', () => this.set('hasFocus', true) );
+    editor.on('blur', () => this.set('hasFocus', false) );
   },
 
   configureCommon(options) {

--- a/client/app/pods/components/rich-text-editor/template.hbs
+++ b/client/app/pods/components/rich-text-editor/template.hbs
@@ -12,7 +12,7 @@
       onNewValue=(action onContentsChanged)
       onValueChanged=newValueCheck
       options=editorOptions
-      value=value
+      value=editorValue
     }}
   </div>
 {{/if}}

--- a/client/tests/integration/pods/components/rich-text-editor/component-test.js
+++ b/client/tests/integration/pods/components/rich-text-editor/component-test.js
@@ -128,3 +128,23 @@ test('checking the focusOut action triggers after editor is disabled', function(
 
   assert.equal(focusOutCount, 2, 'focusOut was called again after reenabling the editor');
 });
+
+test('contents do not update from upstream changes when editor is active', function(assert) {
+  const initialValue = '<p>pickachu</p>';
+  this.set('value', initialValue);
+  this.set('saveContents', function() {});
+  const template = hbs`{{rich-text-editor
+                      value=value
+                      ident='test-editor'
+                      onContentsChanged=saveContents}}`;
+  this.render(template);
+  const editor = findEditor('test-editor');
+  editorFireEvent('test-editor', 'focus'); // get focus
+  assert.equal(editor.getContent(), initialValue, 'initial value should be set');
+  this.set('value', '<p>bulbasaur</p>');
+  assert.equal(editor.getContent(), initialValue, 'the contents should not change when the editor has focus');
+  editorFireEvent('test-editor', 'blur'); // lose focus
+  const upstreamValue = '<p>charmander</p>';
+  this.set('value', upstreamValue);
+  assert.equal(editor.getContent(), upstreamValue, 'the contents should change if the editor does not have focus');
+});


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11792

#### What this PR does:

This prevents server changes from updating the contents of a tinyMCE editor which the user is currently editing. 

This should have the effect of fixing the jumping cursor problem in all tinyMCE editors 🤞 

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
