### PR TITLE
Revert "APERTA-12003: only refresh pdf viewer when replacing with ano…

### DIFF
--- a/client/app/pods/components/pdf-manuscript/component.js
+++ b/client/app/pods/components/pdf-manuscript/component.js
@@ -23,9 +23,7 @@ export default Ember.Component.extend({
   },
 
   fileChanged: observer('paper.file.fileHash', function() {
-    if (this.get('paper.latestVersionedText.fileType') === 'pdf') {
-      this.refreshPdf();
-    }
+    this.refreshPdf();
   }),
 
   loadPdf: function() {


### PR DESCRIPTION
# Dev ticket - Hi!

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12003

🔥 This is an RC PR 🔥 

#### What this PR does:

We attempted to create fix for APERTA-12003 but it actually seemed to just make things a little worse. Rather than whipping together a fix for the fix which might jeopardize the RC, we're going to play it safe and just revert back to a safe baseline.

This PR reverts the changes originally made in https://github.com/Tahi-project/tahi/pull/3774 to get us back to the functionality in release/1.54 (which wasn't that bad).

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases