### PR TITLE
Remove uneeded VALUE_TYPES_FOR_CONTENT

### DIFF
--- a/app/models/card_content.rb
+++ b/app/models/card_content.rb
@@ -74,12 +74,13 @@ class CardContent < ActiveRecord::Base
   SUPPORTED_VALUE_TYPES = %w[attachment boolean question-set text html].freeze
 
   # Note that value_type really refers to the value_type of answers associated
-  # with this piece of card content. In the old NestedQuestion world, both
-  # NestedQuestionAnswer and NestedQuestion had a value_type column, and the
-  # value_type was duplicated between them. In the hash below, we say that the
+  # with this piece of card content. In the hash below, we say that the
   # 'short-input' answers will have a 'text' value type, while 'radio' answers
   # can either be boolean or text.
-  # Content types that don't store answers ('display-children, etc') are omitted from this check
+  #
+  # Content types that don't store answers ('display-children, etc') are omitted
+  # from this check, meaning 'foo': [nil] is not necessary to spell out for the
+  # validation.
   VALUE_TYPES_FOR_CONTENT =
     {
       'dropdown': ['text', 'boolean'],
@@ -90,10 +91,8 @@ class CardContent < ActiveRecord::Base
       'email-editor': ['html'],
       'radio': ['boolean', 'text'],
       'tech-check': ['boolean'],
-      'tech-check-email': [nil],
       'date-picker': ['text'],
-      'sendback-reason': ['boolean'],
-      'repeat': [nil]
+      'sendback-reason': ['boolean']
     }.freeze.with_indifferent_access
 
   # Although we want to validate the various combinations of content types


### PR DESCRIPTION
JIRA ticket: none (these code changes are a no-op)
As part of 1b7fd92bb60480f38947016e20094472b0061636 (part of [this PR](https://github.com/Tahi-project/tahi/pull/3481)), we made it so
VALUE_TYPES_FOR_CONTENT didn't need entries whose values were [nil].  Some of
those entries have cropped up over time (they don't hurt anything), but it's
good to keep from perpetuating the pattern.

This commit also clarifies the advice in the comments as well.