### PR TITLE
APERTA-11838 Display group authors in paper submit modal

### DIFF
--- a/app/serializers/paper_serializer.rb
+++ b/app/serializers/paper_serializer.rb
@@ -31,8 +31,7 @@ class PaperSerializer < LitePaperSerializer
 
   has_many :group_authors,
            embed: :ids,
-           include: true,
-           serializer: GroupAuthorSerializer
+           include: true
 
   has_one :journal, embed: :id
   has_one :file, embed: :id, include: true, serializer: AttachmentSerializer

--- a/client/app/pods/paper/submit/controller.js
+++ b/client/app/pods/paper/submit/controller.js
@@ -22,6 +22,13 @@ export default Ember.Controller.extend({
     return paperDownloadPath({ paperId: this.get('paper.id'), format: 'pdf_with_attachments' });
   }),
 
+  coAuthorsSort: ['position:asc'],
+  authors: Ember.computed.union('paper.authors', 'paper.groupAuthors'),
+  coAuthors: Ember.computed.filter('authors.@each', function(author) {
+    return author.get('position') > 1;
+  }),
+  sortedCoAuthors: Ember.computed.sort('coAuthors', 'coAuthorsSort'),
+
   recordPreviousPublishingState: function () {
     this.set('previousPublishingState', this.get('paper.publishingState'));
   },
@@ -29,11 +36,6 @@ export default Ember.Controller.extend({
   showFeedbackOverlayFunc() {
     this.set('showFeedbackOverlay', true);
   },
-
-  groupAuthors: Ember.computed('paper.groupAuthors', function() {
-    return this.get('paper.groupAuthors').map((author) =>
-      `${author.get('contactFirstName')} ${author.get('contactLastName')}`).join(', ');
-  }),
 
   setPaperStateAsSubmitted() {
     this.set('paperSubmitted', true);

--- a/client/app/pods/paper/submit/template.hbs
+++ b/client/app/pods/paper/submit/template.hbs
@@ -72,19 +72,16 @@
               <th>Co-Authors</th>
               <td>
                 <p>
-                  {{#each paper.authors as |author|}}
-                    {{#unless (eq author paper.authors.firstObject)}}
-                      <span>{{author.firstName}} {{author.middleInitial}} {{author.lastName}}{{#if author.affiliation}},&nbsp;&nbsp;{{author.affiliation}}{{/if}}{{#unless (eq author paper.authors.lastObject)}}<br/>{{/unless}}</span>
-                    {{/unless}}
+                  {{#each sortedCoAuthors as |author|}}
+                  <span>
+                    {{#if author.name }}
+                      {{author.name}}
+                    {{else}}
+                      {{author.firstName}} {{author.middleInitial}} {{author.lastName}}{{#if author.affiliation}},&nbsp;&nbsp;{{author.affiliation}}{{/if}}
+                    {{/if}}
+                    {{#unless (eq author sortedCoAuthors.lastObject)}}<br/>{{/unless}}
+                  </span>
                   {{/each}}
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <th>Group Authors</th>
-              <td>
-                <p>
-                  <span>{{groupAuthors}}</span>
                 </p>
               </td>
             </tr>


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11838

#### What this PR does:

It displays group authors in the preprint submit modal

#### Special instructions for Review or PO:

None, the ticket has all the necessary instructions.

#### Major UI changes

I added a new row with the group authors information

![group-authors](https://user-images.githubusercontent.com/30911/32521690-7d0f31f8-c3e2-11e7-8c3b-c493dcd13aa5.png)

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):


- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
