### PR TITLE
APERTA-11742 Prevent validation of technically deleted figures

### DIFF
--- a/client/app/pods/components/figure-thumbnail/component.js
+++ b/client/app/pods/components/figure-thumbnail/component.js
@@ -35,6 +35,13 @@ export default Ember.Component.extend(ValidationErrorsMixin, {
         let rank = this.get('figure.rank');
         if (rank === 0) { return true; }
 
+        // the validation mixin is checking records that
+        // are technically destroyed somehow
+        // see APERTA-11742 for details
+        if (!this.get('figure.paper')) {
+          return true;
+        }
+
         let count = this.get('figure.paper.figures').filterBy('rank', rank).get('length');
 
         return count === 1;


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11742

#### What this PR does:

This fixes an issue caught be QA regarding the deletion of figures.  This was likely a consequence of the Ember upgrade as it was present in the previous RC.  For now, this is a quick fix (it's just a check to see if the "deleted" figure has a paper) until I can figure why it's doing this and what it might mean for other legacy cards that are using the legacy validation mixin.  

#### Special instructions for Review or PO:

On production builds, it doesn't seem to throw an error (instead, the app becomes unresponsive with zero error messages).  On development builds, it will throw a glimmer infinite render error with the main error causing that cascade above it.

#### Notes

I recommend checking it out with images with figure labels already set on the filename and also renaming the figure directly in the interface.

#### Major UI changes

None
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
