### PR TITLE
APERTA-11988 enforce ordering of scheduled Events in UI

### DIFF
--- a/client/app/pods/components/scheduled-events/component.js
+++ b/client/app/pods/components/scheduled-events/component.js
@@ -8,4 +8,6 @@ export default Ember.Component.extend({
     let tz = moment.tz.guess();
     return moment(this.get('dueDate')).tz(tz).format('z');
   }),
+  eventsAscendingSort: ['dispatchAt:asc'],
+  eventsAscending: Ember.computed.sort('events', 'eventsAscendingSort')
 });

--- a/client/app/pods/components/scheduled-events/template.hbs
+++ b/client/app/pods/components/scheduled-events/template.hbs
@@ -1,6 +1,6 @@
 <p style="font-size:18px;">Reminders</p>
 <div class='scheduled-events-table'>
-  {{#each events as |event|}}
+  {{#each eventsAscending as |event|}}
     <div class="scheduled-event scheduled-event-row event-{{event.state}}">
       <div class="scheduled-event-cell">
         <div class="scheduled-event-description">

--- a/client/tests/components/scheduled-event-test.js
+++ b/client/tests/components/scheduled-event-test.js
@@ -15,29 +15,61 @@ moduleForComponent('review-status', 'Integration | Component | Scheduled Event',
     manualSetup(this.container);
     let dueDate = moment('2020-08-19', 'YYYY-MM-DD');
     this.set('dueDate', dueDate);
-  }
+  },
+
+  createScheduledEvents(events) {
+    return _.map(events, (event) => {
+      return FactoryGuy.make('scheduled-event', {
+        name: event.name,
+        dispatchAt: moment(this.get('dueDate')).add(event.offset, 'days').toDate()
+      });
+    });
+  },
 });
 
+function assertScheduledEvents(assertNames, assert) {
+  _.each(assertNames, (assertName, index) => {
+    assert.textPresent(`.scheduled-event-description:eq(${index})`, assertName);
+  });
+}
+
 test('renders future scheduled differences properly', function (assert) {
-  let scheduledEvents = [
-    FactoryGuy.make('scheduled-event', {
-      name: 'Pre Event',
-      dispatchAt: moment(this.get('dueDate')).add(2, 'days')
-    }),
+  assert.expect(1);
+  const eventData = [
+    {name: 'Post Event', offset: 2},
   ];
+  const scheduledEvents = this.createScheduledEvents(eventData);
   this.set('events', scheduledEvents);
   this.render(hbs`{{scheduled-events events=events dueDate=dueDate}}`);
-  assert.textPresent('.scheduled-event-description', '2 days after due date');
+  assertScheduledEvents(['2 days after due date'], assert);
 });
 
 test('renders past scheduled differences properly', function (assert) {
-  let scheduledEvents = [
-    FactoryGuy.make('scheduled-event', {
-      name: 'Pre Event',
-      dispatchAt: moment(this.get('dueDate')).subtract(2, 'days')
-    }),
+  assert.expect(1);
+  const eventData = [
+    {name: 'Pre Event', offset: -2},
   ];
+  const scheduledEvents = this.createScheduledEvents(eventData);
   this.set('events', scheduledEvents);
   this.render(hbs`{{scheduled-events events=events dueDate=dueDate}}`);
-  assert.textPresent('.scheduled-event-description', '2 days before due date');
+  assertScheduledEvents(['2 days before due date'], assert);
 });
+
+test('renders scheduled events in order', function (assert) {
+  assert.expect(3);
+  const eventData = [
+    {name: 'Post Event', offset: 2},
+    {name: 'Pre Event', offset: -2},
+    {name: 'Super Post Event', offset: 4}
+  ];
+  const scheduledEvents = this.createScheduledEvents(eventData);
+  this.set('events', scheduledEvents);
+  this.render(hbs`{{scheduled-events events=events dueDate=dueDate}}`);
+  assertScheduledEvents(
+    [
+      'Pre Event',
+      'Post Event',
+      'Super Post Event'
+    ], assert );
+});
+


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11988

🔥 this is an RC PR 🔥 

#### What this PR does:

Sets an explicit ordering for Scheduled events in the UI based on dispatchAt date, rather than relying on them to be serialized in the correct order.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
