### PR TITLE
Features/APERTA 11942 record duedate changes in recent activity feed

### DIFF
--- a/app/controllers/due_datetimes_controller.rb
+++ b/app/controllers/due_datetimes_controller.rb
@@ -10,7 +10,7 @@ class DueDatetimesController < ApplicationController
       requires_user_can :edit_due_date, due_datetime.due.task
       due_datetime.update_attributes due_datetime_params
       due_datetime.due.schedule_events if FeatureFlag[:REVIEW_DUE_AT]
-      Activity.duedate_updated!(due_datetime, user: current_user)
+      Activity.due_datetime_updated!(due_datetime, user: current_user)
     end
     render json: due_datetime
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -373,7 +373,7 @@ class Activity < ActiveRecord::Base
     )
   end
 
-  def self.duedate_updated!(due_datetime, user:)
+  def self.due_datetime_updated!(due_datetime, user:)
     new_due_date = due_datetime.due_at.strftime('%B %d, %Y')
     reviewer_name = due_datetime.due.user.full_name
     msg = "Due date for Review by #{reviewer_name} was changed to #{new_due_date}"

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -590,4 +590,22 @@ describe Activity do
       )
     }
   end
+
+  describe "#due_datetime_updated!" do
+    let(:due) { FactoryGirl.create :reviewer_report }
+    let(:due_datetime) { FactoryGirl.create :due_datetime, :in_5_days, due: due }
+    subject { Activity.due_datetime_updated!(due_datetime, user: user) }
+
+    it {
+      expected_reviewer_name = due_datetime.due.user.full_name
+      expected_new_date = due_datetime.due_at.strftime('%B %d, %Y')
+
+      is_expected.to have_attributes(
+        feed_name: 'workflow',
+        activity_key: 'duedatetime.updated',
+        subject: due_datetime.due.paper,
+        message: "Due date for Review by #{expected_reviewer_name} was changed to #{expected_new_date}"
+      )
+    }
+  end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11942

#### What this PR does:

This PR ensures that when a review due date is modified, details of the change can be seen in the workflow activity feed.

Can your changes be *seen* by a user? Then add a screenshot. Is it an
interaction?  Perhaps a quick recording?
<img width="1280" alt="screen shot 2017-11-21 at 12 34 23 am" src="https://user-images.githubusercontent.com/20759355/33047013-df78740a-ce53-11e7-9d7e-3f0136af2e13.png">
<img width="743" alt="screen shot 2017-11-21 at 12 35 02 am" src="https://user-images.githubusercontent.com/20759355/33047014-dfa0afec-ce53-11e7-9efe-20e958decf60.png">

#### Code Review Tasks:

**Author tasks**
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases