### PR TITLE
APERTA-11380 enable secure cookies

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,7 @@ Tahi::Application.configure do
 
   # defaults to local storage
   # config.carrierwave_storage = :fog
+  config.session_store :cookie_store, key: '_tahi_session'
 
   # compress logging output
   # config.lograge.enabled = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,6 +42,8 @@ Tahi::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = TahiEnv.force_ssl?
 
+  config.session_store :cookie_store, key: '_tahi_session', secure: true
+
   # Set to :debug to see everything in the log.
   config.log_level = :info
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,8 @@ Tahi::Application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   # config.eager_load = true
 
+  config.session_store :cookie_store, key: '_tahi_session'
+
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_files  = true
   config.static_cache_control = "public, max-age=3600"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-Tahi::Application.config.session_store :cookie_store, key: '_tahi_session'


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-11380

#### What this PR does:

Because force_ssl is false in prod, we need to granularly enable secure cookies. 


#### Notes

note that force_ssl is set by `TahiEnv.force_ssl?` which is set to false in prod according to salt. Should I keep the secure logic as is or negate that env var? @slimeate @egh  pretty much following https://stackoverflow.com/a/31255092


#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] ~~I have found the tests to be sufficient for both positive and negative test cases~~