### PR TITLE
APERTA-10504: fix ordering of sections in dashboard

### DIFF
--- a/client/app/pods/dashboard/index/template.hbs
+++ b/client/app/pods/dashboard/index/template.hbs
@@ -94,6 +94,28 @@
             </table>
           {{/if}}
 
+          {{#if hasPostedPreprints}}
+            <table summary="This table displays papers that are posted to preprint" class="table-borderless top-margin">
+              <thead class="manuscript-list-heading {{if
+            preprintsVisible "gray-line" }} active-papers" {{action "togglePreprintContainer"}}>
+                <tr>
+                  <th class="col-xs-8 hug-left">{{postedPreprintsHeading}}</th>
+                  {{#if preprintsVisible}}
+                    <th class="col-xs-3 hug-left">Role</th>
+                    <th class="col-xs-2 hug-left">Status</th>
+                  {{/if}}
+                </tr>
+              </thead>
+              <tbody>
+                {{#if preprintsVisible}}
+                  {{#each preprints as |paper|}}
+                    {{preprint-dashboard-link model=paper type="active" class="active-paper-table-row"}}
+                  {{/each}}
+                {{/if}}
+              </tbody>
+            </table>
+          {{/if}}
+
           {{#if hasInactivePapers}}
             <table summary="This table displays manuscript data and roles" class="table-borderless top-margin">
               <thead class="manuscript-list-heading {{if inactivePapersVisible "gray-line"}} inactive-papers" {{action "toggleInactiveContainer"}}>
@@ -116,28 +138,6 @@
           {{/if}}
         {{else}}
           <p class="dashboard-info-text">Your scientific paper submissions will<br> appear here.</p>
-        {{/if}}
-
-        {{#if hasPostedPreprints}}
-          <table summary="This table displays papers that are posted to preprint" class="table-borderless top-margin">
-            <thead class="manuscript-list-heading {{if
-          preprintsVisible "gray-line" }} active-papers" {{action "togglePreprintContainer"}}>
-              <tr>
-                <th class="col-xs-8 hug-left">{{postedPreprintsHeading}}</th>
-                {{#if preprintsVisible}}
-                  <th class="col-xs-3 hug-left">Role</th>
-                  <th class="col-xs-2 hug-left">Status</th>
-                {{/if}}
-              </tr>
-            </thead>
-            <tbody>
-              {{#if preprintsVisible}}
-                {{#each preprints as |paper|}}
-                  {{preprint-dashboard-link model=paper type="active" class="active-paper-table-row"}}
-                {{/each}}
-              {{/if}}
-            </tbody>
-          </table>
         {{/if}}
 
       </section>


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10504

#### What this PR does:

Fixes ordering of dashboard sections to place new preprints section (which has already been PO accepted) directly after active manuscripts (see screenshot)

<img width="1662" alt="dashoard_after" src="https://user-images.githubusercontent.com/5750708/32339845-30e4e762-bfb6-11e7-928b-92dbbd2e326d.png">

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] If I made any UI changes, I've let QA know.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
