### PR TITLE
Qa fix paper tracker tests

### DIFF
--- a/test/frontend/Pages/paper_tracker.py
+++ b/test/frontend/Pages/paper_tracker.py
@@ -304,23 +304,23 @@ class PaperTrackerPage(AuthenticatedPage):
         :param user_type: the user who is running the test - used to determine journal access
         :return: None
         """
-        title_th = self._get(self._paper_tracker_table_title_th)
+        self._get(self._paper_tracker_table_title_th)
         # self.validate_table_heading_style(title_th)
-        manid_th = self._get(self._paper_tracker_table_paper_id_th)
+        self._get(self._paper_tracker_table_paper_id_th)
         # self.validate_table_heading_style(manid_th)
-        verdate_th = self._get(self._paper_tracker_table_version_date_th)
+        self._get(self._paper_tracker_table_version_date_th)
         # self.validate_table_heading_style(verdate_th)
-        subdate_th = self._get(self._paper_tracker_table_submit_date_th)
+        self._get(self._paper_tracker_table_submit_date_th)
         # self.validate_table_heading_style(subdate_th)
-        paptype_th = self._get(self._paper_tracker_table_paper_type_th)
+        self._get(self._paper_tracker_table_paper_type_th)
         # self.validate_table_heading_style(paptype_th)
-        status_th = self._get(self._paper_tracker_table_status_th)
+        self._get(self._paper_tracker_table_status_th)
         # self.validate_table_heading_style(status_th)
-        members_th = self._get(self._paper_tracker_table_members_th)
+        self._get(self._paper_tracker_table_members_th)
         # self.validate_table_heading_style(members_th)
-        handedit_th = self._get(self._paper_tracker_table_he_th)
+        self._get(self._paper_tracker_table_he_th)
         # self.validate_table_heading_style(handedit_th)
-        covedit_th = self._get(self._paper_tracker_table_ce_th)
+        self._get(self._paper_tracker_table_ce_th)
         # self.validate_table_heading_style(covedit_th)
 
         # Validate the contents of the table: papers, links, sorting, roles

--- a/test/frontend/test_paper_tracker.py
+++ b/test/frontend/test_paper_tracker.py
@@ -16,7 +16,7 @@ import random
 from Base.Decorators import MultiBrowserFixture
 from frontend.common_test import CommonTest
 from .Pages.paper_tracker import PaperTrackerPage
-from Base.Resources import editorial_users, staff_admin_login, super_admin_login
+from Base.Resources import editorial_users
 
 __author__ = 'jgray@plos.org'
 
@@ -69,8 +69,8 @@ class ApertaPaperTrackerTest(CommonTest):
     def test_validate_paper_tracker_search(self):
         """
         test_paper_tracker: Validate Paper tracker search and saved search functions
-        Validate the Aperta Query Language Usage, Search function elements, including saved search, and
-        the Saved Search functions
+        Validate the Aperta Query Language Usage, Search function elements, including saved search,
+         and the Saved Search functions
         """
         logging.info('Test Paper Tracker::search')
         current_path = os.getcwd()


### PR DESCRIPTION
# QA Ticket

JIRA issue: no JIRA ticket

#### What this PR does:
1. Updates the test ApertaPaperTrackerTest.**test_validate_paper_tracker_table_content** to address the failure on stage:
https://teamcity.plos.org/teamcity/viewLog.html?buildId=147100&tab=buildResultsDiv&buildTypeId=Aperta_NoNoseIntegrationTestOnSomaStage#testNameId7315932669959811141
As it is not so easy to see changes due to updating files to follow PEP-8 guidelines, I'll list main changes here:

- Fixed the mentioned above failure by changing split():
page_hes_by_role = handedits.text.split('\n') ->
page_hes_by_role = handedits.text.split(', ')
and 
page_ces_by_role = covredits.text.split('\n') ->
page_ces_by_role = covredits.text.split(', ')
in paper_tracker.py

2. **test_validate_paper_tracker_search**
This test fails in my local environment every time when the list of saved searches is too long and needs scrolling to make the last search to be accessible, so after click on 'search' button the delete icon web element gets stale.
Added  _get_saved_search_links() function to paper_tracker_py to get it after page refresh and make the test more stable.
 

#### Notes



---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [x] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [x] Follows first PLOS style guidelines for Python, then PEP-8
- [x] Code is implemented in a Python 3 way
- [x] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
