### PR TITLE
APERTA-11913 simply go back() when exiting the card overlay

### DIFF
--- a/client/app/pods/paper/workflow/controller.js
+++ b/client/app/pods/paper/workflow/controller.js
@@ -1,3 +1,5 @@
+/* global history */
+
 import Ember from 'ember';
 import deepCamelizeKeys from 'tahi/lib/deep-camelize-keys';
 import deNamespaceTaskType from 'tahi/lib/de-namespace-task-type';
@@ -107,9 +109,7 @@ export default Controller.extend(Discussions, {
     },
 
     hideTaskOverlay() {
-      const r = this.get('routing.router._routerMicrolib');
-      const lastRoute = r.currentHandlerInfos[r.currentHandlerInfos.length - 1];
-      r.updateURL(r.generate(lastRoute.name, lastRoute.context.get('shortDoi')));
+      history.back();
       this.set('showTaskOverlay', false);
     },
 


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11913

#### What this PR does:

This simplifies the `hideTaskOverlay()` action on the task overlay controller to move the browser history back rather than do some convoluted thing with the private router api that I think was meant to drop the user back onto the workflow page but breaks when the user was actually previously on a discussion topic.

I was expecting this change to not work for people that navigate directly to task from outside aperta--I was figuring it would `history.back()` them back to whatever site they were on before, but it actually just drops them back at the manuscript page, which doesn't seem awful, and I believe is the current behavior on master.

I tested the behavior in IE11, and current chrome and FF. All seem to work fine.


---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
