### PR TITLE
APERTA-7683 added update(active: true) when invited_for_full_submission

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -186,10 +186,7 @@ class Paper < ActiveRecord::Base
     event(:invite_full_submission) do
       transitions from: :initially_submitted,
                   to: :invited_for_full_submission,
-                  after: [:allow_edits!, :new_draft!]
-      before do
-        update(active: true)
-      end
+                  after: [:allow_edits!, :new_draft!, :set_active!]
     end
 
     event(:minor_check) do
@@ -210,19 +207,19 @@ class Paper < ActiveRecord::Base
     event(:minor_revision) do
       transitions from: :submitted,
                   to: :in_revision,
-                  after: [:allow_edits!, :new_draft!]
+                  after: [:allow_edits!, :new_draft!, :set_active!]
     end
 
     event(:major_revision) do
       transitions from: :submitted,
                   to: :in_revision,
-                  after: [:allow_edits!, :new_draft!]
+                  after: [:allow_edits!, :new_draft!, :set_active!]
     end
 
     event(:accept) do
       transitions from: :submitted,
                   to: :accepted,
-                  after: [:set_accepted_at!]
+                  after: [:set_accepted_at!, :set_active!]
     end
 
     event(:reject) do
@@ -709,6 +706,10 @@ class Paper < ActiveRecord::Base
 
   def new_minor_version!
     draft.be_minor_version!
+  end
+
+  def set_active!
+    update!(active: true)
   end
 
   def set_editable!


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-7683 Rescinded reject of an initial decision is placed in authors inactive pile

#### What this PR does:

This PR fixes a bug where a paper remained in an inactive state even after an initial decision to reject the paper was rescinded and an invite for full submission was registered instead.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases