### PR TITLE
APERTA-11687 Fix floating preprint opt-out button

### DIFF
--- a/app/assets/stylesheets/overlays/_offer-preprint-overlay.scss
+++ b/app/assets/stylesheets/overlays/_offer-preprint-overlay.scss
@@ -42,8 +42,5 @@
 @media screen and (max-height: 680px) {
   .split-pane.preprint-pane button {
     bottom: 10px;
-    position: fixed;
-    right: inherit;
-    left: calc(50% + 350px);
   }
 }


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11687

#### What this PR does:

<img width="989" alt="screen shot 2017-11-06 at 11 04 50 am" src="https://user-images.githubusercontent.com/6579120/32458785-66adf224-c2e2-11e7-9fad-e14dbf4a9fca.png">

This PR prevents the continue button from floating away from the modal.  Previously, it was set as 'position: fixed', which would fix the button relative to the screen's viewport, which is undesirable behavior.

#### Special instructions for Review or PO:

None

#### Notes

None

#### Major UI changes

I would check to make sure you have the button viewable in your selenium spec if the test(s) were reliant on the button always being visible in Firefox's viewport.  Otherwise, there should be no other surprises here.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

