### PR TITLE
APERTA-12015 paper tracker order fix

### DIFF
--- a/spec/controllers/paper_tracker_controller_spec.rb
+++ b/spec/controllers/paper_tracker_controller_spec.rb
@@ -32,6 +32,32 @@ describe PaperTrackerController do
     end
   end
 
+  describe '#order_dir' do
+    let(:user) { FactoryGirl.create :user }
+    before { expect(controller).to receive(:params).and_return(orderDir: value) }
+    ['foo', 'asc', 'desc'].each do |val|
+      context "with #{val} param" do
+        let(:value) { val }
+        it "it returns the correct value" do
+          expect(controller.send(:order_dir)).to eql(val == 'desc' ? 'desc' : 'asc')
+        end
+      end
+    end
+  end
+
+  describe '#column' do
+    let(:user) { FactoryGirl.create :user }
+
+    Paper.column_names.dup.push('bogus').each do |val|
+      context "with #{val} param" do
+        it "returns the correct value" do
+          allow(controller).to receive(:params).and_return(orderBy: val)
+          expect(controller.send(:column)).to eql(val == 'bogus' ? 'submitted_at' : val)
+        end
+      end
+    end
+  end
+
   describe 'on GET #index' do
     let(:user) { FactoryGirl.create :user, :site_admin }
 
@@ -169,7 +195,7 @@ describe PaperTrackerController do
         make_matchable_paper(title: 'aaa foo')
         make_matchable_paper(title: 'bbb foo')
         make_matchable_paper(title: 'aaa foo')
-        get :index, format: :json, query: 'foo', orderBy: :title
+        get :index, format: :json, query: 'foo', orderBy: 'title'
         json = JSON.parse(response.body)
         expect(Paper.count).to eq(3)
         expect(json['papers'][0]['title']).to eq('aaa foo')
@@ -184,8 +210,8 @@ describe PaperTrackerController do
         get :index,
             format: :json,
             query: 'foo',
-            orderBy: :title,
-            orderDir: :desc
+            orderBy: 'title',
+            orderDir: 'desc'
         json = JSON.parse(response.body)
         expect(Paper.count).to eq(3)
         expect(json['papers'][0]['title']).to eq('bbb foo')


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12015

#### What this PR does:

Before we were interpolating unsanitary params into SQL fragments, now we make sure only the correct stuff makes in into our ordering clauses.

#### Special instructions for Review or PO:

~~Should probably be PO'd by another dev who can see rails logs...~~
This is a sample query that would error prior to the fix.  I tested the breakage on my local box, but it . 
 https://plos-ciagent-pr-3814.herokuapp.com/api/paper_tracker.json?page=1&query=(TITLE%20IS%20egocentric%25)&orderBy=doi&orderDir=undefined

#### Notes

I reeeealllyy wanted to clean up `order_by_role`... alas my activerecord foo wasn't strong enough.
The only other place we really interpolate user input into SQL calls is in `Arel::Table#matches` in `query_parser.rb` but I think that is safe from injection, though it would be nice to get a second opinion.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
