### PR TITLE
Order incomplete tech checks by id

### DIFF
--- a/app/models/tech_check_scenario.rb
+++ b/app/models/tech_check_scenario.rb
@@ -22,7 +22,7 @@ class TechCheckScenario < TemplateContext
     incomplete_tech_checks = task.paper.tasks
       .joins(card_version: [card_contents: [:answers]])
       .where(card_contents: { content_type: 'tech-check' })
-      .where(answers: { value: 'f' }).group('id')
+      .where(answers: { value: 'f' }).group('id').order('id')
 
     incomplete_tech_checks.flat_map { |task| task_sendback_reasons(task) }
   end


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

Fixes a flaky spec by forcing the ordering of the sendback tasks that contribute to the `paperwide_sendback_reasons` merge field.

Previously failing rspec invocation:
```
rspec ./engines/plos_bio_tech_check/spec/models/changes_for_author_task_spec.rb[1:3:1:1] ./spec/controllers/decisions_controller_spec.rb[1:1:1:1,1:1:2:1,1:1:2:2:1,1:1:2:3,1:1:2:4,1:1:3:1,1:2:1:1,1:2:3:1] ./spec/models/answer_spec.rb[1:2:1] ./spec/models/tech_check_scenario_spec.rb[1:1:4:1] ./spec/serializers/invitation_serializer_spec.rb[1:2:1] -p 30 -t ~js --seed 26630
```

#### Code Review Tasks:


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases