### PR TITLE
APERTA-12236 fix clipping of Radio buttons

### DIFF
--- a/app/assets/stylesheets/overlays/_offer-preprint-overlay.scss
+++ b/app/assets/stylesheets/overlays/_offer-preprint-overlay.scss
@@ -14,7 +14,7 @@
   }
 
   .split-pane-element {
-    padding: 15px 0 25px 0;
+    padding: 20px;
   }
 
   button {


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12236 Update preprint card in CI and RC

#### What this PR does:

This is a PR that includes no development work. It is a simple css change to _offer-preprint-overlay.scss to address the clipping of the Radio buttons in Preprint Posting Card.

To validate this fix enable the preprint feature flag. Add a Preprint Posting card to a workflow of your choosing - for example, NO AUTHORS TASK. Make certain the preprint enable flag is selected to true on that workflow. Create a manuscript submission selecting a paper type that maps to the workflow with the card.

The Preprint Posting to opt out should appear and the Radio buttons should not be clipped.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases