### PR TITLE
remove googletagmanager snippets

### DIFF
--- a/app/views/ember_cli/ember/index.html.erb
+++ b/app/views/ember_cli/ember/index.html.erb
@@ -17,26 +17,6 @@
   <% end %>
 
   <% body.append do %>
-    <% unless Rails.env.test? %>
-      <!-- Tag manager immediately after opening body. https://support.google.com/tagmanager/answer/6103696?hl=en -->
-      <!-- Google Tag Manager -->
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TP26BH"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-TP26BH');</script>
-
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-MQQMGF"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-MQQMGF');</script>
-      <!-- End Google Tag Manager -->
-    <% end %>
     <script type="text/javascript">
       window.eventStreamConfig = <%= TahiPusher::Config.to_json.html_safe %>;
       <% if current_user %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,26 +18,6 @@
     <% end %>
   </head>
   <body class="sessions">
-    <% unless Rails.env.test? %>
-      <!-- Google Tag Manager -->
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TP26BH"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-TP26BH');</script>
-
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-MQQMGF"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-MQQMGF');</script>
-      <!-- End Google Tag Manager -->
-    <% end %>
-
     <div id="aperta-container" class="<%= yield(:tahi_container_class) %>">
       <%= yield %>
     </div>


### PR DESCRIPTION

#### What this PR does:

Removes Google Tag Manager snippets from Aperta.  These contain PLOS-specific GTM container IDs, which we do not want to expose in an open sourced Aperta.
---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
