### PR TITLE
Use valid date constant

### DIFF
--- a/client/app/pods/components/paper-downloads/template.hbs
+++ b/client/app/pods/components/paper-downloads/template.hbs
@@ -14,7 +14,7 @@
             {{#if version.isDraft}}
               Draft
             {{else}}
-              v{{version.majorVersion}}.{{version.minorVersion}} - {{format-date version.updatedAt 'short-date-2'}}
+              v{{version.majorVersion}}.{{version.minorVersion}} - {{format-date version.updatedAt 'short-date'}}
             {{/if}}
           </td>
           {{#if (or (eq version.fileType "docx") (eq version.fileType "doc"))}}


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12329
#### What this PR does:

Fixes a bug in the Downloads date format.  The date should no longer be goofy as in this comment:
https://jira.plos.org/jira/browse/APERTA-12329?focusedCommentId=199004&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-199004

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good