### PR TITLE
Enable using our own rubocop configuration within codeclimate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,4 +2,13 @@ plugins:
   rubocop:
     enabled: true
     channel: rubocop-0-49
+exclude_patterns:
+  - ".fonts/"
+  - "bin/"
+  - "client/tests/"
+  - "client/vendor/"
+  - "doc/"
+  - "spec/"
+  - "test/"
+  - "vendor/"
 


### PR DESCRIPTION
Hi!

No JIRA Issue

#### What this PR does:

Establishes a basic .codeclimate.yml file - that points .codeclimate to our .rubocop.yml configuration file.

#### Special instructions for Review or PO:

PO don't enter into it... 

#### Notes

I am not really sure this will work, it seems like it should based on my reading of the codeclimate docs but I am human and fallible. I don't think things will be weird if it fails.

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read the code; it looks good

