### PR TITLE
Update test_initial_submission_infobox due to aperta-11669

### DIFF
--- a/test/frontend/test_manuscript_viewer.py
+++ b/test/frontend/test_manuscript_viewer.py
@@ -183,7 +183,7 @@ class ManuscriptViewerTest(CommonTest):
         # AC2: Test closing the info box
         # APERTA-11669: No flash messages on creation of manuscript via pdf
         # closing flash message for word files closes also infobox, we have to close infobox for pdf
-        # we will have to remove next 2 lines once APERTA-11669 gets resolved
+        # TODO: remove next 2 lines once APERTA-11669 gets resolved
         if format == 'pdf':
             manuscript_page.close_infobox()
         try:


### PR DESCRIPTION
# QA Ticket

JIRA issue: no JIRA ticket, but changes related to APERTA-11669

#### What this PR does:
**initial_submission_infobox**: AC2 failed for pdf due to APERTA-11669:
closing flash message for word files closes also infobox, but there is no flash message on creation of manuscript via pdf, so we have to close infobox for pdf.

Also added titles to created manuscripts and unmuted test_paper_download.

#### Notes


---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [x] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [x] Follows first PLOS style guidelines for Python, then PEP-8
- [x] Code is implemented in a Python 3 way
- [x] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
