### PR TITLE
Resolved failure in ad hoc card execution https://teamcity.plos.org/t…

### DIFF
--- a/test/frontend/Cards/ad_hoc_author_card.py
+++ b/test/frontend/Cards/ad_hoc_author_card.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Page Object definition for the Ad-hoc for authors card
@@ -10,11 +10,11 @@ __author__ = 'sbassi@plos.org'
 
 
 class AHAuthorCard(AHCard):
-  """
-  Page Object Model for Ad Hoc for Authors Card
-  """
-  def __init__(self, driver):
-    super(AHAuthorCard, self).__init__(driver)
+    """
+    Page Object Model for Ad Hoc for Authors Card
+    """
+    def __init__(self, driver):
+        super(AHAuthorCard, self).__init__(driver)
 
-    # Locators - Instance members
-    # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')
+        # Locators - Instance members
+        # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')

--- a/test/frontend/Cards/ad_hoc_card.py
+++ b/test/frontend/Cards/ad_hoc_card.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Page Object model for the generic Ad Hoc card
@@ -13,144 +13,182 @@ __author__ = 'sbassi@plos.org'
 
 
 class AHCard(BaseCard):
-  """
-  Abstract class for Page Object Model of all types of Ad-Hoc Cards
-  """
-  def __init__(self, driver):
-    super(AHCard, self).__init__(driver)
+    """
+    Abstract class for Page Object Model of all types of Ad-Hoc Cards
+    """
+    def __init__(self, driver):
+        super(AHCard, self).__init__(driver)
 
