### PR TITLE
APERTA-11792 ensure that tinyMCE’s content remains after being disabled

### DIFF
--- a/client/app/pods/components/rich-text-editor/component.js
+++ b/client/app/pods/components/rich-text-editor/component.js
@@ -70,12 +70,8 @@ export default Ember.Component.extend({
 
   hasFocus: false,
 
-  init() {
-    this._super(...arguments);
-    this.set('editorValue', this.get('value'));
-  },
-
   editorIsEnabled: Ember.observer('disabled', function() {
+    this.set('editorValue', this.get('value'));
     if (!this.get('disabled')) {
       Ember.run.scheduleOnce('afterRender', this, this.postRender);
     }


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11792

#### What this PR does:
Galina noticed that if you disable and re-enable a rich-text-editor, it forgets the last change. This commit fixes that. More details on how to reproduce in her comment on the ticket: 
https://jira.plos.org/jira/browse/APERTA-11792?focusedCommentId=189774&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-189774

The fix took 5 minutes to figure out, but I've been banging my head against the tests for the past 45 minutes, so I figured I'd just cut bait and bail on it. I might add one in an empowerment ticket later.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
Letting this one go ~~I have found the tests to be sufficient for both positive and negative test cases~~
