### PR TITLE
APERTA-9774 Remove icon from paper title in versions view

### DIFF
--- a/client/app/pods/components/overlay-task-version/template.hbs
+++ b/client/app/pods/components/overlay-task-version/template.hbs
@@ -6,7 +6,6 @@
         <header class="overlay-header">
           <span>
             {{#link-to "paper.index" model.paper.id class="task-overlay-paper-title"}}
-              {{partial "svg/manuscript-icon"}}
               {{{model.paperTitle}}}
             {{/link-to}}
           </span>


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-9774

#### What this PR does:

Removes an overlapping icon from the paper title in the versions view.

Can your changes be *seen* by a user? Then add a screenshot. Is it an
interaction?  Perhaps a quick recording?
<img width="1280" alt="screen shot 2017-11-30 at 11 59 18 am" src="https://user-images.githubusercontent.com/20759355/33427835-0cecd97e-d5c7-11e7-8fac-1f032a598e72.png">

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
