### PR TITLE
Remove JSON parsing of text/html

### DIFF
--- a/client/app/models/card-content.js
+++ b/client/app/models/card-content.js
@@ -19,7 +19,7 @@ export default DS.Model.extend({
   contentType: DS.attr('string'),
   ident: DS.attr('string'),
   possibleValues: DS.attr(),
-  defaultAnswerValue: DS.attr(),
+  defaultAnswerValue: DS.attr('string'),
   order: DS.attr('number'),
   text: DS.attr('string'),
   instructionText: DS.attr('string'),
@@ -123,12 +123,10 @@ export default DS.Model.extend({
     let defaultAnswerValue = this.get('defaultAnswerValue');
     if(!defaultAnswerValue) { return; }
 
-    // If the valueType is text or html, it will return it, otherwise (boolean) it will
-    // cast it will typecast it to boolean
-    if(this.get('valueType') === 'text' || this.get('valueType') === 'html')  {
-      return defaultAnswerValue;
+    if (this.get('valueType') === 'boolean') {
+      return defaultAnswerValue.trim() === 'true';
     } else {
-      return JSON.parse(defaultAnswerValue);
+      return defaultAnswerValue;
     }
   },
 


### PR DESCRIPTION
Empowerment Ticket

1. Change card config answer processing to simplify it and not attempt to JSON.parse raw text or HTML. 

2. All default-answer-values are strongly-typed as String in the database, even if they represent booleans in the UI, so they should be represented as String in Ember. 