### PR TITLE
Delete all letter templates after creating journal

### DIFF
--- a/spec/services/journal_factory_spec.rb
+++ b/spec/services/journal_factory_spec.rb
@@ -182,6 +182,7 @@ describe JournalFactory do
         TaskTemplate.delete_all
         Card.delete_all
         CardTaskType.delete_all
+        LetterTemplate.delete_all
       end
 
       let!(:journal) { @journal }


### PR DESCRIPTION
Fixes

```
rspec ./spec/models/letter_template_spec.rb[1:4:2] ./spec/services/journal_factory_spec.rb[1:1:5:15:5:1] -t ~js --seed 1
```

JIRA issue: None

#### What this PR does:

Adds letter template to the things that we clean up when we are done with the journal factory  spec.

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
