### PR TITLE
APERTA-12241 Fix coauthor notifications when coauthor doesn't have last name

### DIFF
--- a/app/views/email/_author_salutation.html.erb
+++ b/app/views/email/_author_salutation.html.erb
@@ -2,6 +2,6 @@
   <% if author.try(:last_name) %>
    Dr <%= author.last_name %>,
   <% else %>
-   <%= author.name %>,
+   <%= author.full_name.strip %>,
   <% end %>
 </p>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -233,6 +233,12 @@ describe UserMailer, redis: true do
         expect(email_2.body).to include_as_escaped_html(author_full_name)
       end
     end
+
+    it "will use the coauthor's full name if they have not specified a last name, omitting the 'Dr.' title" do
+      author_3.update!(last_name: nil, first_name: 'Cher')
+      email = UserMailer.notify_coauthor_of_paper_submission(paper.id, author_3.id, "Author")
+      expect(email.body).to include_as_escaped_html("Cher,")
+    end
   end
 
   describe '#notify_creator_of_initial_submission' do


### PR DESCRIPTION

# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12241

#### What this PR does:

When a coauthor is notified of a paper's submission, if the coauthor has not entered a last name we choose to just show their full name (really their first name). We were invoking the coauthors full name incorrectly.  

#### Special instructions for Review or PO:

If you submit a paper with first-name-only coauthor you'll see this in action via the sent emails.


#### Notes

Use the author's `full_name` instead of `name`, which exists on the client side
but not on the server side.


#### Major UI changes

None
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

