### PR TITLE
Hacky but true, the initial click of the accept or reject radio butto…

### DIFF
--- a/test/frontend/Cards/initial_decision_card.py
+++ b/test/frontend/Cards/initial_decision_card.py
@@ -39,8 +39,12 @@ class InitialDecisionCard(BaseCard):
     card_title = self._get(self._card_title)
     assert card_title.text == 'Initial Decision'
     self.validate_overlay_card_title_style(card_title)
-    self._get(self._invite_radio_button).click()
-    time.sleep(1) # added as a bug fix to give previous step time
+    invite_radio = self._get(self._invite_radio_button)
+    # This is totally stupid, but the initial click is not actually always registering only when using Marionette.
+    # Adding a repeat click seems to solidify this. Hacky but true.
+    invite_radio.click()
+    invite_radio.click()
+    self._wait_for_element(self._get(self._intro_text))
     intro_text = self._get(self._intro_text)
     # APERTA-8902
     # self.validate_application_body_text(intro_text)


### PR DESCRIPTION
…n of the initial decision card, is not always registering when running under Marionette. Added a gratuitous second click that seems to make it work - also killed one stupid sleep - small victory to make up for feeling dirty with the double click.

# QA Ticket

JIRA issue: No Jira issue - test suite failure in Teamcity at: https://teamcity.plos.org/teamcity/viewLog.html?buildId=145880&tab=buildResultsDiv&buildTypeId=Aperta_PythonAutomationTestRuns_IntegrationTestOnSfoRc#testNameId-2163134355818846764

#### What this PR does:

Only when running under Marionette, the click of the Invite for Full Submission or Reject button is not always registering - and thus the "Intro text" of the decision letter is not showing as non-hidden in the DOM. 

Added in a gratuitous second click() event which seems to resolve this issue. 

#### Notes

Also took out one of the too many stupid time.sleep() calls in this initial decision method.
---

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 2/3 agnostic way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
