### PR TITLE
Added utc to local time zone conversion to validate_download_drawer_styles

### DIFF
--- a/test/frontend/Pages/manuscript_viewer.py
+++ b/test/frontend/Pages/manuscript_viewer.py
@@ -1137,7 +1137,8 @@ class ManuscriptViewerPage(AuthenticatedPage):
           version_data = ms_versions[key]
           expected_version_name = version_data['version']
           # adding submission date: APERTA-9335
-          expected_version_date = version_data['date'].strftime("%b %d, %Y")
+          expected_version_date_local = self.utc_to_local_tz(version_data['date'])
+          expected_version_date = expected_version_date_local.strftime("%b %d, %Y")
 
           # Fix for adding the 'V' before the version number
           if expected_version_name != 'draft':

--- a/test/frontend/common_test.py
+++ b/test/frontend/common_test.py
@@ -257,15 +257,15 @@ class CommonTest(FrontEndTest):
 
         PgSQL().modify(
                 'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                'created_at, updated_at) VALUES (%S, %S, %S, \'Paper\', now(), now());',
+                'created_at, updated_at) VALUES (%s, %s, %s, \'Paper\', now(), now());',
                 (handedit_user_id, handling_editor_role_for_env, paper_id))
         PgSQL().modify(
                 'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                'created_at, updated_at) VALUES (%S, %S, %S, \'Paper\', now(), now());',
+                'created_at, updated_at) VALUES (%s, %s, %s, \'Paper\', now(), now());',
                 (covedit_user_id, cover_editor_role_for_env, paper_id))
         PgSQL().modify(
                 'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                'created_at, updated_at) VALUES (%S, %S, %S, \'Paper\', now(), now());',
+                'created_at, updated_at) VALUES (%s, %s, %s, \'Paper\', now(), now());',
                 (acadedit_user_id, academic_editor_role_for_env, paper_id))
 
     @staticmethod
@@ -319,7 +319,7 @@ class CommonTest(FrontEndTest):
             logging.info('Internal Editor user lack Internal Editor role. Adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, %S, \'Journal\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, %s, \'Journal\', now(), now());',
                     (intedit_user_id, internal_editor_role_for_env, wombat_journal_id))
 
         try:
@@ -335,7 +335,7 @@ class CommonTest(FrontEndTest):
             logging.info('Staff Admin user lack Staff Admin role. Adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, %S, \'Journal\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, %s, \'Journal\', now(), now());',
                     (staffadm_user_id, staff_admin_role_for_env, wombat_journal_id))
 
         try:
@@ -351,7 +351,7 @@ class CommonTest(FrontEndTest):
             logging.info('Billing Staff user lack Billing Staff role. Adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, %S, \'Journal\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, %s, \'Journal\', now(), now());',
                     (billstaff_user_id, billstaff_role_for_env, wombat_journal_id))
 
         try:
@@ -367,7 +367,7 @@ class CommonTest(FrontEndTest):
             logging.info('Publishing Services user lack Publishing Services role. Adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, %S, \'Journal\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, %s, \'Journal\', now(), now());',
                     (pubsvcs_user_id, pubsvcs_role_for_env, wombat_journal_id))
 
         try:
@@ -383,7 +383,7 @@ class CommonTest(FrontEndTest):
             logging.info('Production Staff user lack Production Staff role. Adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, %S, \'Journal\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, %s, \'Journal\', now(), now());',
                     (prodstaff_user_id, prodstaff_role_for_env, wombat_journal_id))
 
     @staticmethod
@@ -420,7 +420,7 @@ class CommonTest(FrontEndTest):
             logging.info('Handling editor user lacks Freeland Editor role, adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, %S, \'Journal\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, %s, \'Journal\', now(), now());',
                     (handedit_user_id, freelance_editor_role_for_env, wombat_journal_id))
 
         try:
@@ -436,7 +436,7 @@ class CommonTest(FrontEndTest):
             logging.info('Cover editor user lacks Freeland Editor role, adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, %S, \'Journal\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, %s, \'Journal\', now(), now());',
                     (covedit_user_id, freelance_editor_role_for_env, wombat_journal_id))
 
     @staticmethod
@@ -467,7 +467,7 @@ class CommonTest(FrontEndTest):
             logging.info('Site Admin user lacks Site Admin role, adding...')
             PgSQL().modify(
                     'INSERT INTO assignments (user_id, role_id, assigned_to_id, assigned_to_type, '
-                    'created_at, updated_at) VALUES (%S, %S, 1, \'System\', now(), now());',
+                    'created_at, updated_at) VALUES (%s, %s, 1, \'System\', now(), now());',
                     (siteadmin_user_id, site_admin_role_for_env))
 
     @staticmethod
@@ -525,7 +525,7 @@ class CommonTest(FrontEndTest):
             mmt_phase_ids.append(mmt_phase_id_tuple[0])
         try:
             PgSQL().query('SELECT title FROM task_templates WHERE title = \'Preprint Posting\' '
-                          'AND phase_template_id = ANY(%S) ;', (mmt_phase_ids,))[0][0]
+                          'AND phase_template_id = ANY(%s) ;', (mmt_phase_ids,))[0][0]
         except IndexError:
             return False
         return True


### PR DESCRIPTION
# QA Ticket

JIRA issue: -

#### What this PR does:

1. Updated **validate_download_drawer_styles()** in **manuscript_viewer.py**:
added utc_to_local_tz conversion to address TC test failure (ManuscriptViewerTest.test_paper_download): 
https://teamcity.plos.org/teamcity/viewLog.html?buildId=147436&tab=buildResultsDiv&buildTypeId=Aperta_NoNoseIntegrationTestOnSfoCI#testNameId-5744517630367870098

2. **common_test.py**: After auto fixing code style with PyCharm most '%s' in pg queries were replaced by '%S'. Changed back.  

#### Notes

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [x] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [x] Follows first PLOS style guidelines for Python, then PEP-8
- [x] Code is implemented in a Python 3 way
- [x] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
