### PR TITLE
APERTA-11977 centers card--overlay for all browsers

### DIFF
--- a/app/assets/stylesheets/ui/_overlay-card.scss
+++ b/app/assets/stylesheets/ui/_overlay-card.scss
@@ -7,6 +7,7 @@ $ov--card-breakpoint: 900px;
   justify-content: center;
   overflow-y: scroll;
   padding: 40px 0;
+  display: grid;
 
   // TODO: This needs another home:
   h1 {
@@ -19,7 +20,7 @@ $ov--card-breakpoint: 900px;
     min-height: 25rem;
     width: 112rem;
     border-radius: 5px;
-    margin: auto 75px;
+    margin: auto;
     background-color: #fff;
   }
 }


### PR DESCRIPTION
https://jira.plos.org/jira/browse/APERTA-11977
#### What this PR does:

The card overlay that pops up if you click a card in workflow view was off center in all browsers. This fix contains two lines, one which fixes this for ie11, one which fixes browsers that aren't ie11

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