-    # Locators - Instance members
-    self._card_title = (By.CSS_SELECTOR, 'h1.inline-edit')
-    self._edit_title = (By.CSS_SELECTOR, 'h1 span.fa-pencil')
-    self._subtitle = (By.CLASS_NAME, 'ad-hoc-corresponding-role')
-    self._add_btn = (By.CSS_SELECTOR, 'div.adhoc-content-toolbar div.button--green')
-    self._plus_icon = (By.CLASS_NAME, 'fa-plus')
-    self._tb_check = (By.CLASS_NAME, 'adhoc-toolbar-item--list')
-    self._tb_text = (By.CLASS_NAME, 'adhoc-toolbar-item--text')
-    self._tb_paragraph = (By.CLASS_NAME, 'adhoc-toolbar-item--label')
-    self._tb_email = (By.CLASS_NAME, 'adhoc-toolbar-item--email')
-    self._tb_image = (By.CLASS_NAME, 'adhoc-toolbar-item--image')
-    self._text_area = (By.CSS_SELECTOR, 'div.content-editable-muted')
-    self._text_delete_icon = (By.CSS_SELECTOR, 'span.fa-trash')
-    # checkboxes
-    self._chk_item_remove = (By.CLASS_NAME, 'item-remove')
-    self._chk_cancel_lnk = (By.CSS_SELECTOR, 'div.edit-actions div.button-link')
-    self._chk_save_btn = (By.CSS_SELECTOR, 'div.edit-actions div.button-secondary')
-    self._chk_add_btn = (By.CSS_SELECTOR, 'div.inline-edit-body-part div.add-item')
-    # delete confirmation option
-    self._delete_warning = (By.CSS_SELECTOR, 'div.bodypart-destroy-overlay h4')
-    self._cancel_warning = (By.CSS_SELECTOR, 'div.bodypart-destroy-overlay button.button--white')
-    self._delete_btn = (By.CSS_SELECTOR, 'div.bodypart-destroy-overlay button.delete-button')
-    # paragraph
-    self._paragraph_form = (By.CSS_SELECTOR, 'div.inline-edit-form div.editable')
-    self._cancel_lnk = (By.CLASS_NAME, 'cancel-block')
-    self._save_btn = (By.CSS_SELECTOR, 'div.save-block')
-    # email
-    self._email_subject = (By.CSS_SELECTOR, 'div.email input.ember-text-field')
-    # ad file
-    self._text_title_edit_icon = (By.CSS_SELECTOR, 'div.inline-edit-body-part span.fa-pencil')
-    self._add_file_title = (By.CSS_SELECTOR, 'div.bodypart-display div.item-text')
-    self._upload_btn = (By.CSS_SELECTOR, 'div.attachment-manager div.button-secondary')
+        # Locators - Instance members
+        self._card_title = (By.CSS_SELECTOR, 'h1.inline-edit')
+        self._edit_title = (By.CSS_SELECTOR, 'h1 span.fa-pencil')
+        self._subtitle = (By.CLASS_NAME, 'ad-hoc-corresponding-role')
+        self._add_btn = (By.CSS_SELECTOR, 'div.adhoc-content-toolbar div.button--green')
+        self._plus_icon = (By.CLASS_NAME, 'fa-plus')
+        self._tb_check = (By.CLASS_NAME, 'adhoc-toolbar-item--list')
+        self._tb_text = (By.CLASS_NAME, 'adhoc-toolbar-item--text')
+        self._tb_paragraph = (By.CLASS_NAME, 'adhoc-toolbar-item--label')
+        self._tb_email = (By.CLASS_NAME, 'adhoc-toolbar-item--email')
+        self._tb_image = (By.CLASS_NAME, 'adhoc-toolbar-item--image')
+        self._text_area = (By.CSS_SELECTOR, 'div.content-editable-muted')
+        # checkboxes
+        self._chk_item_remove = (By.CLASS_NAME, 'item-remove')
+        self._chk_cancel_lnk = (By.CSS_SELECTOR, 'div.edit-actions div.button-link')
+        self._chk_save_btn = (By.CSS_SELECTOR, 'div.edit-actions div.button-secondary')
+        self._chk_add_btn = (By.CSS_SELECTOR, 'div.inline-edit-body-part div.add-item')
+        # paragraph
+        self._paragraph_form = (By.CSS_SELECTOR, 'div.inline-edit-form div.editable')
+        self._cancel_lnk = (By.CLASS_NAME, 'cancel-block')
+        self._save_btn = (By.CSS_SELECTOR, 'div.save-block')
+        # email
+        self._email_subject = (By.CSS_SELECTOR, 'div.email input.ember-text-field')
+        self._email_body = (By.CSS_SELECTOR, 'div.email-body')
+        self._email_cancel = (By.CSS_SELECTOR, 'div.cancel-block')
+        self._email_send_btn = (By.CSS_SELECTOR, 'div.email-send-participants')
+        # attach file
+        self._add_file_title = (By.CSS_SELECTOR, 'div.bodypart-display div.item-text')
+        self._upload_btn = (By.CSS_SELECTOR, 'div.attachment-manager div.button-secondary')
+        # global widget elements
+        self._widget_edit_icon = (By.CSS_SELECTOR, 'div.inline-edit-body-part span.fa-pencil')
+        self._widget_delete_icon = (By.CSS_SELECTOR, 'span.fa-trash')
+        # delete confirmation option
+        self._delete_warning = (By.CSS_SELECTOR, 'div.bodypart-destroy-overlay h4')
+        self._cancel_warning = (By.CSS_SELECTOR,
+                                'div.bodypart-destroy-overlay button.button--white')
+        self._delete_btn = (By.CSS_SELECTOR, 'div.bodypart-destroy-overlay button.delete-button')
 
