### PR TITLE
Qa fix ci diff test

### DIFF
--- a/test/frontend/Tasks/basetask.py
+++ b/test/frontend/Tasks/basetask.py
@@ -212,18 +212,16 @@ class BaseTask(AuthenticatedPage):
         #     first element containing the text would be all we would evaluate.
         if old_value == new_value and new_value:
             # values exist - must look for no-diff text style
-            new_value_locator = (
+            self._new_value_element_locator = (
                 By.XPATH, '//span[contains(@class, "text-diff")]'
                           '/span[not (@class)]/p[text()="{0}"]'.format(new_value))
-            new_value_element = self._get(new_value_locator)
+            new_value_element = self._get(self._new_value_element_locator)
             self.validate_diff_no_change_style(new_value_element)
         elif old_value != new_value and old_value and new_value:
             # values exist - must look for addition or redaction
             self._new_value_element_locator = (
-                By.XPATH, '//span[contains(@class, \'added\')]/p[text() = '
-                          '\'{0}\']'.format(new_value))
-            self._new_value_element_locator = (
-                By.XPATH, '//span[contains(@class, \'added\') and ./p[text() = "{0}"]]'.format(new_value))
+                By.XPATH, '//span[contains(@class, \'added\') and ./p[text() = "{0}"]]'\
+                    .format(new_value))
             old_value_element = self._get(self._old_value_element_locator)
             new_value_element = self._get(self._new_value_element_locator)
             self.validate_diff_redaction_style(old_value_element)
@@ -231,8 +229,8 @@ class BaseTask(AuthenticatedPage):
         elif not old_value and new_value:
             # previous value didn't exist - new one does
             self._new_value_element_locator = (
-                By.XPATH, '//span[contains(@class, \'added\') and ./p[text() = "{0}"]]'.format(new_value))
-            import pdb; pdb.set_trace()
+                By.XPATH, '//span[contains(@class, \'added\') and ./p[text() = "{0}"]]'\
+                    .format(new_value))
             new_value_element = self._get(self._new_value_element_locator)
             self.validate_diff_addition_style(new_value_element)
         elif old_value and not new_value:


### PR DESCRIPTION
# QA Ticket

JIRA issue: link-to-jira

#### What this PR does:

Attempts to fix the failure in https://teamcity.plos.org/teamcity/viewLog.html?buildId=148331&tab=buildResultsDiv&buildTypeId=Aperta_NoNoseIntegrationTestOnSfoCI#testNameId-1616724613874087752

The validation for background color was being done against the child `p` element, but the property is applied to the `span.added` element. This PR addresses this by modifying the XPATH selector that is used to select the diffed elements.

#### Notes

---

#### Code Review Tasks:

Reviewer tasks:

- [x] I read the code; it looks good
- [x] I ran the code (against a review environment, ci or other common environment)
- [x] If the PR changes code on which any other tests are dependent, I ran the dependent tests
- [x] I have found the tests to address all explicit and implicit AC or other test standards
- [x] I agree the author has fulfilled their tasks
- [x] All asserts output the failing attribute, ideally in context
- [x] All functions, classes have docstrings with all params and returns specified
- [x] Does not rely on dynamic, or excessively positional (more than two relations) locators
- [x] Does not rely on explicit sleeps except where absolutely necessary or dictated by the
        complexity of working around such use. Comment why when used.
- [x] Follows first PLOS style guidelines for Python, then PEP-8
- [x] Code is implemented in a Python 3 way
- [x] Code follows implementation guidance at: https://confluence.plos.org/confluence/display/FUNC/Implementing+your+python+end-to-end+tests

#### After the Code Review:

Reviewer tasks:

- [x] I have moved the ticket forward in JIRA
