### PR TITLE
Ignore order in paperwide_sendback_reasons check

### DIFF
--- a/spec/models/tech_check_scenario_spec.rb
+++ b/spec/models/tech_check_scenario_spec.rb
@@ -51,14 +51,14 @@ describe TechCheckScenario do
 
         task.answers.create!(card_content: tech_check_parent, value: 'f', paper: paper)
         task2.answers.create!(card_content: tech_check_parent2, value: 'f', paper: paper)
-
-        task.answers.create!(card_content: reasons, value: 'it is ugly', paper: paper)
-        task.answers.create!(card_content: reasons, value: 'it is wrong', paper: paper)
-        task2.answers.create!(card_content: reasons, value: 'it is the worst', paper: paper)
-        task2.answers.create!(card_content: reasons, value: 'I hate it', paper: paper)
+        complaints = ['it is ugly', 'it is wrong', 'it is the worst', 'I hate it']
+        task.answers.create!(card_content: reasons, value: complaints[0], paper: paper)
+        task.answers.create!(card_content: reasons, value: complaints[1], paper: paper)
+        task2.answers.create!(card_content: reasons, value: complaints[2], paper: paper)
+        task2.answers.create!(card_content: reasons, value: complaints[3], paper: paper)
         template = "{% for reason in paperwide_sendback_reasons %}{{ reason.value }}, {% endfor %}"
-        expect(LetterTemplate.new(body: template).render(context).body)
-          .to eq('it is ugly, it is wrong, it is the worst, I hate it, ')
+        reasons = LetterTemplate.new(body: template).render(context).body.split(',').map(&:strip).reject(&:blank?)
+        expect(reasons).to match_array(complaints)
       end
 
       it "only renders reasons from unpassed tech checks" do


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

Changes a spec to ignore order.

This will fix our frequent flaky spec issue on master.

Thanks to @jhaungs for the original code.

---

#### Code Review Tasks:


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
