### PR TITLE
APERTA-12494 cancel reminders upon decision reg

### DIFF
--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -58,6 +58,7 @@ class Decision < ActiveRecord::Base
               minor_version: paper.minor_version,
               registered_at: DateTime.now.utc
       originating_task.try(:after_register, self)
+      reviewer_reports.each(&:cancel_reminders)
     end
   end
 

--- a/app/models/reviewer_report.rb
+++ b/app/models/reviewer_report.rb
@@ -142,6 +142,10 @@ class ReviewerReport < ActiveRecord::Base
     admin_edits.active.present?
   end
 
+  def cancel_reminders
+    scheduled_events.cancelable.each(&:cancel!)
+  end
+
   private
 
   def set_submitted_at
@@ -168,9 +172,5 @@ class ReviewerReport < ActiveRecord::Base
     when 'review_pending'
       mailer.delay.welcome_reviewer(assignee_id: user.id, paper_id: paper.id)
     end
-  end
-
-  def cancel_reminders
-    scheduled_events.cancelable.each(&:cancel!)
   end
 end

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -242,4 +242,17 @@ describe Decision do
       end
     end
   end
+
+  describe '#register!' do
+    let(:created_paper) { FactoryGirl.create :paper, :submitted_lite }
+    let(:task) { FactoryGirl.create(:reviewer_report_task, paper: created_paper) }
+    let(:reviewer_report) { FactoryGirl.create(:reviewer_report, task: task) }
+    it 'cancels asociated reviewer reports reminders' do
+      allow(reviewer_report).to receive(:review_duration_period).and_return(10)
+      reviewer_report.set_due_datetime
+      decision.reviewer_reports << reviewer_report
+      new_states = Array.new(3) { 'canceled' }
+      expect { decision.register!(task) }.to change { reviewer_report.scheduled_events.reload.map(&:state) }.to(new_states)
+    end
+  end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12494

#### What this PR does:

Cancels reminders associated with a decision's reviewer reports upon registering a decision. To test, register a decision on a paper with an unsubmitted reviewer report and note that the scheduled events get cancelled.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):


- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

