### PR TITLE
Tasks/aperta 11791 fix some errors in bin setup

### DIFF
--- a/test/bin/download_and_extract_assets
+++ b/test/bin/download_and_extract_assets
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Downloads and extracts a bunch of testing assets in the project
+#
+# this prevents us from needing to check a bunch of binary data into git
+
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEST_DIR=$BIN_DIR/..
+ASSETS_DIR=$TEST_DIR/frontend/assets
+
+# Fetch the assets archive from big hector
+cd $ASSETS_DIR
+TESTING_ASSETS_ARCHIVE="testing_assets.tar.gz"
+wget http://bighector.plos.org/aperta/$TESTING_ASSETS_ARCHIVE
+
+# Extract the archive
+if tar --version | grep -q 'gnu'; then
+  echo "Detected GNU tar"
+  tar --warning=no-unknown-keyword -vxf $TESTING_ASSETS_ARCHIVE
+else
+  echo "Detected non-GNU tar"
+  tar -vxf $TESTING_ASSETS_ARCHIVE
+fi
+
+# Remove the archive
+rm $TESTING_ASSETS_ARCHIVE

--- a/test/bin/setup
+++ b/test/bin/setup
@@ -6,6 +6,8 @@ command_exists () {
   command -v $1 &> /dev/null;
 }
 
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 USAGE="usage: bin/setup [-v]"
 DESC="Prepare application state for our python tests. Default sets up a local dev env. -v sets up a local vagrant env"
 
@@ -56,6 +58,9 @@ else
   echo "Configuring development environment ..."
   source config/env.dev
 fi
+
+# setup testing assets
+$BIN_DIR/download_and_extract_assets
 
 # setup data on host
 python -m frontend.test_a_1_add_superadmin


### PR DESCRIPTION
# QA Ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11791

*This PR doesn't resolve APERTA-11791, it just moves us a little closer towards it.*

#### What this PR does:

Fixes some minor issues with the tests/bin/setup script. See commit messages for more details.

I still don't have tests/bin/setup running happily, but these changes are needed to get me to what looks like the first non-trivial error:

```
======================================================================
FAIL: test_populate_base_mmts (__main__.ApertaSeedJournalMMTTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jlabarba/code/tahi/test/frontend/test_a_2_add_stock_mmt.py", line 245, in test_populate_base_mmts
    uses_resrev_report=mmt['uses_resrev_report'])
  File "/Users/jlabarba/code/tahi/test/frontend/Pages/admin_workflows.py", line 311, in add_new_mmt_template
    self.add_card_to_mmt(card_name)
  File "/Users/jlabarba/code/tahi/test/frontend/Pages/admin_workflows.py", line 402, in add_card_to_mmt
    raise ElementDoesNotExistAssertionError('No such card: {0}'.format(card_title))
Base.CustomException.ElementDoesNotExistAssertionError: No such card: Upload Manuscript

----------------------------------------------------------------------
Ran 1 test in 52.583s

FAILED (failures=1)
```

which on the face of it looks like it's due to our failure to set up new journals with some default cards and should hopefully be solved by https://jira.plos.org/jira/browse/APERTA-12356 Do you think that's the case @jgray-PLOS ? If so, we should add that ticket as a blocker to APERTA-11791

~~Also, I noticed that the test suite has some expectations about the files which appear in tests/frontend/assests/imgs, but that directory is .gitignored. I didn't want to change tests/.gitignore for fear of breaking a testing workflow that I don't yet understand, but I find it confusing to have files checked in to the project which are .gitignored.~~ It's expected that these files are extracted from an archive, not checked into git.

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 3 way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA

  
  