### PR TITLE
Add behavior:list, behavior:destroy[id] rake tasks

### DIFF
--- a/lib/tasks/behavior.rake
+++ b/lib/tasks/behavior.rake
@@ -1,8 +1,12 @@
 namespace :behavior do
-  desc "List all extand behaviors"
+  desc "List all existing behaviors."
   task list: :environment do |_t, _args|
-    Behavior.all.find_each do |behavior|
-      STDOUT.write("#{behavior.inspect}\n")
+    if Behavior.count.zero?
+      STDOUT.write("No behaviors found\n")
+    else
+      Behavior.all.find_each do |behavior|
+        STDOUT.write("#{behavior.inspect}\n")
+      end
     end
   end
 


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

Adds 2 helper methods for dealing with behaviors that we should have added for QA in the first place: `destroy` and `list`


```
$ bundle exec rake -T |grep behavior
rake behavior:create:create_task[journal_id,event,card_id,duplicates_allowed]           # Create a new create task behavior
rake behavior:create:send_email[journal_id,event,letter_template]                       # Create a new send email behavior
rake behavior:create:task_completion[journal_id,event,card_id,change_to]                # Create a new autocomplete task behavior
rake behavior:destroy[behavior_id]                                                      # Destroy a behavior with a given id
rake behavior:list 

$ bundle exec rake "behavior:create:task_completion[1, paper.state_changed.published, 47, toggle]"
Created #<TaskCompletionBehavior id: 3, event_name: "paper.state_changed.published", type: "TaskCompletionBehavior", journal_id: 1, created_at: "2017-12-06 00:43:31", updated_at: "2017-12-06 00:43:31">

$ bundle exec rake behavior:list
#<TaskCompletionBehavior id: 3, event_name: "paper.state_changed.published", type: "TaskCompletionBehavior", journal_id: 1, created_at: "2017-12-06 00:43:31", updated_at: "2017-12-06 00:43:31">

$ bundle exec rake behavior:destroy[3]
Destroyed #<TaskCompletionBehavior id: 3, event_name: "paper.state_changed.published", type: "TaskCompletionBehavior", journal_id: 1, created_at: "2017-12-06 00:43:31", updated_at: "2017-12-06 00:43:31">
```

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
