### PR TITLE
APERTA-8281 fix figure title and name

### DIFF
--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -33,6 +33,11 @@ class Figure < Attachment
     insert_figures! if all_figures_done?
   end
 
+  def filename
+    # pending_url holds the actual URI encoded filename, Carrierwave mangles it something awful
+    pending_url ? URI.decode(pending_url.split('/').last.tr('+', ' ')) : super
+  end
+
   protected
 
   def build_title
@@ -44,7 +49,7 @@ class Figure < Attachment
 
   def title_from_filename
     title_rank_regex = /fig(ure)?[^[:alnum:]]*(?<label>\d+)/i
-    title_rank_regex.match(file.filename) do |match|
+    title_rank_regex.match(filename) do |match|
       return "Fig #{match['label']}"
     end
   end

--- a/spec/models/figure_spec.rb
+++ b/spec/models/figure_spec.rb
@@ -206,16 +206,16 @@ describe Figure, redis: true do
   end
 
   describe '#title_from_filename' do
-    ["Figure 1.tiff", "figure 1.tiff", "fig. 1.tiff", "fig_1.tiff"].each do |filename|
-      it "returns 'Fig 1' when file is named #{filename}" do
-        expect(figure.file).to receive(:filename).and_return(filename)
+    ["Figure 1", "figure 1", "fig. 1", "fig_1", "fig+1", "fig#1", "foo/fig%231"].each do |filename|
+      it "returns 'Fig 1' when file is named #{filename}.tiff" do
+        expect(figure).to receive(:pending_url).twice.and_return("#{filename}.tiff")
         expect(figure.send(:title_from_filename)).to eq("Fig 1")
       end
     end
 
     ["1.tiff", "Figure.tiff", "Figure S1.tiff", "Figure ABC.tiff", "abc.tiff", "abc 1.tiff"].each do |filename|
       it "returns nil when file is named #{filename}" do
-        expect(figure.file).to receive(:filename).and_return(filename)
+        expect(figure).to receive(:pending_url).twice.and_return(filename)
         expect(figure.send(:title_from_filename)).to be_nil
       end
     end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-8281

#### What this PR does:

Displays the correct user supplied file name.

#### Special instructions for Review or PO:

Upload a figure where the name is `figure#2` or the specified ones in the ticket. should display stuff nicely.

#### Notes

Feels sorta hacky. Upon first upload, we have the actual filename in the controller `params[:filename]` but there's nowhere particularly nice to store it. I could make a migration to add a new column to attachment and save the filename there but it seemed like a bit of a child-class specific fix. let me know if that is better tho. Ideally there would be something like `self.origina_filename` but I couldnt really find something like that...

Also kind of important: these file name fixes are reflected in the file names exported to apex. I can make a browser level only fix if that is deemed necessary.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] If I made any UI changes at all, I've let the entire QA team know in the JIRA ticket and in the Aperta QA hipchat room.
- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