-  # POM Actions
-  def validate_card_elements_styles(self, short_doi, role):
-    """
-    Style check for the card
-    :param role: String with the role the card is made for
-    :param short_doi: Used to pass through to validate_common_elements_styles
-    :return: None
-    """
-    self.validate_common_elements_styles(short_doi)
-    title = self._get(self._card_title)
-    self.validate_overlay_card_title_style(title)
-    role_title = 'Ad-hoc for {0}'.format(role)
-    assert title.text == role_title, 'Current title {0} is not {1}'.format(title.text,
-                                                                           role_title)
-    self._get(self._edit_title)
-    subtitle = self._get(self._subtitle)
-    if role == 'Staff Only':
-      role = 'Staff-only'
-    corresponding_role = 'Corresponding Role {0}'.format(role)
-    assert subtitle.text in corresponding_role, '{0} not in {1}'.format(subtitle.text,
-                                                                        corresponding_role)
-    self.validate_application_body_text(subtitle)
-    add_btn = self._get(self._add_btn)
-    self.validate_primary_big_green_button_style(add_btn)
-    self._get(self._plus_icon)
+    # POM Actions
+    def validate_card_elements_styles(self, short_doi, role):
+        """
+        Style check for the card
+        :param role: String with the role the card is made for
+        :param short_doi: Used to pass through to validate_common_elements_styles
+        :return: None
+        """
+        self.validate_common_elements_styles(short_doi)
+        title = self._get(self._card_title)
+        self.validate_overlay_card_title_style(title)
+        role_title = 'Ad-hoc for {0}'.format(role)
+        assert title.text == role_title, 'Current title {0} is not {1}'.format(title.text,
+                                                                               role_title)
+        self._get(self._edit_title)
+        subtitle = self._get(self._subtitle)
+        if role == 'Staff Only':
+            role = 'Staff-only'
+        corresponding_role = 'Corresponding Role {0}'.format(role)
+        assert subtitle.text in corresponding_role, '{0} not in {1}'.format(subtitle.text,
+                                                                            corresponding_role)
+        self.validate_application_body_text(subtitle)
+        add_btn = self._get(self._add_btn)
+        self.validate_primary_big_green_button_style(add_btn)
+        self._get(self._plus_icon)
 
