### PR TITLE
APERTA-11985 ensure passive events can also be deactivated

### DIFF
--- a/app/models/scheduled_event.rb
+++ b/app/models/scheduled_event.rb
@@ -19,7 +19,7 @@ class ScheduledEvent < ActiveRecord::Base
   before_save :reactivate, if: :should_reactivate?
 
   def should_deactivate?
-    dispatch_at && dispatch_at < DateTime.now.in_time_zone && active?
+    dispatch_at && dispatch_at < DateTime.now.in_time_zone && (active? || passive?)
   end
 
   def should_reactivate?
@@ -44,7 +44,7 @@ class ScheduledEvent < ActiveRecord::Base
     end
 
     event(:deactivate) do
-      transitions from: :active, to: :inactive
+      transitions from: [:active, :passive], to: :inactive
     end
 
     event(:switch_off) do

--- a/spec/models/scheduled_event_spec.rb
+++ b/spec/models/scheduled_event_spec.rb
@@ -56,7 +56,7 @@ describe ScheduledEvent do
         subject.dispatch_at = DateTime.now.in_time_zone.beginning_of_minute - 3.days
       end
 
-      it 'should be true for only active events' do
+      it 'should be true for only active or passive events' do
         expect(subject.should_deactivate?).to be true
 
         subject.deactivate!
@@ -65,6 +65,10 @@ describe ScheduledEvent do
         subject.reactivate!
         subject.trigger!
         expect(subject.should_deactivate?).to be false
+
+        subject.reactivate!
+        subject.switch_off!
+        expect(subject.should_deactivate?).to be true
       end
     end
 
@@ -95,7 +99,7 @@ describe ScheduledEvent do
         subject.dispatch_at = DateTime.now.in_time_zone.beginning_of_minute + 3.days
       end
 
-      it 'should be true for only active events' do
+      it 'should be true for only inactive events' do
         expect(subject.should_reactivate?).to be false
 
         subject.deactivate!


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11985

🔥 this is an RC PR 🔥 

#### What this PR does:

This prevents events which are deactivated from retaining their toggle even if
their dispatch_at is in the past.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

