### PR TITLE
APERTA-12390 fix author orcid serialization (let us save authors with orcid accounts)

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -45,7 +45,18 @@ class AuthorsController < ApplicationController
   end
 
   def author_list_payload(author)
-    serializer = PaperAuthorSerializer.new(author.paper, root: 'paper')
+    # The PaperAuthorSerializer eventually invokes the OrcidAccountSerializer if
+    # circumstances are right (TahiEnv.orcid_connect_enabled and the author
+    # belongs to a user with an orcid account). Since we're manually creating
+    # the PaperAuthorSerializer we need to set the scope and the scope name
+    # manually as well. This process is normally taken care of for us by active
+    # model serializers.
+    serializer = PaperAuthorSerializer.new(
+      author.paper,
+      root: 'paper',
+      scope: current_user,
+      scope_name: :current_user
+    )
     hash = serializer.as_json
     hash.delete("paper")
     hash

--- a/spec/controllers/authors_controller_spec.rb
+++ b/spec/controllers/authors_controller_spec.rb
@@ -59,6 +59,19 @@ describe AuthorsController do
       expect(author.reload.last_name).to eq "Blabby"
     end
 
+    context 'the author belongs to a user with an orcid account and orcid connect is enabled' do
+      before do
+        allow_any_instance_of(TahiEnv).to receive(:orcid_connect_enabled?).and_return(true)
+        user = FactoryGirl.create(:user)
+        author.update!(user: user)
+        FactoryGirl.create(:orcid_account, user: user)
+      end
+      it 'serializes the orcid account for the author' do
+        put_request
+        expect(res_body).to have_key('orcid_accounts')
+      end
+    end
+
     it 'a DELETE request deletes the author' do
       expect { delete_request }.to change { Author.count }.by(-1)
     end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12390

#### What this PR does:

Manually sets the scope for the `PaperAuthorSerializer` in the `AuthorsController`.
As of #3930 the `PaperAuthorSerializer` will eventually invoke the `OrcidAccountSerializer` if the `ORCID_CONNECT_ENABLED` env variable is set to true and if an author on the paper belongs to a user with an OrcidAccount.

The OrcidAccountSerializer uses the :current_user scope, which the
controller normally provides when the serializer is invoked as part of a
responder, like `respond_with: user` or a `render json: user`, but in
the `author_list_item` method we use `as_json`, which doesn't set the
scope on the serializer, thus causing a 500 when we tried to use it.

Also added a test that will fail on master. The specific case of having
`orcid_connect_enabled` set to true, etc wasn't relevant until the fixes in
c45489093f0b19605f2eb5a7beacdc7c3c09f023, and we missed adding the test case
there.

#### Special instructions for Review or PO:
Previous to these changes it was impossible to save any author with an orcid account in an environment where we'd enabled the `orcid_connect` flag.

**Arthur Author** has an orcid account and `orcid_connect_enabled=true` in the review app. Go to town.
You should also see `orcid_accounts` serialized when PUTing and POSTing to authors, like so:
<img width="518" alt="screen shot 2018-01-03 at 4 25 17 pm" src="https://user-images.githubusercontent.com/2043348/34540555-fd0fb3a4-f0a2-11e7-81af-91f5ef07a065.png">


#### Notes

I missed the test case for this in #3930, and although I thought I was manually testing it under the same conditions that we'd encounter in production that was obvs not the case.

#### Major UI changes

None

---

#### Code Review Tasks:

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

  