-  def validate_widgets_styles(self, widget):
-    """
-    Style check for elements inside a given widget
-    :return: None
-    """
-    if widget == 'checkbox':
-      self._get(self._tb_check).click()
-      self._get(self._chk_item_remove)
-      cancel_lnk = self._get(self._chk_cancel_lnk)
-      assert cancel_lnk.text == 'cancel', cancel_lnk.text
-      self.validate_link_big_green_button_style(cancel_lnk)
-      save_btn = self._get(self._chk_save_btn)
-      assert save_btn.text == 'SAVE', save_btn.text
-      # Disabled due to APERTA-9063
-      # self.validate_secondary_big_disabled_button_style(save_btn)
-      self._get(self._chk_add_btn)
-      # Can't validate PLUS sign style due to APERTA-9082
-    elif widget == 'input_text':
-      self._get(self._tb_text).click()
-      # Wait for the widget to display
-      time.sleep(1)
-      placeholder_text = self._get(self._text_area).text
-      assert placeholder_text == u'Click to type in your response.', placeholder_text
-      self._wait_for_element(self._get(self._text_delete_icon))
-      delete_icon = self._get(self._text_delete_icon)
-      # The following code could be used when APERTA-9139 is fixed
-      # self._actions.move_to_element(delete_icon).perform()
-      delete_icon.click()
-      # Wait to the delete modal to display
-      time.sleep(1)
-      # Disabled due to APERTA-9139
-      # self.validate_delete_icon_grey(delete_icon)
-      # self._actions.move_to_element(delete_icon).perform()
-      # delete_icon = self._get(self._text_delete_icon)
-      # Disabled due to APERTA-9139
-      # self.validate_delete_icon_green(delete_icon)
-      delete_warning = self._get(self._delete_warning)
-      warning_msg = 'This will permanently delete your item. Are you sure?'
-      self.validate_warning_message_style(delete_warning, warning_msg)
-      cancel_lnk = self._get(self._cancel_warning)
-      self.validate_cancel_confirmation_style(cancel_lnk)
-      delete_btn = self._get(self._delete_btn)
-      self.validate_delete_confirmation_style(delete_btn)
-    elif widget == 'paragraph':
-      self._get(self._tb_paragraph).click()
-      cancel_lnk = self._get(self._cancel_lnk)
-      assert cancel_lnk.text == 'cancel', cancel_lnk.text
-      self.validate_cancel_link_style(cancel_lnk)
-      save_btn = self._get(self._save_btn)
-      assert save_btn.text == 'SAVE', save_btn.text
-      # Disabled due to APERTA-9063
-      # self.validate_secondary_big_green_button_style(save_btn)
-      # Disabled due to APERTA-9167
-      # self._get(self._paragraph_form)
-    elif widget == 'email':
-      self._get(self._tb_email).click()
-      subject = self._get(self._email_subject)
-      assert subject.get_attribute('placeholder') == 'Enter a subject', \
-          subject.get_attribute('placeholder')
-      cancel_lnk = self._get(self._chk_cancel_lnk)
-      assert cancel_lnk.text == 'cancel', cancel_lnk.text
-      self.validate_link_big_green_button_style(cancel_lnk)
-      save_btn = self._get(self._save_btn)
-      assert save_btn.text == 'SAVE', save_btn.text
-      # Disabled due to APERTA-9063
-      # self.validate_secondary_big_green_button_style(save_btn)
-    elif widget == 'file_upload':
-      self._get(self._tb_image).click()
-      self._get(self._text_title_edit_icon)
-      self._get(self._text_delete_icon)
-      self._add_file_title = (By.CSS_SELECTOR, 'div.bodypart-display div.item-text')
-      title = self._get(self._add_file_title)
-      assert title.text == u'Please select a file.', title.text
-      upload_btn = self._get(self._upload_btn)
-      assert upload_btn.text == u'UPLOAD FILE', upload_btn.text
-      self.validate_secondary_big_green_button_style(upload_btn)
+    def validate_widgets_styles(self, widget):
+        """
+        Style check for elements inside a given widget
+        :return: None
+        """
+        if widget == 'checkbox':
+            self._get(self._tb_check).click()
+            self._get(self._chk_item_remove)
+            cancel_lnk = self._get(self._chk_cancel_lnk)
+            assert cancel_lnk.text == 'cancel', cancel_lnk.text
+            self.validate_link_big_green_button_style(cancel_lnk)
+            save_btn = self._get(self._chk_save_btn)
+            assert save_btn.text == 'SAVE', save_btn.text
+            # Disabled due to APERTA-9063
+            # self.validate_secondary_big_disabled_button_style(save_btn)
+            self._get(self._chk_add_btn)
+            # Can't validate PLUS sign style due to APERTA-9082
+        elif widget == 'input_text':
+            add_attach_btn = self._get(self._tb_text)
+            # Due to the way this widget is implemented (too clever) all the buttons are
+            #     visible to Selenium in the DOM (The buttons go from having a negative dimension
+            #     that offsets their box model, to having positive dimensions. Giving a half
+            #     second stutter here allows the test to succeed with the newer faster Firefox
+            #     Quantum.
+            time.sleep(.5)
+            add_attach_btn.click()
+            self._wait_for_element(self._get(self._widget_delete_icon))
+            placeholder_text = self._get(self._text_area).text
+            assert placeholder_text == u'Click to type in your response.', placeholder_text
+            delete_icon = self._get(self._widget_delete_icon)
+            # The following code could be used when APERTA-9139 is fixed
+            # self._actions.move_to_element(delete_icon).perform()
+            delete_icon.click()
+            # Wait to the delete modal to display
+            time.sleep(1)
+            # Disabled due to APERTA-9139
+            # self.validate_delete_icon_grey(delete_icon)
+            # self._actions.move_to_element(delete_icon).perform()
+            # delete_icon = self._get(self._widget_delete_icon)
+            # Disabled due to APERTA-9139
+            # self.validate_delete_icon_green(delete_icon)
+            delete_warning = self._get(self._delete_warning)
+            warning_msg = 'This will permanently delete your item. Are you sure?'
+            self.validate_warning_message_style(delete_warning, warning_msg)
+            cancel_lnk = self._get(self._cancel_warning)
+            self.validate_cancel_confirmation_style(cancel_lnk)
+            delete_btn = self._get(self._delete_btn)
+            self.validate_delete_confirmation_style(delete_btn)
+        elif widget == 'paragraph':
+            self._get(self._tb_paragraph).click()
+            cancel_lnk = self._get(self._cancel_lnk)
+            assert cancel_lnk.text == 'cancel', cancel_lnk.text
+            self.validate_cancel_link_style(cancel_lnk)
+            save_btn = self._get(self._save_btn)
+            assert save_btn.text == 'SAVE', save_btn.text
+            # Disabled due to APERTA-9063
+            # self.validate_secondary_big_green_button_style(save_btn)
+            # Disabled due to APERTA-9167
+            # self._get(self._paragraph_form)
+        elif widget == 'email':
+            add_attach_btn = self._get(self._tb_email)
+            # Due to the way this widget is implemented (too clever) all the buttons are
+            #     visible to Selenium in the DOM (The buttons go from having a negative dimension
+            #     that offsets their box model, to having positive dimensions. Giving a half
+            #     second stutter here allows the test to succeed with the newer faster Firefox
+            #     Quantum.
+            time.sleep(.5)
+            add_attach_btn.click()
+            self._wait_for_element(self._get(self._email_cancel))
+            self._get(self._tb_email).click()
+            subject = self._get(self._email_subject)
+            assert subject.get_attribute('placeholder') == 'Enter a subject', \
+                subject.get_attribute('placeholder')
+            email_body = self._get(self._email_body)
+            cancel_lnk = self._get(self._email_cancel)
+            assert cancel_lnk.text == 'cancel', cancel_lnk.text
+            self.validate_link_big_green_button_style(cancel_lnk)
+            save_btn = self._get(self._save_btn)
+            assert save_btn.text == 'SAVE', save_btn.text
+            # Disabled due to APERTA-9063
+            # self.validate_secondary_big_green_button_style(save_btn)
+            subject.send_keys('An email subject')
+            email_body.send_keys('Tra la la\nTra la la la\nIsn\'t this fun?\n')
+            save_btn.click()
+            # Saving the email dorks the DOM state, so...
+            self.refresh()
+            self._wait_for_element(self._get(self._email_send_btn))
+            send_btn = self._get(self._email_send_btn)
+            assert send_btn.text == 'SEND THIS EMAIL', send_btn.text
+            self._get(self._widget_edit_icon)
+            self._get(self._widget_delete_icon)
+        elif widget == 'file_upload':
+            add_attach_btn = self._get(self._tb_image)
+            # Due to the way this widget is implemented (too clever) all the buttons are
+            #     visible to Selenium in the DOM (The buttons go from having a negative dimension
+            #     that offsets their box model, to having positive dimensions. Giving a half
+            #     second stutter here allows the test to succeed with the newer faster Firefox
+            #     Quantum.
+            time.sleep(.5)
+            add_attach_btn.click()
+            self._wait_for_element(self._get(self._widget_edit_icon))
+            self._get(self._widget_edit_icon)
+            self._get(self._widget_delete_icon)
+            self._add_file_title = (By.CSS_SELECTOR, 'div.bodypart-display div.item-text')
+            title = self._get(self._add_file_title)
+            assert title.text == u'Please select a file.', title.text
+            upload_btn = self._get(self._upload_btn)
+            assert upload_btn.text == u'UPLOAD FILE', upload_btn.text
+            self.validate_secondary_big_green_button_style(upload_btn)

