### PR TITLE
Fix Data Transformation Spec Test Pollution

### DIFF
--- a/spec/lib/data_transformation/base_spec.rb
+++ b/spec/lib/data_transformation/base_spec.rb
@@ -10,6 +10,10 @@ describe DataTransformation::Base do
     end
   end
 
+  before(:each) do
+    data_transformation.counters = {}
+  end
+
   describe "#register_counter" do
     let(:counter_name) { :my_counter }
 

--- a/spec/lib/data_transformation/fix_xml_text_node_values_spec.rb
+++ b/spec/lib/data_transformation/fix_xml_text_node_values_spec.rb
@@ -4,7 +4,12 @@ require 'data_transformation/fix_xml_text_node_values'
 
 describe 'DataTransformation::FixXmlTextNodeValues' do
   describe '#remove_cdata_nodes' do
-    subject { DataTransformation::FixXmlTextNodeValues.new }
+    subject(:data_transformation) { DataTransformation::FixXmlTextNodeValues.new }
+
+    before(:each) do
+      data_transformation.counters = {}
+    end
+
     let(:text) do
       <<-TEXT
           <![CDATA[Thank you very much for submitting your manuscript for consideration at PLOS Biology.
@@ -28,7 +33,7 @@ describe 'DataTransformation::FixXmlTextNodeValues' do
       # We want to put the text in an invalid state to make it mirror prod
       # rubocop:disable Rails/SkipsModelValidations:
       card_content.update_attribute('text', text)
-      subject.remove_cdata_nodes
+      data_transformation.remove_cdata_nodes
       expect(card_content.reload.text).to eq expected_text
     end
   end


### PR DESCRIPTION
# Dev ticket

#### What this PR does:

Fixes a possible condition where the DataTransformations counters doesn't get reset.  If the base spec goes before fix_xml_data_values_spec.rb, it won't reset its counter.

The failure can be reproduced by running this rspec line (thanks again to @egh for providing this and notifying me of the issue):

```bash
rspec ./spec/lib/data_transformation/base_spec.rb[1:2:1,1:2:2,1:3:1:1,1:4:1:1] ./spec/lib/data_transformation/fix_xml_text_node_values_spec.rb[1:1:1] -p 30 -t ~js --seed 33242
```

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
