### PR TITLE
Pin heroku postgres at 9.6

### DIFF
--- a/app.json
+++ b/app.json
@@ -234,7 +234,12 @@
     "sendgrid:starter",
     "papertrail:choklad",
     "pusher:sandbox",
-    "heroku-postgresql:hobby-dev",
+    {
+      "plan": "heroku-postgresql:hobby-dev",
+      "options": {
+        "version": "9.6"
+      }
+    },
     "rediscloud:30"
   ],
   "formation": {


### PR DESCRIPTION
## WAT
Keep postgres at 9.x on heroku to fix our review apps

## WHY
Heroku defaulted to Postgres 10 on December 14, 2017

As of that time when we try to run the `db:data:load` task upon deploy we
encounter an error:

```
PG::UndefinedColumn: ERROR:  column "increment_by" does not exist
LINE 1: ...ties_id_seq"', (SELECT COALESCE(MAX("id")+(SELECT increment_...
```

googling revealed  https://ppworks.github.io/posts/244/ which seems to
corroborate a bit, and that post references
https://github.com/rails/rails/pull/28864

