### PR TITLE
Add rake task to assign the site admin role by the user email

### DIFF
--- a/lib/tasks/roles_and_permissions.rake
+++ b/lib/tasks/roles_and_permissions.rake
@@ -21,4 +21,29 @@ namespace :'roles-and-permissions' do
       JournalFactory.assign_hints(journal)
     end
   end
+
+  desc 'Assigns the Site Admin role to a user by email address'
+  task assign_site_admin: :environment do
+    email = ENV['email']
+    if email.blank?
+      puts 'This rake task requires an email= parameter'
+      exit(1)
+    end
+
+    user = User.find_by(email: email)
+    if user.blank?
+      puts "No user with email '#{email}' could be found."
+      exit(1)
+    end
+
+    if user.site_admin?
+      puts "User '#{email}' is already a Site Admin."
+      exit(1)
+    end
+
+    user.assign_to!(role: Role.site_admin_role, assigned_to: System.first)
+
+    status = user.site_admin? ? 'was' : 'was not'
+    puts "User '#{email}' #{status} assigned the Site Admin role."
+  end
 end


### PR DESCRIPTION
# Dev ticket

JIRA issue: https://jira.plos.org/jira/browse/APERTA-10030

#### What this PR does:

Adds a rake task to assign the Site Admin role to a user, found by their email address:

**rake roles-and-permissions:assign_site_admin email=user@plos.org**

#### Special instructions for Review or PO:

This rake task is self-testing, in that it checks that the user is indeed now a site admin after the role has been assigned, and announces the results in the output message.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases

#### After the Code Review:

Reviewer tasks:

- [ ] I have moved the ticket forward in JIRA
