### PR TITLE
APERTA-11622 make title unlisted in user context

### DIFF
--- a/app/services/merge_field.rb
+++ b/app/services/merge_field.rb
@@ -29,6 +29,7 @@ class MergeField
     @unlisted ||= Hash.new { [] }.tap do |hash|
       hash[PaperContext] = [:url_for, :url_helpers]
       hash[ReviewerReportContext] = ActionView::Helpers::SanitizeHelper.public_instance_methods
+      hash[UserContext] = [:title]
     end
   end
 


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11622

#### What this PR does:

It unlists `:title`, hence editor editors wont have this mergefield. Is this too hamfisted b/c its for all users?

#### Special instructions for Review or PO:

On this page: https://plos-ciagent-pr-3824.herokuapp.com/admin/journals/emailtemplates/1/edit
You should not see `{{ manuscript.editor.last_name }}` among the Available Merge Fields

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
