### PR TITLE
Empowerment: Remove vestigial task.descendants spec

### DIFF
--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -185,31 +185,6 @@ describe Task do
     end
   end
 
-  describe 'Task.descendants' do
-    it 'includes a new subclass of Task' do
-      new_task = Class.new(Task)
-      expect(Task.descendants).to include(new_task)
-    end
-
-    it 'returns all the tasks' do
-      tasks_from_source = Dir[Rails.root.join('**/*.rb')]
-                          .select { |path| path.match(%r{models/.*task.rb}) }
-                          .reject { |path| path.match(/concerns/) }
-                          .reject { |path| path.match(%r{models/task.rb}) }
-                          .map { |path| path.match(%r{models/(.*).rb})[1] }
-
-      tasks = Task.descendants.map { |c| c.to_s.underscore }
-      expect(tasks).to include(*tasks_from_source)
-    end
-
-    it 'works across reload' do
-      expect do
-        ActionDispatch::Reloader.cleanup!
-        ActionDispatch::Reloader.prepare!
-      end.not_to change { Task.descendants.count }
-    end
-  end
-
   describe 'Task.safe_constantize' do
     it 'fails with Task' do
       expect { Task.safe_constantize('Task') }


### PR DESCRIPTION
I took the failure from https://circleci.com/gh/Tahi-project/tahi/28742#tests/containers/8, bisected it, and got
```
rspec './spec/features/sign_in_cas_spec.rb[1:1,1:2]' './spec/models/task_spec.rb[1:12:3]' -p 30 -t ~js --seed 56927
```
That ran the task 'it works across reload' spec first, then the cas specs.

Here's works across reload
```ruby
it 'works across reload' do
  expect do
    ActionDispatch::Reloader.cleanup!
    ActionDispatch::Reloader.prepare!
  end.not_to change { Task.descendants.count }
```

This used to be a spec for task.all_task_types, which we've subsequently
removed from the codebase.  The test as it stands is testing a standard
`ActiveSupport::DescendantsTracker` method, which we don't need to do.
It looks like the `ActionDispatch::Reloader` calls were the thing that
caused some failures related to missing constants after removing the
rails engines 🤞 