### PR TITLE
Empowerment: fix send email behavior spec on master

### DIFF
--- a/spec/models/send_email_behavior_spec.rb
+++ b/spec/models/send_email_behavior_spec.rb
@@ -5,7 +5,7 @@ describe Behavior do
   let(:journal) { create(:journal) }
   let(:paper) { create(:paper, journal: journal) }
   let(:task) { create(:task, paper: paper, title: 'My Task') }
-  let!(:template) { create(:letter_template, journal: journal, ident: 'foo-bar', scenario: 'Preprint Decision') }
+  let!(:template) { create(:letter_template, journal: journal, ident: 'foo-bar', scenario: 'Manuscript') }
   let(:event) { Event.new(name: :fake_event, paper: paper, task: task, user: paper.creator) }
   subject { build(:send_email_behavior, letter_template: 'foo-bar') }
 


### PR DESCRIPTION
#### What this PR does:

A spec broke due to a recent merge in master.  It was using a scenario that was filtered out in the test due to a feature flag (the feature flag blocking the scenario didn't exist in the context the test was testing prior to getting merged in). This should fix it

```bash
rspec ./spec/models/send_email_behavior_spec.rb:32 # Behavior should call GenericMailer to send the email
```
![screen shot 2017-11-22 at 1 40 31 pm](https://user-images.githubusercontent.com/6579120/33150958-b9cd7916-cf8a-11e7-957e-4ef980b7d2dd.png)


#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):

- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases


