### PR TITLE
Sinatra is used by sidekiq, it should be available in all envs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'sdoc'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 gem 'sidekiq-unique-jobs'
+gem 'sinatra', require: nil # used by sidekiq and for tests
 gem 'sort_alphabetical'
 gem 'syslogger'
 gem 'timeliness'
@@ -136,7 +137,6 @@ group :test do
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'
   gem 'simplecov'
-  gem 'sinatra', require: nil
   gem 'test_after_commit'
   gem 'thin'
   gem 'timecop'


### PR DESCRIPTION
Moving `sinatra` out of all environments broke our CI deploy
```
LoadError: cannot load such file -- sinatra/base
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/sidekiq-3.5.3/lib/sidekiq/web.rb:3:in `<top (required)>'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
[10:51:02]/var/www/tahi/releases/20180308185049/config/routes.rb:1:in `<top (required)>'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `block in load'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/routes_reloader.rb:40:in `block in load_paths'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/routes_reloader.rb:40:in `each'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/routes_reloader.rb:40:in `load_paths'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/routes_reloader.rb:16:in `reload!'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/routes_reloader.rb:26:in `block in updater'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/file_update_checker.rb:75:in `execute'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/routes_reloader.rb:27:in `updater'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/routes_reloader.rb:7:in `execute_if_updated'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application/finisher.rb:69:in `block in <module:Finisher>'
[10:51:02]/var/www/tahi/shared/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/initializable.rb:30:in `instance_exec'
```