--- a/test/frontend/Cards/ad_hoc_editor_card.py
+++ b/test/frontend/Cards/ad_hoc_editor_card.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Page Object definition for the Ad-hoc for editors card
@@ -9,11 +9,11 @@ __author__ = 'sbassi@plos.org'
 
 
 class AHEditorCard(AHCard):
-  """
-  Page Object Model for Invite AE Card
-  """
-  def __init__(self, driver):
-    super(AHEditorCard, self).__init__(driver)
+    """
+    Page Object Model for Invite AE Card
+    """
+    def __init__(self, driver):
+        super(AHEditorCard, self).__init__(driver)
 
-    # Locators - Instance members
-    # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')
+        # Locators - Instance members
+        # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')

--- a/test/frontend/Cards/ad_hoc_reviewer_card.py
+++ b/test/frontend/Cards/ad_hoc_reviewer_card.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Page Object definition for the Ad-hoc for reviewers card
@@ -9,11 +9,11 @@ __author__ = 'sbassi@plos.org'
 
 
 class AHReviewerCard(AHCard):
-  """
-  Page Object Model for Ad Hoc for Reviewers Card
-  """
-  def __init__(self, driver):
-    super(AHReviewerCard, self).__init__(driver)
+    """
+    Page Object Model for Ad Hoc for Reviewers Card
+    """
+    def __init__(self, driver):
+        super(AHReviewerCard, self).__init__(driver)
 
-    # Locators - Instance members
-    # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')
+        # Locators - Instance members
+        # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')

--- a/test/frontend/Cards/ad_hoc_staff_card.py
+++ b/test/frontend/Cards/ad_hoc_staff_card.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Page Object definition for the Ad-hoc for staff card
@@ -9,11 +9,11 @@ __author__ = 'sbassi@plos.org'
 
 
 class AHStaffCard(AHCard):
