### PR TITLE
APERTA-12390 also fix group authors controller

### DIFF
--- a/app/controllers/group_authors_controller.rb
+++ b/app/controllers/group_authors_controller.rb
@@ -47,7 +47,18 @@ class GroupAuthorsController < ApplicationController
   end
 
   def author_list_payload(group_author)
-    serializer = PaperAuthorSerializer.new(group_author.paper, root: 'paper')
+    # The PaperAuthorSerializer eventually invokes the OrcidAccountSerializer if
+    # circumstances are right (TahiEnv.orcid_connect_enabled and the author
+    # belongs to a user with an orcid account). Since we're manually creating
+    # the PaperAuthorSerializer we need to set the scope and the scope name
+    # manually as well. This process is normally taken care of for us by active
+    # model serializers. (Note this logic is duplicated in the AuthorsController)
+    serializer = PaperAuthorSerializer.new(
+      group_author.paper,
+      root: 'paper',
+      scope: current_user,
+      scope_name: :current_user
+    )
     hash = serializer.as_json
     hash.delete("paper")
     hash

--- a/spec/controllers/group_authors_controller_spec.rb
+++ b/spec/controllers/group_authors_controller_spec.rb
@@ -49,6 +49,19 @@ describe GroupAuthorsController do
       expect(group_author.reload.contact_last_name).to eq "Blabby"
     end
 
+    context 'the group author belongs paper that also has an author with an orcid account and orcid connect is enabled' do
+      before do
+        allow_any_instance_of(TahiEnv).to receive(:orcid_connect_enabled?).and_return(true)
+        user = FactoryGirl.create(:user)
+        FactoryGirl.create(:author, user: user, paper: paper)
+        FactoryGirl.create(:orcid_account, user: user)
+      end
+      it 'serializes the orcid account for the author' do
+        put_request
+        expect(res_body).to have_key('orcid_accounts')
+      end
+    end
+
     it 'a DELETE request deletes the author' do
       expect { delete_request }.to change { GroupAuthor.count }.by(-1)
     end


### PR DESCRIPTION


JIRA issue: https://jira.plos.org/jira/browse/APERTA-12390

#### What this PR does:

Although we'd fixed the AuthorsController as part of #3936, we missed
the GroupAuthorsController.  Even though group authors don't have users
with Orcids, if there is an Author on the same paper as the group author
then it will fail to serialize.

Please see #3936 for more details.

#### Special instructions for Review or PO:

Add a group author to a paper that already has an Author with an orcid id.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

