### PR TITLE
APERTA-11397 :is_array replaced :many

### DIFF
--- a/client/app/pods/components/admin-page/email-templates/edit/merge-field/component.js
+++ b/client/app/pods/components/admin-page/email-templates/edit/merge-field/component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 export default Ember.Component.extend({
 
-  isGroup: Ember.computed.alias('mergeField.many'),
+  isGroup: Ember.computed.alias('mergeField.is_array'),
   children: Ember.computed.alias('mergeField.children'),
   isLeafNode: Ember.computed.not('children.length'),
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11397

#### What this PR does:
The merge fields presentation stopped presenting array-type merge fields as such and was presenting them as single-value merge fields.  This happened after the attr that the front end was looking for was renamed.  A reference was missed.

This does not affect email template processing.  This is only in the UI of the component that suggests merge fields to email template admins.

incorrect:
![screen shot 2017-11-09 at 4 26 21 pm](https://user-images.githubusercontent.com/1165691/32636919-e4583050-c56b-11e7-84b4-e2a24727258d.png)

fixed:
![screen shot 2017-11-09 at 4 25 51 pm](https://user-images.githubusercontent.com/1165691/32636926-f023ceee-c56b-11e7-8bfd-2a7d69946ad5.png)

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow):
- [x] I read the code; it looks good
