### PR TITLE
APERTA-12460 anchor invitation email validation regex

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -26,7 +26,7 @@ class Invitation < ActiveRecord::Base
 
   before_validation :set_invitee_role
   validates :invitee_role, presence: true
-  validates :email, format: /.+@.+/
+  validates :email, format: /\A.+@.+\z/
   validates :task, presence: true
 
   belongs_to :invitation_queue

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -25,6 +25,11 @@ describe Invitation do
       expect(invitation.valid?).to be(true)
     end
 
+    it 'requires a valid email address sans new line' do
+      invitation.email = "foo@bar.com\nwat"
+      expect(invitation).to_not be_valid
+    end
+
     it 'requires an invitee_role' do
       invitation.task = nil
       invitation.invitee_role = nil


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12460

#### What this PR does:

Validates against newlines in invitation email address

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have set an appropriate resolution in the JIRA ticket
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
