### PR TITLE
APERTA-10901 Can't move completed card by drag and drop in workflow

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -31,16 +31,14 @@ class TasksController < ApplicationController
 
   def update
     requires_user_can :edit, task
-
     # If user is going to be removed get it to log Activity event
     last_assigned_user = task.assigned_user
 
     if task.completed?
-      # If the task is already completed, all the user can do is uncomplete it
-      # or assign an user.
-      attrs = params.require(:task).permit(:completed, :assigned_user_id)
-      task.completed = attrs[:completed]
-      task.assigned_user_id = attrs[:assigned_user_id]
+      # If the task is already completed, all the user can do is uncomplete it,
+      # assign an user or move it to a different phase in the workflow.
+      attrs = task_params(task.class).slice(:completed, :assigned_user_id, :phase_id, :position)
+      task.assign_attributes(attrs)
     else
       # At this point, the user could be doing one of two things.
       # 1. They are toggling the completed flag.

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -291,6 +291,16 @@ describe TasksController, redis: true do
           end.to change { task.reload.assigned_user_id }.from(11).to(nil)
         end
 
+        it "allows changing phase and position in the workflow" do
+          task.update!(phase_id: 11, position: 11)
+          task_params[:phase_id] = 22
+          task_params[:position] = 22
+          do_request
+          task.reload
+          expect(task.phase_id).to eq(22)
+          expect(task.position).to eq(22)
+        end
+
         it "does not incomplete the task when the completed param is not a part of the request" do
           expect do
             task_params = { title: 'vernors' }


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-10901

#### What this PR does:

It updates TasksController#update to allow user update phase_id and position when task is completed.

#### Special instructions for Review or PO:

None

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
