### PR TITLE
APERTA-11946 fix and refactor controller

### DIFF
--- a/app/controllers/admin/journals_controller.rb
+++ b/app/controllers/admin/journals_controller.rb
@@ -21,9 +21,8 @@ class Admin::JournalsController < ApplicationController
   end
 
   def create
-    requires_user_can(:administer, Journal)
+    raise AuthorizationError unless current_user.site_admin?
     @journal = JournalFactory.create(journal_params)
-    journal.save!
     process_pending_logo(params[:admin_journal][:logo_url])
     respond_with(journal, serializer: AdminJournalSerializer, root: 'admin_journal')
   end

--- a/spec/controllers/admin/journals_controller_spec.rb
+++ b/spec/controllers/admin/journals_controller_spec.rb
@@ -30,11 +30,7 @@ describe Admin::JournalsController, redis: true do
     context 'when the user has access' do
       before do
         stub_sign_in user
-        allow(user).to receive(:can?) do |action, object|
-          expect(action).to eq(:administer)
-          expect(object).to(controller.action_name == 'create' ? be(Journal) : be_kind_of(Journal))
-          true
-        end
+        expect(user).to receive(:site_admin?).and_return(true)
       end
 
       it 'creates a journal' do
@@ -78,11 +74,7 @@ describe Admin::JournalsController, redis: true do
     context "when the user does not have access" do
       before do
         stub_sign_in user
-        allow(user).to receive(:can?) do |action, object|
-          expect(action).to eq(:administer)
-          expect(object).to(controller.action_name == 'create' ? be(Journal) : be_kind_of(Journal))
-          false
-        end
+        expect(user).to receive(:site_admin?).and_return(false)
       end
 
       it "renders status 403" do


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11946

#### What this PR does:

The pattern of fetching or creating a controller's model based on incoming params is biting us. 

#### Special instructions for Review or PO:

going to that path, it should not create a new journal.
`/api/admin/journals/%20.json?admin_journal[name]=foo&admin_journal[description]=bar&admin_journal[doi_journal_prefix]=journal_baz1&admin_journal[doi_publisher_prefix]=qux`

#### Notes

We should have greater scrutiny about which actions allow for db persistence logic.



---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.
- [x] Write tests

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
