### PR TITLE
Improve the behavior of the inspect method for attributable models

### DIFF
--- a/app/models/concerns/attributable.rb
+++ b/app/models/concerns/attributable.rb
@@ -11,6 +11,18 @@ module Attributable
 
   included do
     has_many :entity_attributes, dependent: :destroy, inverse_of: :entity, as: :entity
+
+    def inspect
+      super.tap do |base|
+        # Inspect strings end in >. We will chop of the end and insert some
+        # stuff in between.
+        base.chomp!(">")
+        entity_attributes.each do |a|
+          base << ", *#{a.name}: #{a.value}"
+        end
+        base << ">"
+      end
+    end
   end
 
   module ClassMethods

--- a/spec/concerns/attributable_spec.rb
+++ b/spec/concerns/attributable_spec.rb
@@ -12,9 +12,9 @@ describe Attributable do
     FakeTestSystem
   end
 
-  describe 'setting values' do
-    let(:instance) { klass.create }
+  let(:instance) { klass.create }
 
+  describe 'setting values' do
     describe 'boolean values' do
       it 'sets truthy values' do
         instance.bool_attr = true
@@ -37,6 +37,17 @@ describe Attributable do
         instance.string_attr = false
         expect(instance.reload.string_attr).to eq('f') # fails on master
       end
+    end
+  end
+
+  describe '#inspect' do
+    let(:word) { Faker::Lorem.word }
+
+    it 'includes the attributes' do
+      instance.bool_attr = true
+      instance.string_attr = word
+      expect(instance.inspect).to match(/\*string_attr: #{word}/)
+      expect(instance.inspect).to match(/\*bool_attr: true/)
     end
   end
 end


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

Previously, using the `inspect` method on objects that used the `Attributable` concern (which provides an EAV model) would not include the `entity_attributes`. This affected, e.g., the `behavior:list` rake task, making it less useful than it should be. This appends the entity attributes to the inspect string, prefixing them with `*`.

Example:

Before:
```
[1] pry(main)> Behavior.first.inspect
=> "#<CreateTaskBehavior id: 1, event_name: \"paper.email_sent\", type: \"CreateTaskBehavior\", journal_id: 1, created_at: \"2017-12-11 17:46:42\", updated_at: \"2017-12-11 17:46:42\">"
```

After:
```
[1] pry(main)> Behavior.first.inspect
=> "#<CreateTaskBehavior id: 1, event_name: \"paper.email_sent\", type: \"CreateTaskBehavior\", journal_id: 1, created_at: \"2017-12-11 17:46:42\", updated_at: \"2017-12-11 17:46:42\", *duplicates_allowed: false, *card_id: 86>"
```

#### Code Review Tasks:

- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
