### PR TITLE
APERTA-11833 correct error class on custom card complete task

### DIFF
--- a/client/app/templates/-task-completed-section.hbs
+++ b/client/app/templates/-task-completed-section.hbs
@@ -6,7 +6,7 @@
         Make changes to this task
       </button>
     {{else}}
-      <button class="task-completed task-not-completed button-secondary {{if validationErrors.completed "button--red" "button--green"}}"
+      <button class="task-completed task-not-completed button-secondary {{if task.notReady "button--red" "button--green"}}"
               name="task_completed">
         I am done with this task
       </button>

--- a/client/tests/components/custom-card-task-test.js
+++ b/client/tests/components/custom-card-task-test.js
@@ -11,19 +11,35 @@ moduleForComponent('custom-card-task', 'Integration | Components | Tasks | Custo
   beforeEach() {
     manualSetup(this.container);
     this.registry.register('service:can', FakeCanService);
-
-    // factory builds a CustomCardTask along with a piece of sample CardContent
-    let task = FactoryGuy.make('custom-card-task');
-    this.set('task', task);
   }
 });
 
-test('it renders the custom card content', function(assert) {
-  assert.expect(1);
+test('it renders the custom card content starting in a non error state', function(assert) {
+  // factory builds a CustomCardTask along with a piece of sample CardContent
+  let task = FactoryGuy.make('custom-card-task', {notReady: false});
+  this.set('task', task);
+  let fake = this.container.lookup('service:can');
+  fake.allowPermission('edit', this.get('task'));
 
   this.render(hbs`
     {{custom-card-task task=task}}
   `);
 
   assert.elementFound('.card-content-short-input', 'found the associated card content');
+  assert.elementFound('.task-completed.button--green', 'renders the task completed button in a non error state');
+});
+
+
+test('if errors are present on submit, the complete button gets an error state', function(assert) {
+  // factory builds a CustomCardTask along with a piece of sample CardContent
+  let task = FactoryGuy.make('custom-card-task', {notReady: true});
+  this.set('task', task);
+  let fake = this.container.lookup('service:can');
+  fake.allowPermission('edit', this.get('task'));
+
+  this.render(hbs`
+    {{custom-card-task task=task}}
+  `);
+
+  assert.elementFound('.task-completed.button--red', 'renders the task completed button in an error state');
 });


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11833

#### What this PR does:
Reinstates error class on complete button in custom cards. Check repro instructions on jira ticket above


---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
