### PR TITLE
Spike - Use application adapter in restless calls

### DIFF
--- a/client/app/services/restless.js
+++ b/client/app/services/restless.js
@@ -6,6 +6,8 @@ import camelizeKeys from 'tahi/lib/camelize-keys';
 const { getOwner } = Ember;
 
 export default Ember.Service.extend({
+  store: Ember.inject.service(),
+
   pathFor(model) {
     let adapter = model.get('store').adapterFor(model.constructor.modelName);
     let resourceType = model.constructor.modelName;
@@ -13,32 +15,8 @@ export default Ember.Service.extend({
   },
 
   ajaxPromise(method, path, data) {
-    let pusher = getOwner(this).lookup('service:pusher');
-    let socketId = null;
-    if (pusher) {
-      socketId = getOwner(this).lookup('service:pusher').get('socketId');
-    }
-
-    let contentType = 'application/x-www-form-urlencoded; charset=UTF-8';
-    if (method !== 'GET') {
-      contentType = 'application/json';
-      data = JSON.stringify(data);
-    }
-
-    return new Ember.RSVP.Promise(function(resolve, reject) {
-      return Ember.$.ajax({
-        url: path,
-        type: method,
-        data: data,
-        contentType: contentType,
-        success: resolve,
-        error: reject,
-        headers: {
-          'Pusher-Socket-ID': socketId
-        },
-        dataType: 'json'
-      });
-    });
+    let adapter = Ember.get(this, 'store').adapterFor('application');
+    return adapter.ajax(path, method, { data });
   },
 
   'delete': function(path, data) {


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-

#### What this PR does:

Changes our restless service to use ember data's application adapter. Why?
- The application adapter already takes care of the headers we've had to specify manually in the restless service.
- When errors come back from Rails restless currently doesn't format them into the JSON api format, which is troublesome further down the line.

#### Special instructions for Review or PO:


#### Notes

Are there any surprises? Anything that was particularly difficult, or clever, or
made you nervous, and should get particular attention during review? Call it
out.


#### Major UI changes

Were there major UI changes? Add a screenshot here -- and please let the QA team know that changes are imminent. They would love a little extra time to prepare the QA test suite.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes at all, I've let the entire QA team know in the JIRA ticket and in the Aperta QA hipchat room.
- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have set an appropriate resolution in the JIRA ticket
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] If I modified `app/services/journal_factory.rb`, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data-migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results with `rake db:test_migrations` (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

