### PR TITLE
APERTA-11728 Fix bug iterating over mail recipients

### DIFF
--- a/app/mail_handlers/mail_log/log_to_database.rb
+++ b/app/mail_handlers/mail_log/log_to_database.rb
@@ -56,10 +56,12 @@ module MailLog
       end
 
       def self.get_recipients(message)
-        message.to.map do |to_email|
-          u = User.find_by(email: to_email)
-          u ? "#{u.full_name} <#{to_email}>" : to_email
-        end.join(', ')
+        recipients = Array(message.to)
+        users = User.where(email: recipients)
+        emails = users.map(&:email).compact
+        unknown = recipients - emails
+        known = users.map { |user| "#{user.full_name} <#{user.email}>" }
+        (known + unknown).join(', ')
       end
     end
 

--- a/spec/mail_handlers/mail_log/log_to_database_spec.rb
+++ b/spec/mail_handlers/mail_log/log_to_database_spec.rb
@@ -136,10 +136,10 @@ module MailLog::LogToDatabase
         end
       end
 
-      it 'inserts known recipient names' do
+      it 'inserts known recipient names, first known, then unknown' do
         user = FactoryGirl.create(:user, email: mail.to.last)
         interceptor.delivering_email(mail)
-        expect(Correspondence.last.recipients).to eq("#{mail.to.first}, #{user.full_name} <#{mail.to.last}>")
+        expect(Correspondence.last.recipients).to eq("#{user.full_name} <#{mail.to.last}>, #{mail.to.first}")
       end
     end
 


### PR DESCRIPTION
# Bug fix ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11728

#### What this PR does:

The Mail::Message "to" recipients field can be either a string or an array of strings. This PR normalizes the recipient list, permitting the proper construction of the correspondence history, and fixing a frequent bugsnag bug.

It also optimizes the database queries for known users to a single fetch, rather than one per recipient.

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):

- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

#### After the Code Review:

Reviewer tasks:

- [x] I have moved the ticket forward in JIRA
