### PR TITLE
Covered the case where a sort puts a paper with a null submit date at…

### DIFF
--- a/test/frontend/Pages/login_page.py
+++ b/test/frontend/Pages/login_page.py
@@ -82,7 +82,7 @@ class LoginPage(AuthenticatedPage):
                                    'will be rolled out on other PLOS journals in the coming ' \
                                    'months.\nClick here for more information about submitting to ' \
                                    'PLOS Biology.\nTo submit to one of our other journals, start ' \
-                                   'here.', avail_jrnls_msg.text                      
+                                   'here.', avail_jrnls_msg.text
     avail_jrnls_list = self._get(self._avail_journals_list)
     assert avail_jrnls_list.text == 'PLOS Biology', avail_jrnls_list.text
     avail_jrnls_info_link = self._get(self._avail_journals_more_info_link)
@@ -343,3 +343,8 @@ class LoginPage(AuthenticatedPage):
     orcid_signin = self._get(self._orcid_signin)
     orcid_signin.click()
     time.sleep(3)
+
+  def page_ready_cas_login(self):
+    self.set_timeout(10)
+    self._wait_for_element(self._get(self._cas_signin))
+    self.restore_timeout()

--- a/test/frontend/Pages/manuscript_viewer.py
+++ b/test/frontend/Pages/manuscript_viewer.py
@@ -829,14 +829,17 @@ class ManuscriptViewerPage(AuthenticatedPage):
         logging.info(current_env)
         if current_env in production_urls:
             return False
-        preprint_feature_flag = PgSQL().query('SELECT active FROM feature_flags WHERE name = \'PREPRINT\';')[0][0]
+        preprint_feature_flag = PgSQL().query('SELECT active '
+                                              'FROM feature_flags '
+                                              'WHERE name = \'PREPRINT\';')[0][0]
         return preprint_feature_flag
 
     def is_review_before_submission(self):
         """
-        A method that will determine for the manuscript if the 'Review Your Submission' overlay should be shown
-        on submission. Tests for Preprint feature flag enablement for system, preprint checkbox selection for mmt,
-        and finally presence of Preprint Posting card in the manuscript. If all three are found,
+        A method that will determine for the manuscript if the 'Review Your Submission' overlay
+            should be shown on submission. Tests for Preprint feature flag enablement for system,
+            preprint checkbox selection for mmt, and finally presence of Preprint Posting card in
+            the manuscript. If all three are found,
         return True, else False
         """
         # check if the pre-print feature flag is ON

--- a/test/frontend/common_test.py
+++ b/test/frontend/common_test.py
@@ -68,6 +68,7 @@ class CommonTest(FrontEndTest):
         # Login to Aperta
         logging.info('Logging in as user: {0}'.format(email))
         login_page = LoginPage(self.getDriver())
+        login_page.page_ready_cas_login()
         login_page.login_cas()
         cas_signin_page = AkitaLoginPage(self.getDriver())
         cas_signin_page.enter_login_field(email)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -7,7 +7,7 @@ mysql-connector-repackaged==0.3.1
 psycopg2==2.7.3.2
 PyPDF2==1.26.0
 requests==2.18.4
-selenium==3.7.0
+selenium==3.8.0
 smart_getenv==1.1.0
 teamcity-messages==1.21
 pytest==3.2.5


### PR DESCRIPTION
… the top of the sort order. We now validate that to be the case and emit a warning only. We still fail the test if there is a problem sorting non-null items.

TeamCity issue: https://teamcity.plos.org/teamcity/viewLog.html?buildId=147483&tab=buildResultsDiv&buildTypeId=Aperta_NoNoseIntegrationTestOnSfoCI#testNameId7315932669959811141

#### What this PR does:

Now, in the case where we get a sort validation failure, we test the page presented short doi to see if it is null and in this case present only a warning. We cannot validate ordering in this case because ordering in non-deterministic in rails.

#### Notes

Added in a small page ready function in common test to ensure we are clearly indicating the failure reason when we can't log in.
---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [x] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [x] Follows first PLOS style guidelines for Python, then PEP-8
- [x] Code is implemented in a Python 3 way
- [x] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
