### PR TITLE
APERTA-12364 Upgrade httpclient

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,7 +365,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
-    httpclient (2.6.0.1)
+    httpclient (2.8.3)
     humanize (1.1.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12364

Pusher uses httpclient and right now it's throwing a deprecation warning:
```
/opt/circleci/.rvm/gems/ruby-2.3.6@tahi/gems/httpclient-2.6.0.1/lib/httpclient/session.rb:616:in `query': Object#timeout is deprecated, use Timeout.timeout instead.
```





