### PR TITLE
APERTA-6281 - Edit submitted reviewer reports (WIP)

### DIFF
--- a/client/app/pods/components/nested-question/component.js
+++ b/client/app/pods/components/nested-question/component.js
@@ -99,7 +99,7 @@ export default Component.extend({
   }).keepLatest(),
 
   _saveAnswer(answer){
-    if(answer.get('owner.isNew')){
+    if(answer.get('owner.isNew') || answer.get('owner.delaySave')){
       // no-op
     } else if(answer.get('wasAnswered')){
       // Handle the edge case where an answer was deleted in the UI, and two inputs get posted

--- a/engines/tahi_standard_tasks/client/app/components/reviewer-report-questions.js
+++ b/engines/tahi_standard_tasks/client/app/components/reviewer-report-questions.js
@@ -2,18 +2,18 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   readOnly: false,
-  hasReport: Ember.computed('model.status', function() {
-    const reportStatus = this.get('model.status');
+  hasReport: Ember.computed('report.status', function() {
+    const reportStatus = this.get('report.status');
     const hasReportStates = ['pending', 'completed', 'invitation_accepted'];
     return hasReportStates.includes(reportStatus);
   }),
 
-  competingInterestsLink: Ember.computed('model.task.paper.journal.name', function() {
-    const name = this.get('model.task.paper.journal.name');
+  competingInterestsLink: Ember.computed('report.task.paper.journal.name', function() {
+    const name = this.get('report.task.paper.journal.name');
     if (name) {
       return `http://journals.plos.org/${name.toLowerCase().replace(' ', '')}/s/reviewer-guidelines#loc-competing-interests`;
     } else {
       return 'http://journals.plos.org/';
     }
-  }),
+  })
 });

--- a/engines/tahi_standard_tasks/client/app/components/reviewer-report-task.js
+++ b/engines/tahi_standard_tasks/client/app/components/reviewer-report-task.js
@@ -14,6 +14,13 @@ export default TaskComponent.extend({
   // this property is responsible for displaying (or not) the 'Make changes to this Task' button.
   // It can be modified later to depend on permissions
   taskStateToggleable: false,
+  editing: false,
+  notEditing: Ember.computed.not('editing'),
+
+  changedAnswers: Ember.computed('currentReviewerReport.nestedQuestionAnswers.[]', function() {
+    return this.get('currentReviewerReport.nestedQuestionAnswers')
+      .filter(answer => answer && answer.changedAttributes().value);
+  }),
 
   actions: {
     confirmSubmission() {
@@ -32,6 +39,24 @@ export default TaskComponent.extend({
         this.get('task').save();
         this.get('flash').displayRouteLevelMessage('success', 'Thank you for submitting your review.');
       });
+    },
+
+    // Admin functions to modify a submitted report
+    editReport() {
+      this.set('currentReviewerReport.delaySave', true);
+      this.set('editing', true);
+    },
+
+    saveEdits() {
+      this.set('editing', false);
+      this.get('changedAnswers').forEach(answer => answer.save());
+      this.set('currentReviewerReport.delaySave', false);
+    },
+
+    cancelEdits() {
+      this.set('editing', false);
+      this.get('changedAnswers').forEach(answer => answer.rollbackAttributes());
+      this.set('currentReviewerReport.delaySave', false);
     }
   }
 });

--- a/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-questions.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-questions.hbs
@@ -4,7 +4,7 @@
     <li class="question">
       {{nested-question-radio-decision
         ident="reviewer_report--decision_term"
-        owner=model
+        owner=report
         readOnly=readOnly
       }}
     </li>
@@ -12,7 +12,7 @@
     <li class="question">
       {{nested-question-radio
         ident="reviewer_report--competing_interests"
-        owner=model
+        owner=report
         displayContent=true
         readOnly=readOnly
         helpText=(concat
@@ -23,7 +23,7 @@
       {{nested-question-textarea
         ident="reviewer_report--competing_interests--detail"
         editorStyle='expanded'
-        owner=model
+        owner=report
         disabled=readOnly
         displayQuestionText=false
         inputClassNames="reviewer_report--competing_interests--detail"
@@ -34,7 +34,7 @@
       {{nested-question-textarea
         ident="reviewer_report--identity"
         editorStyle='expanded'
-        owner=model
+        owner=report
         displayContent=true
         disabled=readOnly
         inputClassNames="reviewer_report--identity"
@@ -46,7 +46,7 @@
       {{nested-question-textarea
         ident="reviewer_report--comments_for_author"
         editorStyle='expanded'
-        owner=model
+        owner=report
         displayContent=true
         disabled=readOnly
         inputClassNames="taller reviewer_report--comments_for_author"
@@ -61,7 +61,7 @@
     <li class="question">
       {{nested-question-textarea
         ident="reviewer_report--additional_comments"
-        owner=model
+        owner=report
         disabled=readOnly
         displayContent=true
         inputClassNames="reviewer_report--additional_comments"
@@ -74,7 +74,7 @@
     <li class="question">
       {{nested-question-radio
         ident="reviewer_report--suitable_for_another_journal"
-        owner=model
+        owner=report
         readOnly=readOnly
         helpText=(concat "If so, please specify which PLOS journal and whether you will be willing to continue there as reviewer on this manuscript. To reduce redundant review cycles, <em>PLOS Biology</em> is committed to facilitating the transfer of suitable manuscripts between journals, and we appreciate your support.")
       }}
@@ -82,7 +82,7 @@
       {{nested-question-textarea
         ident="reviewer_report--suitable_for_another_journal--journal"
         editorStyle='expanded'
-        owner=model
+        owner=report
         inputClassNames="reviewer_report--suitable_for_another_journal--journal"
         displayQuestionText=false
         disabled=readOnly
@@ -94,7 +94,7 @@
                          buttonText="upload file"
                          hasCaption=false
                          multiple=true
-                         owner=model
+                         owner=report
                          disabled=readOnly}}
     </li>
   </ol>

--- a/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-task.hbs
+++ b/engines/tahi_standard_tasks/client/app/templates/components/reviewer-report-task.hbs
@@ -9,13 +9,16 @@
                          dueDate=currentReviewerReport.dueAt}}
     {{/if}}
     {{#if task.isSubmitted}}
-      {{reviewer-report-questions model=currentReviewerReport readOnly=true}}
+      <a {{action "editReport"}}>Edit</a>
+      <a {{action "saveEdits"}}>Save</a>
+      <a {{action "cancelEdits"}}>Cancel</a>
+      {{reviewer-report-questions report=currentReviewerReport readOnly=notEditing}}
     {{else}}
       <p><strong>Please refer to our
         <a href="http://journals.plos.org/plosbiology/s/reviewer-guidelines#loc-criteria-for-publication">reviewer</a>
         guidelines for detailed instructions.</strong>
       </p>
-      {{reviewer-report-questions model=currentReviewerReport readOnly=isNotEditable}}
+      {{reviewer-report-questions report=currentReviewerReport readOnly=isNotEditable}}
 
       {{#if currentReviewerReport.needsSubmission }}
       <div class="reviewer-report-confirmation">
@@ -49,7 +52,7 @@
             </div>
             <div id="collapse-{{unbound report.decision.id}}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="decision-{{unbound report.decision.id}}">
               <div class="panel-body">
-                {{reviewer-report-questions model=report readOnly=true}}
+                {{reviewer-report-questions report=report readOnly=true}}
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-6281

#### What this PR does:

* Introduces ‘delaySave’ field for answer owners, so nested-question’s
debounced saveAnswer function will no-op
* Swap “model” with “report” in reviewer-report-questions to make
meaning clearer
* Add edit/save/cancel actions to reviewer-report component to allow
touching an existing report record without auto-saving answers as you
type
- Note to self: don’t forget front-matter!

#### Major UI changes

Yes. (Coming soon once I fix styling and behavior)

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
