### PR TITLE
Use the right date format

### DIFF
--- a/client/app/lib/aperta-moment.js
+++ b/client/app/lib/aperta-moment.js
@@ -33,6 +33,7 @@ const formats = {
   'long-date-time-2':          'MMMM DD, YYYY H:mm', // "September 04, 1986 20:30"
   'long-date-day-ordinal':     'MMMM Do YYYY', // "September 4th 1986"
   'short-date':                'MMM D, YYYY', // (alias: ll) "Sep 4, 1986"
+  'short-date-long-day':       'MMM DD, YYYY', // "Sep 04, 1986"
   'month-day-year':            'MM/DD/YYYY', // "09/04/1986"
   'month-day-year-time':       'MM/DD/YYYY H:m', // ""09/04/1986 20:30""
   'hour-minute-1':             'H:m', // "20:30"

--- a/client/app/pods/components/paper-downloads/template.hbs
+++ b/client/app/pods/components/paper-downloads/template.hbs
@@ -14,7 +14,7 @@
             {{#if version.isDraft}}
               Draft
             {{else}}
-              v{{version.majorVersion}}.{{version.minorVersion}} - {{format-date version.updatedAt 'short-date'}}
+              v{{version.majorVersion}}.{{version.minorVersion}} - {{format-date version.updatedAt 'short-date-long-day'}}
             {{/if}}
           </td>
           {{#if (or (eq version.fileType "docx") (eq version.fileType "doc"))}}

--- a/client/app/pods/versioned-text/model.js
+++ b/client/app/pods/versioned-text/model.js
@@ -21,7 +21,7 @@ export default DS.Model.extend({
   }),
   sourceType: DS.attr('string'),
   versionString: computed('majorVersion', 'minorVersion', 'updatedAt', function() {
-    const date = formatDate(this.get('updatedAt'), 'long-date-2');
+    const date = formatDate(this.get('updatedAt'), 'short-date-long-day');
     const fileType = isBlank(this.get('fileType')) ? '' : `(${this.get('fileType').toUpperCase()})`;
     if (this.get('isDraft')) {
       return`(draft) ${fileType} - ${date}`;


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12329

#### What this PR does:


I accidentally changed the style of the versions dropdown and the downloads list. This fixes it. 

See: https://jira.plos.org/jira/browse/APERTA-12329?focusedCommentId=199137&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-199137

#### PO Steps:
- Make your way here: https://plos-ciagent-pr-3955.herokuapp.com/papers/devs.100004/versions?selectedVersion1=1.0&selectedVersion2=0.0
- Confirm that in both the version comparison dropdowns and the downloads drawer the dates have a short month and zero-padded day, like this:
![screen shot 2018-01-09 at 7 24 06 pm](https://user-images.githubusercontent.com/1165691/34754562-687c0faa-f573-11e7-9c7c-2f9d6e39525c.png)

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] ~I have found the tests to be sufficient for both positive and negative test cases~

  