### PR TITLE
APERTA-6281 followup: Require non-whitespace in notes for edited reviews

### DIFF
--- a/client/app/pods/components/reviewer-report-edit-notes/component.js
+++ b/client/app/pods/components/reviewer-report-edit-notes/component.js
@@ -22,7 +22,10 @@ export default Ember.Component.extend({
 
     saveEdit() {
       let activeEdit = this.get('activeEdit');
-      if (Ember.isEmpty(activeEdit.get('notes'))) {
+      let notes = activeEdit.get('notes');
+      // If Ember thinks the note is empty, or the note contains only whitespace,
+      // consider it invalid, and don't save the edit
+      if (Ember.isEmpty(notes) || !/\S/.test(notes)) {
         this.set('notesEmpty', true);
       } else {
         let report = this.get('currentReviewerReport');


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-6281

#### What this PR does:

This adds an additional test after "isEmpty" to reviewer report editor's notes, to make sure at least one non-whitespace character exists in the string.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] ~~I have found the tests to be sufficient for both positive and negative test cases~~
