### PR TITLE
APERTA-11153-included-first_submitted_at-to-paper-serializer

### DIFF
--- a/app/serializers/paper_serializer.rb
+++ b/app/serializers/paper_serializer.rb
@@ -1,7 +1,7 @@
 class PaperSerializer < LitePaperSerializer
   attributes :abstract, :body, :current_user_roles, :doi, :gradual_engagement,
              :legends_allowed, :links, :manually_similarity_checked,
-             :paper_type, :short_title, :submitted_at, :versions_contain_pdf,
+             :paper_type, :short_title, :submitted_at, :first_submitted_at, :versions_contain_pdf,
              :preprint_eligible?
 
   %i(supporting_information_files).each do |relation|


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11153

What this PR does:

Included the firstSubmittedAt field in the paper serializer in order to avoid having null values on the client side. 

Special instructions for Review or PO:

The submittedAt field for the papers in our seed data used in our review app has their firstSubmittedAt return null so the review app might not be the best way to test the new update. Kindly communicate with Ramzi on how to proceed.
#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I read the code; it looks good

NO I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket

NO [ ] I have found the tests to be sufficient for both positive and negative test cases

