### PR TITLE
Enable Rails/SaveBang rubocop checker

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,6 +84,9 @@ Rails/Delegate:
   # cannot replace the flagged method.
   Enabled: false
 
+Rails/SaveBang:
+  Enabled: true
+
 Style/ClassAndModuleChildren:
   # Rails autoloading can get us into situations where it is very
   # difficult to disambiguate the long-hand version of


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

Makes rubocop yell at you if you don't use the `!` methods of ActiveRecord saving methods *or* check the return value.

See https://github.com/bbatsov/rails-style-guide#save-bang

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
