### PR TITLE
cleans up fullscreen overlay ui

### DIFF
--- a/app/assets/stylesheets/ui/_overlay-fullscreen.scss
+++ b/app/assets/stylesheets/ui/_overlay-fullscreen.scss
@@ -15,7 +15,7 @@ $ov--fullscreen-breakpoint: 780px;
     width: 85rem;
     margin: auto;
     background-color: $aperta-grey-xlight;
-    padding: 40px 60px;
+    padding: 40px 60px 80px;
   }
 }
 


### PR DESCRIPTION
Another recent PR regarding fixing the overlay ui https://github.com/Tahi-project/tahi/pull/3741/files had an unintended side effect in certain other overlays which was not noticed. This fixes those overlays 
---
old and broke
![overlay-broken](https://user-images.githubusercontent.com/28537466/32936197-a3e827a4-cbb6-11e7-9165-e145c81479db.jpeg)


new and fixed
![overlay-fixed](https://user-images.githubusercontent.com/28537466/32936135-60b5b212-cbb6-11e7-863f-d4a4bc0d0a63.jpeg)


#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes, I've let QA know.
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
