### PR TITLE
Revert "Temporarily upgrade to hobby dynos for review apps"

### DIFF
--- a/app.json
+++ b/app.json
@@ -238,7 +238,7 @@
     "rediscloud:30"
   ],
   "formation": {
-     "web": {"quantity": 1, "size": "hobby"},
-     "worker": {"quantity": 1, "size": "hobby"}
+     "web": {"quantity": 1, "size": "free"},
+     "worker": {"quantity": 1, "size": "free"}
   }
 }


### PR DESCRIPTION
# Dev ticket - Hi!

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12100

#### What this PR does:

Reverts https://github.com/Tahi-project/tahi/pull/3795 so we don't have to keep paying for heroku dynos. It's the first of the month so we can go back to using free dynos.

We'll need to ask developers to merge this into their feature branches ASAP. They might also need to manually downgrade their dynos in the heroku dashboard. I *think* based on the experiences that we had with rolling out 3795, things worked automatically for brand new review apps, but any review app that was created before the change had a hard time changing dynos (even if we closed and reopened the PR to trigger a new review app).

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- ~~[ ] I have found the tests to be sufficient for both positive and negative test cases~~