### PR TITLE
APERTA-11397 We missed a scenario that is not used in seed data

### DIFF
--- a/lib/tasks/data-migrations/APERTA-11397-friendly-scenario-names.rake
+++ b/lib/tasks/data-migrations/APERTA-11397-friendly-scenario-names.rake
@@ -8,14 +8,14 @@ namespace :data do
       # APERTA-11397. TemplateContext.scenarios may change, that's why this list
       # is duplicated here.
       scenarios = {
-        'Manuscript' => PaperScenario,
-        'Reviewer Report' => ReviewerReportScenario,
-        'Invitation' => InvitationScenario,
-        'Paper Reviewer' => PaperReviewerScenario,
-        'Preprint Decision' => PreprintDecisionScenario,
-        'Decision' => RegisterDecisionScenario,
-        'Tech Check' => TechCheckScenario
-      }.invert
+        'PaperScenario'            => 'Manuscript',
+        'ReviewerReportScenario'   => 'Reviewer Report',
+        'InvitationScenario'       => 'Invitation',
+        'PaperReviewerScenario'    => 'Paper Reviewer',
+        'PreprintDecisionScenario' => 'Preprint Decision',
+        'RegisterDecisionScenario' => 'Decision',
+        'TechCheckScenario'        => 'Tech Check'
+      }
 
       # Remove module scopes
       # rubocop:disable Rails/SkipsModelValidations
@@ -36,7 +36,7 @@ namespace :data do
           tpl.update(scenario: 'Tech Check')
           next
         end
-        scenario_class = scenario_class.constantize
+
         tpl.update(scenario: scenarios[scenario_class]) if scenarios.key? scenario_class
       end
     end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11397

#### What this PR does:
Migrates the PaperReviewerScenario, which we missed because a letter template that uses it does not exist in our seed data, but one does on CI apparently

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
