### PR TITLE
Add dummy data for email template preview

### DIFF
--- a/config/letter_templates/dummy_data.yml
+++ b/config/letter_templates/dummy_data.yml
@@ -5,6 +5,24 @@ author:
   first_name: 'David'
   last_name: 'Cash'
   full_name: 'David Cash'
+invitation:
+  state: 'invited'
+  due_in_days: 42
+  decline_reason: 'This was obviously a fake invite, and I am not a real scientist.'
+  reviewer_suggestions: 'A real scientist would be better suited to review this manuscript.'
+invitee:
+  email: 'invitee@plos.org'
+  first_name: 'Indiana'
+  last_name: 'Invitedottir'
+  full_name: 'Indiana Invitedottir'
+  title: 'Doctor'
+invitee_name_or_email: 'Indiana Invitedottir'
+inviter:
+  email: 'inviter@plos.org'
+  first_name: 'Ignatius'
+  last_name: 'Invitorson'
+  full_name: 'Ignatius Invitorson'
+  title: 'Doctor'
 journal:
   logo_url: 'https://www.plos.org/uploads/image/file/27230/sm_plos-logo-sm.png'
   name: 'PLOS'
@@ -22,12 +40,14 @@ manuscript:
         email: 'john.doe@plos.org'
         first_name: 'John'
         last_name: 'Doe'
+        full_name: 'John Doe'
   corresponding_authors:
     -  affiliation: 'XYZ University'
        author_initial: 'J'
        email: 'jerry@plos.org'
        first_name: 'Jerry'
        last_name: 'Moreland'
+       full_name: 'Jerry Moreland'
   creator:
     email: 'marguerite@plos.org'
     first_name: 'Marguerite'


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-10841

#### What this PR does:

Adds missing dummy data for previewing of  invitation letter templates.  Responds to this comment from QA: 
https://jira.plos.org/jira/browse/APERTA-10841?focusedCommentId=199402&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-199402
![screen shot 2018-01-12 at 11 02 57 am](https://user-images.githubusercontent.com/1165691/34890827-4d191ed0-f788-11e7-970d-4ecdd90781c6.png)

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] ~I have found the tests to be sufficient for both positive and negative test cases~
