### PR TITLE
yaml_db 0.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,11 +70,7 @@ gem 'tiny_tds'
 gem 'twitter-text'
 gem 'unf'
 gem 'whenever'
-
-# We need any version of yaml_db after 0.3.0 since it will
-# namespace SerializationHelper
-gem 'yaml_db', git: 'https://github.com/yamldb/yaml_db',
-               ref: 'f980a67dfcfef76824676f3938b176b68c260e68'
+gem 'yaml_db'
 
 # has_secure_token has been accepted into rails, but isn't yet in the most
 # recent release (4.2.5) Remove this gem when we upgrade to a rails version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,15 +6,6 @@ GIT
       activemodel (>= 4.1.0)
       activesupport (>= 4.1.0)
 
-GIT
-  remote: https://github.com/yamldb/yaml_db
-  revision: f980a67dfcfef76824676f3938b176b68c260e68
-  ref: f980a67dfcfef76824676f3938b176b68c260e68
-  specs:
-    yaml_db (0.3.0)
-      rails (>= 3.0, < 4.3)
-      rake (>= 0.8.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -689,6 +680,9 @@ GEM
     xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yaml_db (0.6.0)
+      rails (>= 3.0, < 5.2)
+      rake (>= 0.8.7)
 
 PLATFORMS
   ruby
@@ -810,7 +804,7 @@ DEPENDENCIES
   vcr
   webmock
   whenever
-  yaml_db!
+  yaml_db
 
 RUBY VERSION
    ruby 2.3.6p384


### PR DESCRIPTION
# Dev ticket

#### What this PR does: 

Removes an obsolete SHA constraint from yaml_db.  I saw this while working on something else and spun off a quick empowerment.

This lock on a SHA was done in APERTA-5375.  I confirmed that these PO steps from that ticket still work on the review app:
- Go to ~~https://tahi-staging-pr-1793.herokuapp.com/~~ https://plos-ciagent-pr-3971.herokuapp.com/
- Login as jgray_sa with password: in|fury8
- There should be two seed papers on the dashboard

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
