### PR TITLE
Remove correspondence feature flag

### DIFF
--- a/client/app/pods/components/paper-control-bar/template.hbs
+++ b/client/app/pods/components/paper-control-bar/template.hbs
@@ -19,12 +19,11 @@
         Workflow
       {{/link-to}}
 
-      {{#if (feature-flag "CORRESPONDENCE")}}
-        {{#link-to "paper.correspondence" paper class="control-bar-button" id="nav-correspondence"}}
-          {{fa-icon icon="envelope-open-o"}}
-          Correspondence
-        {{/link-to}}
-      {{/if}}
+    
+      {{#link-to "paper.correspondence" paper class="control-bar-button" id="nav-correspondence"}}
+        {{fa-icon icon="envelope-open-o"}}
+        Correspondence
+      {{/link-to}}
 
       <div class="control-bar-splitter"></div>
     {{/if}}

--- a/client/tests/components/paper-control-bar-test.js
+++ b/client/tests/components/paper-control-bar-test.js
@@ -42,8 +42,7 @@ moduleForComponent('paper-control-bar', 'Integration | Component | Paper Control
 });
 
 
-test('can manage workflow, correspondence enabled, all icons show', function(assert) {
-  FactoryGuy.make('feature-flag', {id: 1, name: 'CORRESPONDENCE', active: true});
+test('can manage workflow, all icons show', function(assert) {
   const can = FakeCanService.create().allowPermission('manage_workflow', paper);
   this.register('service:can', can.asService());
 
@@ -55,17 +54,6 @@ test('can manage workflow, correspondence enabled, all icons show', function(ass
   });
 });
 
-test('can manage workflow, correspondence disabled, no correspondence icon', function(assert) {
-  const can = FakeCanService.create().allowPermission('manage_workflow', paper);
-  this.register('service:can', can.asService());
-
-  this.render(template);
-  return wait().then(() => {
-    assert.equal(this.$('#nav-correspondence').length, 0);
-    assert.equal(this.$('#nav-workflow').length, 1);
-    assert.equal(this.$('#nav-manuscript').length, 1);
-  });
-});
 
 test('can not manage workflow, correspondence enabled, no nav icons', function(assert) {
   const can = FakeCanService.create();

--- a/lib/tasks/create_feature_flags.rake
+++ b/lib/tasks/create_feature_flags.rake
@@ -12,7 +12,6 @@ task 'create_feature_flags': :environment do
     "CARD_CONFIGURATION",
     "EMAIL_TEMPLATE",
     "HEALTH_CHECK",
-    "CORRESPONDENCE",
     "REVIEW_DUE_DATE",
     "REVIEW_DUE_AT",
     "CAS_PHASED_SIGNUP",


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11568

### Link to review app
[https://plos-ciagent-pr-3755.herokuapp.com]()

#### What this PR does:

Deletes the Correspondence feature flag and all code that uses the feature flag.


#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
