### PR TITLE
APERTA-12393 fix financial disclosure xml

### DIFF
--- a/lib/custom_card/configurations/xml_content/financial_disclosure.xml
+++ b/lib/custom_card/configurations/xml_content/financial_disclosure.xml
@@ -30,12 +30,12 @@
           </Radio>
         </Repeat>
       </DisplayWithValue>
+      <DisplayWithValue visible-with-parent-answer="false">
+        <Description>
+          <text>Your Financial Disclosure Statement will appear as: The author(s) received no specific funding for this work.</text>
+        </Description>
+      </DisplayWithValue>
     </Radio>
-    <DisplayWithValue visible-with-parent-answer="false">
-      <Description>
-        <text>Your Financial Disclosure Statement will appear as: The author(s) received no specific funding for this work.</text>
-      </Description>
-    </DisplayWithValue>
     <FinancialDisclosureSummary></FinancialDisclosureSummary>
   </DisplayChildren>
 </card>


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12393

#### What this PR does:

fixes the xml so that the correct text appears when the radio button is set to false. Already backported into https://github.com/Tahi-project/tahi/pull/3951/files#r161020885

#### Special instructions for Review or PO:

This only applies to newly created journals, the exiting card in production got fixed [already](https://jira.plos.org/jira/browse/APERTA-12393?focusedCommentId=199473&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-199473)

#### Notes

I'm making this PR os our process can flow more fluidly, but it can be revoked if it seems unecessary


---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes at all, I've let the entire QA team know in the JIRA ticket and in the Aperta QA hipchat room.
- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have set an appropriate resolution in the JIRA ticket
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases

