### PR TITLE
Fix event name

### DIFF
--- a/spec/models/send_email_behavior_spec.rb
+++ b/spec/models/send_email_behavior_spec.rb
@@ -15,7 +15,7 @@ describe Behavior do
   end
 
   after(:each) do
-    Event.deregister(:fake_name)
+    Event.deregister(:fake_event)
   end
 
   it_behaves_like :behavior_subclass


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

Fixes a flaky spec. On master, this will fail:

```
rspec ./spec/models/send_email_behavior_spec.rb[1:1:1] ./spec/services/event_spec.rb[1:1:1:1,1:1:1:2] -p 30 -t ~js --seed 37354 --format doc
```

but this change will fix it.

---

#### Code Review Tasks:


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
