### PR TITLE
Re-enabling all tests as it should be.

### DIFF
--- a/test/frontend/test_profile.py
+++ b/test/frontend/test_profile.py
@@ -53,7 +53,7 @@ class ApertaProfileTest(CommonTest):
     profile_page.validate_nav_toolbar_elements(profile_user)
     profile_page.clear_transients()
 
-  def rest_core_avatar(self):
+  def test_core_avatar(self):
     """
     Tests editing of the avatar image for a user profile
     :return:
@@ -162,7 +162,7 @@ class ApertaProfileTest(CommonTest):
     profile_page.delete_affiliation(affiliation_to_delete)
     profile_page.validate_no_affiliation(affiliation_to_delete)
 
-  def rest_orcid(self):
+  def test_orcid(self):
     """
     test_profile: validate adding an orcid connection
                   validate linking and oath process

--- a/test/frontend/test_supporting_information.py
+++ b/test/frontend/test_supporting_information.py
@@ -30,7 +30,7 @@ class SITaskTest(CommonTest):
   Validate the elements, styles, functions of the Supporting Information task
   """
 
-  def rest_smoke_si_task_styles(self):
+  def test_smoke_si_task_styles(self):
     """
     test_si_card: Validates the elements, styles SI Task
     :return: None
@@ -159,7 +159,7 @@ class SITaskTest(CommonTest):
       pass
     supporting_info.restore_timeout()
 
-  def rest_core_replace_si_upload(self):
+  def test_core_replace_si_upload(self):
     """
     test_figure_task: Validates replace function in SI task
     :return: None
@@ -243,7 +243,7 @@ class SITaskTest(CommonTest):
     supporting_info.validate_uploads([fn])
     return None
 
-  def rest_full_multiple_si_uploads(self):
+  def test_full_multiple_si_uploads(self):
     """
     test_figure_task: Validates the upload function for miltiple files in SI task
     and in SI Card


### PR DESCRIPTION
JIRA issue: No JIRA issue

#### What this PR does:

Several tests were incorrectly disabled - this PR reenables them all.

#### Notes
The disabled tests may fail - they should be addressed as failures, not commented out.

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [ ] I ran the code (against a review environment, ci or other common environment)
- [ ] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [ ] I have found the tests to address all explicit and implicit AC or other test standards
- [ ] I agree the author has fulfilled their tasks
- [ ] All asserts output the failing attribute, ideally in context
- [ ] All functions, classes have docstrings with all params and returns specified
- [ ] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [ ] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [ ] Follows first PLOS style guidelines for Python, then PEP-8
- [ ] Code is implemented in a Python 3 way
- [ ] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
