### PR TITLE
APERTA-11680-replaced-username-with-fullname-with-refactored-tests

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -148,7 +148,7 @@ class Activity < ActiveRecord::Base
     message = if user == invitation.invitee
                 "#{invitation.recipient_name} accepted invitation as #{invitation.invitee_role.capitalize}"
               else
-                "#{user.username} accepted invitation as #{invitation.invitee_role.capitalize} on behalf of #{invitation.recipient_name}"
+                "#{user.full_name} accepted invitation as #{invitation.invitee_role.capitalize} on behalf of #{invitation.recipient_name}"
               end
     create(
       feed_name: "workflow",

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -196,7 +196,7 @@ describe Activity do
           activity_key: "invitation.accepted",
           subject: invitation.paper,
           user: activity_user,
-          message: "#{activity_user.username} accepted invitation as #{invitation.invitee_role.capitalize} on behalf of #{invitation.recipient_name}"
+          message: "#{activity_user.full_name} accepted invitation as #{invitation.invitee_role.capitalize} on behalf of #{invitation.recipient_name}"
         )
       }
     end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11680

#### What this PR does:

Replaces staff member username with their full name on the Recent activity display when they accept an invitation on a reviewer's behalf.

#### Major UI changes

<img width="761" alt="screen shot 2017-11-24 at 9 33 17 pm" src="https://user-images.githubusercontent.com/10073272/33223379-25f75d70-d15f-11e7-8bcd-f4e53da769d3.png">

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] If I made any UI changes, I've let QA know.
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases