### PR TITLE
APERTA-11963: add a default for preprint opt-out method

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -319,7 +319,8 @@ class Paper < ActiveRecord::Base
   end
 
   def preprint_opt_out?
-    answer_for('preprint-posting--consent').value == '2' rescue false
+    optout = answer_for('preprint-posting--consent')
+    optout.present? && optout.value == '2'
   end
 
   def inactive?


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11963

#### What this PR does:

Adds a default for the preprint opt-out method that references a particular answer, which breaks if that answer is not present. Instead, it should default to false.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