-  """
-  Page Object Model for Ad Hoc for Staff Only Card
-  """
-  def __init__(self, driver):
-    super(AHStaffCard, self).__init__(driver)
+    """
+    Page Object Model for Ad Hoc for Staff Only Card
+    """
+    def __init__(self, driver):
+        super(AHStaffCard, self).__init__(driver)
 
-    # Locators - Instance members
-    # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')
+        # Locators - Instance members
+        # self._invite_editor_text = (By.CLASS_NAME, 'invite-editor-text')

--- a/test/frontend/test_ad_hoc.py
+++ b/test/frontend/test_ad_hoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 This test case validates style and function of the Supporting Information (SI) Card and Task
@@ -24,65 +24,65 @@ __author__ = 'sbassi@plos.org'
 
 @MultiBrowserFixture
 class AdHocCardTest(CommonTest):
-  """
-  Validate the elements, styles, functions of all types of Ad-Hoc Card
-  """
-  def test_ad_hoc_card_styles(self):
     """
-    test_ad_hoc_card_styles: Validates the elements, styles of all types of Ad Hoc card
-    :return: None
+    Validate the elements, styles, functions of all types of Ad-Hoc Card
     """
-    creator_user = random.choice(users)
-    logging.info('Login as {0}'.format(creator_user))
-    dashboard_page = self.cas_login(email=creator_user['email'])
-    dashboard_page.page_ready()
-    dashboard_page.click_create_new_submission_button()
-    self.create_article(journal='PLOS Wombat', type_='Research', random_bit=True)
-    manuscript_page = ManuscriptViewerPage(self.getDriver())
-    paper_url = manuscript_page.get_current_url()
-    short_doi = manuscript_page.get_short_doi()
-    manuscript_page.logout()
-    # Log in as Editorial User
-    editorial_user = random.choice(editorial_users)
-    logging.info('Logging in as {0}'.format(editorial_user))
-    dashboard_page = self.cas_login(email=editorial_user['email'])
-    dashboard_page.page_ready()
-    # go to paper
-    self._driver.get(paper_url)
-    manuscript_page = ManuscriptViewerPage(self.getDriver())
-    manuscript_page.page_ready()
-    manuscript_page.click_workflow_link()
-    workflow_page = WorkflowPage(self.getDriver())
-    workflow_page.page_ready()
-    ad_hoc_user = random.choice(('Authors', 'Editors', 'Reviewers', 'Staff Only'))
-    logging.info('Ad Hoc card for: {0}'.format(ad_hoc_user))
-    if not workflow_page.is_card('Ad-hoc for {0}'.format(ad_hoc_user)):
-      workflow_page.add_card('Ad-hoc for {0}'.format(ad_hoc_user))
-    if ad_hoc_user == 'Authors':
-      workflow_page.click_ad_hoc_authors_card()
-      ad_hoc_card = AHAuthorCard(self._driver)
-    elif ad_hoc_user == 'Editors':
-      workflow_page.click_ad_hoc_editor_card()
-      ad_hoc_card = AHEditorCard(self._driver)
-    elif ad_hoc_user == 'Reviewers':
-      workflow_page.click_ad_hoc_reviewer_card()
-      ad_hoc_card = AHReviewerCard(self._driver)
-    elif ad_hoc_user == 'Staff Only':
-      workflow_page.click_ad_hoc_staff_card()
-      ad_hoc_card = AHStaffCard(self._driver)
-    else:
-      raise(ValueError, 'Ad hoc card type doesn\'t exist')
-    ad_hoc_card.card_ready()
-    ad_hoc_card.validate_card_elements_styles(short_doi, ad_hoc_user)
-    ad_hoc_card._get(ad_hoc_card._add_btn).click()
-    # By design the email widget is only available to users who can properly utilize it - staff.
-    if ad_hoc_user == 'Staff Only':
-        widget = random.choice(('checkbox', 'input_text', 'paragraph', 'email', 'file_upload'))
-    else:
-      widget = random.choice(('checkbox', 'input_text', 'paragraph', 'file_upload'))
-    logging.info('Testing {0} widget'.format(widget))
-    ad_hoc_card.validate_widgets_styles(widget)
-    return None
+    def test_smoke_ad_hoc_card(self):
+        """
+        test_ad_hoc_card_styles: Validates the elements, styles of all types of Ad Hoc card
+        :return: None
+        """
+        creator_user = random.choice(users)
+        logging.info('Login as {0}'.format(creator_user))
+        dashboard_page = self.cas_login(email=creator_user['email'])
+        dashboard_page.page_ready()
+        dashboard_page.click_create_new_submission_button()
+        self.create_article(journal='PLOS Wombat', title='Test Ad-hoc cards',
+                            type_='Research', random_bit=True)
+        manuscript_page = ManuscriptViewerPage(self.getDriver())
+        paper_url = manuscript_page.get_current_url()
+        short_doi = manuscript_page.get_short_doi()
+        manuscript_page.logout()
 
