### PR TITLE
Empowerment - speed up overlay specs

### DIFF
--- a/spec/support/pages/overlay.rb
+++ b/spec/support/pages/overlay.rb
@@ -3,7 +3,7 @@ class CardOverlay < Page
 
   def dismiss
     session.all('.overlay .overlay-close-button').first.click
-    synchronize_no_content!("CLOSE")
+    expect(page).to have_no_css('.overlay')
   end
 
   text_assertions :assignee, '.chosen-assignee.chosen-container', ->(name){ name.upcase }

--- a/spec/support/pages/overlays/assign_team_overlay.rb
+++ b/spec/support/pages/overlays/assign_team_overlay.rb
@@ -1,13 +1,11 @@
 class AssignTeamOverlay < CardOverlay
   def self.visit(assign_team_task, &blk)
     page.visit "/papers/#{assign_team_task.paper.id}/tasks/#{assign_team_task.id}"
-    wait_for_ajax
 
     new.tap do |overlay|
       if block_given?
         page.assert_selector(".overlay-container .overlay-body")
         blk.call overlay
-        wait_for_ajax
         overlay.dismiss
       end
     end
@@ -17,10 +15,8 @@ class AssignTeamOverlay < CardOverlay
     page.assert_selector(".assign-team-content")
 
     select2 role_name, from: "Role"
-    wait_for_ajax
 
     select2 user.full_name, css: '.assignment-user-input', search: true
-    wait_for_ajax
 
     click_button "Assign"
   end
@@ -28,6 +24,5 @@ class AssignTeamOverlay < CardOverlay
   def unassign_user(user)
     trash_icon = find(".invitation", text: user.full_name).find(".invite-remove")
     trash_icon.click
-    wait_for_ajax
   end
 end


### PR DESCRIPTION
#### What this PR does:

This replaces synchronize_no_content (which appeared to cause some timing issues) with a css check for dismissing overlays, and removes some unneeded wait_for_ajax calls.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [X] I read the code; it looks good
- [X] I have found the tests to be sufficient for both positive and negative test cases
