### PR TITLE
APERTA-11353 Clicking "X" button to remove a workflow phase in Admin unresponsive

### DIFF
--- a/client/app/pods/admin/mmt/journal/manuscript-manager-template/edit/controller.js
+++ b/client/app/pods/admin/mmt/journal/manuscript-manager-template/edit/controller.js
@@ -225,7 +225,8 @@ export default Ember.Controller.extend(ValidationErrorsMixin, {
     },
 
     removeRecord(record){
-      record.destroyRecord();
+      record.deleteRecord();
+      record.unloadRecord();
       this.set('pendingChanges', true);
     },
 

--- a/client/tests/acceptance/manuscript-manager-template-test.js
+++ b/client/tests/acceptance/manuscript-manager-template-test.js
@@ -6,6 +6,7 @@ import * as TestHelper from 'ember-data-factory-guy';
 import moduleForAcceptance from 'tahi/tests/helpers/module-for-acceptance';
 import customAssertions from 'tahi/tests/helpers/custom-assertions';
 let adminJournal, mmt;
+
 moduleForAcceptance('Integration: Manuscript Manager Templates', {
   beforeEach: function() {
     customAssertions();
@@ -42,7 +43,7 @@ moduleForAcceptance('Integration: Manuscript Manager Templates', {
 });
 
 function createPhaseTemplate() {
-  return FactoryGuy.make('phase-template', {
+  FactoryGuy.make('phase-template', {
     id: 1,
     manuscriptManagerTemplate: mmt,
     name: 'Phase 1'
@@ -64,10 +65,10 @@ test('Changing phase name', function(assert) {
 });
 
 test('Deleting a phase with no cards', function(assert) {
-  let phase_template = createPhaseTemplate();
+  createPhaseTemplate();
   $.mockjax({
-    url: `/api/phase_templates/${phase_template.get('id')}`,
-    type: 'DELETE',
+    url: '/api/manuscript_manager_templates/1',
+    type: 'PUT',
     status: 204,
     responseText: ''});
 
@@ -76,8 +77,9 @@ test('Deleting a phase with no cards', function(assert) {
     assert.textPresent('.column-title', 'Phase 1');
   });
   click('.remove-icon');
+  click('.paper-type-save-button'); // Click save to persist changes in the DB
   andThen(function() {
-    assert.mockjaxRequestMade(`/api/phase_templates/${phase_template.get('id')}`, 'DELETE', 'it deletes the phase');
+    assert.mockjaxRequestMade('/api/manuscript_manager_templates/1', 'PUT', 'it deletes the phase');
     assert.textNotPresent('.column-title', 'Phase 1');
   });
 });
@@ -90,6 +92,7 @@ test('Deleting a newly created phase not yet saved in the database', function(as
   });
   click('.remove-icon');
   andThen(function() {
+    assert.mockjaxRequestNotMade('/api/manuscript_manager_templates/1', 'PUT');
     assert.textNotPresent('.column-title', 'New Phase');
   });
 });


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-11353

#### What this PR does:

New phases were not being deleted and hidden from the template because we were using deleteRecord instead of destroyRecord in the controller, to do that we needed to persist that change in the database using destroyRecord; I also checked that destroyRecord works fine for records created in the store but not yet saved in the db by creating 2 tests covering those scenarios, finally I did a little refactor to the test.

#### Special instructions for Review or PO:

The ticket has all the necessary reproduction steps.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
