### PR TITLE
APERTA-12033 Add data-ident attribute with content.ident

### DIFF
--- a/client/app/pods/components/card-content/check-box/component.js
+++ b/client/app/pods/components/card-content/check-box/component.js
@@ -3,12 +3,14 @@ import { PropTypes } from 'ember-prop-types';
 
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-check-box'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
 
   propTypes: {
     content: PropTypes.EmberObject.isRequired,
     disabled: PropTypes.bool,
     repetition: PropTypes.oneOfType([PropTypes.null, PropTypes.EmberObject]).isRequired,
-    answer: PropTypes.EmberObject.isRequired
+    answer: PropTypes.EmberObject.isRequired,
   },
 
   actions: {

--- a/client/app/pods/components/card-content/date-picker/component.js
+++ b/client/app/pods/components/card-content/date-picker/component.js
@@ -3,6 +3,8 @@ import { PropTypes } from 'ember-prop-types';
 
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-date-picker'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
 
   propTypes: {
     content: PropTypes.EmberObject.isRequired,

--- a/client/app/pods/components/card-content/description/component.js
+++ b/client/app/pods/components/card-content/description/component.js
@@ -3,6 +3,8 @@ import { PropTypes } from 'ember-prop-types';
 
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-view-text'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
 
   hasListParent: Ember.computed.equal('content.parent.childTag', 'li'),
 

--- a/client/app/pods/components/card-content/dropdown/component.js
+++ b/client/app/pods/components/card-content/dropdown/component.js
@@ -3,6 +3,8 @@ import { PropTypes } from 'ember-prop-types';
 
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-dropdown'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
 
   propTypes: {
     content: PropTypes.EmberObject.isRequired,

--- a/client/app/pods/components/card-content/email-editor/component.js
+++ b/client/app/pods/components/card-content/email-editor/component.js
@@ -4,6 +4,9 @@ import { PropTypes } from 'ember-prop-types';
 
 export default Ember.Component.extend(ValidationErrorsMixin, {
   classNames: ['card-content', 'card-content-email-editor'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
+
   restless: Ember.inject.service('restless'),
   flash: Ember.inject.service('flash'),
   propTypes: {

--- a/client/app/pods/components/card-content/export-paper/component.js
+++ b/client/app/pods/components/card-content/export-paper/component.js
@@ -3,12 +3,16 @@ import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-export-paper'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
+
   owner: null, //owner
   content: null, //card content
   disabled: false,
   store: Ember.inject.service(),
   task: Ember.computed.reads('owner'),
   destination: Ember.computed.reads('content.text'),
+
   createExportDelivery: task(function * () {
     if (this.get('disabled')) {
       return;

--- a/client/app/pods/components/card-content/file-uploader/component.js
+++ b/client/app/pods/components/card-content/file-uploader/component.js
@@ -3,6 +3,8 @@ import { PropTypes } from 'ember-prop-types';
 
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-file-uploader'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
 
   propTypes: {
     content: PropTypes.EmberObject.isRequired,

--- a/client/app/pods/components/card-content/financial-disclosure-summary/component.js
+++ b/client/app/pods/components/card-content/financial-disclosure-summary/component.js
@@ -8,6 +8,9 @@ let computedFromAnswer = function(ident) {
 };
 
 const Funder = Ember.Object.extend({
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
+
   answers: null,
   repetition: null,
 

--- a/client/app/pods/components/card-content/paragraph-input/component.js
+++ b/client/app/pods/components/card-content/paragraph-input/component.js
@@ -5,6 +5,8 @@ import ValidateTextInput from 'tahi/mixins/validate-text-input';
 export default Ember.Component.extend(ValidateTextInput, {
   classNames: ['card-content', 'card-content-paragraph-input'],
   classNameBindings: ['answer.shouldShowErrors:has-error', 'disabled:read-only'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
 
   propTypes: {
     answer: PropTypes.EmberObject.isRequired,

--- a/client/app/pods/components/card-content/radio/component.js
+++ b/client/app/pods/components/card-content/radio/component.js
@@ -4,6 +4,9 @@ import { PropTypes } from 'ember-prop-types';
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-radio'],
   tagName: 'fieldset',
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
+
   propTypes: {
     answer: PropTypes.EmberObject.isRequired,
     content: PropTypes.EmberObject.isRequired,

--- a/client/app/pods/components/card-content/sendback-reason/component.js
+++ b/client/app/pods/components/card-content/sendback-reason/component.js
@@ -8,6 +8,9 @@ let childAt = function(key, position) {
 };
 
 export default Ember.Component.extend({
+  classNames: ['card-content', 'card-content-sendback-reason'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
 
   propTypes: {
     answer: PropTypes.EmberObject.isRequired,
@@ -16,8 +19,6 @@ export default Ember.Component.extend({
     repetition: PropTypes.oneOfType([PropTypes.null, PropTypes.EmberObject]).isRequired,
     answerChanged: PropTypes.any.isRequired
   },
-
-  classNames: ['card-content', 'card-content-sendback-reason'],
 
   shouldHide: Ember.observer('checkboxAnswer.value', function() {
     Ember.run.once(this, 'revertChildrenAnswers');

--- a/client/app/pods/components/card-content/short-input/component.js
+++ b/client/app/pods/components/card-content/short-input/component.js
@@ -4,9 +4,10 @@ import ValidateTextInput from 'tahi/mixins/validate-text-input';
 
 export default Ember.Component.extend(ValidateTextInput, {
   classNames: ['card-content', 'card-content-short-input'],
-  attributeBindings: ['isRequired:required', 'aria-required'],
-  'aria-required': Ember.computed.reads('isRequiredString'),
   classNameBindings: ['answer.shouldShowErrors:has-error'],
+  attributeBindings: ['isRequired:required', 'aria-required', 'data-ident'],
+  'aria-required': Ember.computed.reads('isRequiredString'),
+  'data-ident': Ember.computed.alias('content.ident'),
 
   propTypes: {
     answer: PropTypes.EmberObject.isRequired,

--- a/client/app/pods/components/card-content/tech-check-email/component.js
+++ b/client/app/pods/components/card-content/tech-check-email/component.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   classNames: ['card-content-tech-check-email'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
+
   showEmailPreview: false,
   restless: Ember.inject.service('restless'),
   flash: Ember.inject.service('flash'),

--- a/client/app/pods/components/card-content/tech-check/component.js
+++ b/client/app/pods/components/card-content/tech-check/component.js
@@ -3,6 +3,9 @@ import { PropTypes } from 'ember-prop-types';
 
 export default Ember.Component.extend({
   classNames: ['card-content', 'card-content-tech-check'],
+  attributeBindings: ['data-ident'],
+  'data-ident': Ember.computed.alias('content.ident'),
+
   propTypes: {
     content: PropTypes.EmberObject.isRequired,
     disabled: PropTypes.bool,


### PR DESCRIPTION
# QA Ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12033

#### What this PR does:

Add data-ident attribute to card config components that allow ident. The attribute value is content.ident if it's present.

#### Code Review Tasks:

Reviewer tasks:

- [ ] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 3 way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
