### PR TITLE
APERTA-11905 Foreign key constraint violation

### DIFF
--- a/app/services/xml_card_loader.rb
+++ b/app/services/xml_card_loader.rb
@@ -34,8 +34,8 @@ class XmlCardLoader
       # delete CardContents before the CardContentValidations
       # Open Bug: https://github.com/collectiveidea/awesome_nested_set/issues/306
       card.latest_card_version.card_contents.each do |cc|
-        cc.card_content_validations.try(:destroy_all)
-        cc.entity_attributes.try(:destroy_all)
+        cc.card_content_validations.destroy_all
+        cc.entity_attributes.destroy_all
       end
 
       # remove and decrement latest card_version


### PR DESCRIPTION
# Dev ticket - Hi!

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11905

#### What this PR does:

When the user follows the steps on the ticket, and tries to modify an already created card that has a field with a validation, then it failed because the gem AANS was trying to destroy the CardContents before the CardContentValidations, triggering a Foreign key constraint violation.
  
Open Bug: https://github.com/collectiveidea/awesome_nested_set/issues/306

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
