### PR TITLE
APERTA-12489 dont reset invite body when invite is sent

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -66,7 +66,6 @@ class Invitation < ActiveRecord::Base
     event(:invite,
       after_commit: [:set_invitee,
                      :set_invited_at,
-                     :set_body,
                      :notify_invitation_invited]) do
       transitions from: :pending, to: :invited, guards: :invite_allowed?
     end


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12489

#### What this PR does:

We were blowing away user changes to the reviewer invite when the invite was sent. This should stop that.

The only time the body should be set to a newly rendered template on the invite is when it's first created (which currently happens in InvitationController#create)

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] If I made any UI changes at all, I've let the entire QA team know in the JIRA ticket and in the Aperta QA hipchat room.
- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have set an appropriate resolution in the JIRA ticket


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

