### PR TITLE
APERTA-12000 Adjust height of overlay card container for MS Edge

### DIFF
--- a/app/assets/stylesheets/ui/_overlay-card.scss
+++ b/app/assets/stylesheets/ui/_overlay-card.scss
@@ -32,6 +32,13 @@ $ov--card-breakpoint: 900px;
   }
 }
 
+// Microsoft Edge styles
+@supports (-ms-ime-align:auto) {
+    .overlay--card .overlay-container {
+      height: 100%; // Fixes APERTA-12000
+    }
+}
+
 // Temporary:
 .overlay--visible {
   display: block;


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12000

#### What this PR does:

It fixes user not able to scroll up for cards that require scrolling, for instance Billing card.

#### Special instructions for Review or PO:

Microsoft Edge 16 is required, you can also make sure this fix doesn't break the card container in IE11.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