-if __name__ == '__main__':
-  CommonTest.run_tests_randomly()
+        # Log in as Editorial User
+        editorial_user = random.choice(editorial_users)
+        logging.info('Logging in as {0}'.format(editorial_user))
+        dashboard_page = self.cas_login(email=editorial_user['email'])
+        dashboard_page.page_ready()
+        # go to paper
+        self._driver.get(paper_url)
+        manuscript_page = ManuscriptViewerPage(self.getDriver())
+        manuscript_page.page_ready()
+        manuscript_page.click_workflow_link()
+        workflow_page = WorkflowPage(self.getDriver())
+        workflow_page.page_ready()
+        ad_hoc_user = random.choice(('Authors', 'Editors', 'Reviewers', 'Staff Only'))
+        logging.info('Ad Hoc card for: {0}'.format(ad_hoc_user))
+        if not workflow_page.is_card('Ad-hoc for {0}'.format(ad_hoc_user)):
+            workflow_page.add_card('Ad-hoc for {0}'.format(ad_hoc_user))
+        if ad_hoc_user == 'Authors':
+            workflow_page.click_ad_hoc_authors_card()
+            ad_hoc_card = AHAuthorCard(self._driver)
+        elif ad_hoc_user == 'Editors':
+            workflow_page.click_ad_hoc_editor_card()
+            ad_hoc_card = AHEditorCard(self._driver)
+        elif ad_hoc_user == 'Reviewers':
+            workflow_page.click_ad_hoc_reviewer_card()
+            ad_hoc_card = AHReviewerCard(self._driver)
+        elif ad_hoc_user == 'Staff Only':
+            workflow_page.click_ad_hoc_staff_card()
+            ad_hoc_card = AHStaffCard(self._driver)
+        else:
+            raise(ValueError, 'Ad hoc card type doesn\'t exist')
+        ad_hoc_card.card_ready()
+        ad_hoc_card.validate_card_elements_styles(short_doi, ad_hoc_user)
+        ad_hoc_card._get(ad_hoc_card._add_btn).click()
+        # By design the email widget is only available to users who can properly utilize it -
+        #     staff.
+        if ad_hoc_user == 'Staff Only':
+            widget = random.choice(('checkbox', 'input_text', 'paragraph', 'email', 'file_upload'))
+        else:
+            widget = random.choice(('checkbox', 'input_text', 'paragraph', 'file_upload'))
+        logging.info('Testing {0} widget'.format(widget))
+        ad_hoc_card.validate_widgets_styles(widget)
+        return None


### PR DESCRIPTION
…eamcity/viewLog.html?buildId=147415&tab=buildResultsDiv&buildTypeId=Aperta_NoNoseIntegrationTestOnSfoCI#testNameId7368998007253527866
Teamcity issue: https://teamcity.plos.org/teamcity/viewLog.html?buildId=147415&tab=buildResultsDiv&buildTypeId=Aperta_NoNoseIntegrationTestOnSfoCI#testNameId7368998007253527866

#### What this PR does:

Modified how we interact with the widget popout of the ad-hoc cards which was implemented too cleverly by half. 

#### Notes

Also updated pages for PEP8

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [x] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [x] Follows first PLOS style guidelines for Python, then PEP-8
- [x] Code is implemented in a Python 3 way
- [x] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
