### PR TITLE
APERTA-11957 ensure that inactive events also get rescheduled

### DIFF
--- a/app/models/scheduled_event.rb
+++ b/app/models/scheduled_event.rb
@@ -13,7 +13,7 @@ class ScheduledEvent < ActiveRecord::Base
   scope :completed, -> { where(state: 'completed') }
   scope :passive, -> { where(state: 'passive') }
   scope :due_to_trigger, -> { active.where('dispatch_at < ?', DateTime.now.in_time_zone) }
-  scope :serviceable, -> { where(state: ['passive', 'active', 'completed']) }
+  scope :serviceable, -> { where(state: ['passive', 'active', 'completed', 'inactive']) }
 
   before_save :deactivate, if: :should_deactivate?
   before_save :reactivate, if: :should_reactivate?

--- a/app/services/scheduled_events_factory.rb
+++ b/app/services/scheduled_events_factory.rb
@@ -50,7 +50,10 @@ class ScheduledEventFactory
 
   def update_scheduled_events
     template.each do |entry|
-      event = owned_serviceable_events.where(name: entry[:name]).first
+      # try to reschedule an already existing version of this event.
+      # if more than one exist, reschedule the one with with the most recent
+      # dispatch_at date
+      event = owned_serviceable_events.where(name: entry[:name]).order(dispatch_at: :desc).first
       reschedule event, entry if event.present?
     end
   end


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11957

🔥 this is an RC PR 🔥 

#### What this PR does:

Previously we were only rescheduling events which were still pending,
or were completed. This change ensures that events which were in the past
and inactive are also rescheduled if their due date changes.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
