### PR TITLE
align config groups in .env to match TahiEnv

### DIFF
--- a/.env
+++ b/.env
@@ -1,55 +1,36 @@
-RAILS_ENV=development
+# App
 APP_NAME=Aperta
-CAPYBARA_SERVER_PORT=31337
+RAILS_ENV=development
 RAILS_SECRET_TOKEN=secret-token-goes-here
-REDIS_PROVIDER="redis://localhost:6379"
-REDIS_SENTINEL_ENABLED='false'
-REDIS_SENTINELS="sentinel://localhost:6379 sentinel://localhost:6379"
+# Devise Database Authenticable
+PASSWORD_AUTH_ENABLED=true
 
+# Email
+ADMIN_EMAIL=admin@example.com
+FROM_EMAIL=no-reply@example.com
+# REPORTING_EMAIL=
+DEFAULT_MAILER_URL=tahi.example.com
+
+# Amazon S3
+S3_URL="http://${S3_BUCKET}.s3.amazonaws.com"
+S3_BUCKET=tahi-test
+AWS_ACCESS_KEY_ID=ur-id
+AWS_SECRET_ACCESS_KEY=ur-key
+AWS_REGION=your-aws-region
+
+# Apex FTP
 APEX_FTP_ENABLED="false"
 APEX_FTP_URL="ftp://ftp-user-not-set:ftp-password-not-set@ftp.example.com:21/ftp-directory"
 
+# Billing FTP
 BILLING_FTP_ENABLED="false"
 BILLING_FTP_URL="ftp://ftp-user-not-set:ftp-password-not-set@ftp.example.com:21/ftp-directory"
 
-SALESFORCE_ENABLED=false
-#DATABASEDOTCOM_USERNAME=
-#DATABASEDOTCOM_PASSWORD=
-#DATABASEDOTCOM_HOST=
-#DATABASEDOTCOM_CLIENT_ID=
-#DATABASEDOTCOM_CLIENT_SECRET=
+# Bugsnag
+BUGSNAG_API_KEY='rails_api_key'
+BUGSNAG_JAVASCRIPT_API_KEY='javascript_api_key'
 
-IHAT_URL="http://localhost:3000"
-
-# IHAT_CALLBACK_URL may need to be updated in .env.development to be
-# 'http://IP_ADDRESS:PORT' where IP_ADDRESS is the ip for your local tahi
-# instance and PORT is the port that tahi is running on locally.  This is
-# required if you are running IHAT in a vagrant instance since IHAT may
-# reference its own localhost in vagrant instead of your local machine.
-IHAT_CALLBACK_URL="http://localhost:5000"
-MAX_ABSTRACT_LENGTH=1000
-
-# {{{ Pusher Configuration
-PUSHER_URL=http://765ec374ae0a69f4ce44:509e5d114295@localhost:4567/apps/es-development-abc123
-EVENT_STREAM_WS_HOST=localhost
-EVENT_STREAM_WS_PORT=40604
-PUSHER_VERBOSE_LOGGING=true
-PUSHER_SSL_VERIFY=true
-# }}} Pusher Configuration
-
-# {{{ Email Configuration
-ADMIN_EMAIL=admin@example.com
-# REPORTING_EMAIL=
-DEFAULT_MAILER_URL=tahi.example.com
-FROM_EMAIL=no-reply@example.com
-# MAILSAFE_REPLACEMENT_ADDRESS=
-# }}} Email Configuration
-
-# {{{ Devise Database Authenticable
-PASSWORD_AUTH_ENABLED=true
-# }}} Devise Database Authenticable
-
-# {{{ CAS-NED Integration
+# CAS
 CAS_ENABLED=false
 CAS_CALLBACK_URL=
 CAS_SSL_VERIFY=false
@@ -60,14 +41,31 @@ CAS_PORT=443
 CAS_SERVICE_VALIDATE_URL='/cas/p3/serviceValidate'
 CAS_SSL=true
 CAS_SIGNUP_URL=
-NED_SSL_VERIFY=
+
+# iHat
+IHAT_URL="http://localhost:3000"
+# IHAT_CALLBACK_URL may need to be updated in .env.development to be
+# 'http://IP_ADDRESS:PORT' where IP_ADDRESS is the ip for your local tahi
+# instance and PORT is the port that tahi is running on locally.  This is
+# required if you are running IHAT in a vagrant instance since IHAT may
+# reference its own localhost in vagrant instead of your local machine.
+IHAT_CALLBACK_URL="http://localhost:5000"
+MAX_ABSTRACT_LENGTH=1000
+
+# iThenticate
+ITHENTICATE_ENABLED=false
+
+# Mailsafe
+# MAILSAFE_REPLACEMENT_ADDRESS=
+
+# NED
 NED_API_URL=
 NED_CAS_APP_ID=ned-is-not-configured
 NED_CAS_APP_PASSWORD=ned-is-not-configured
+NED_SSL_VERIFY=
 USE_NED_INSTITUTIONS=false
-# }}} CAS-NED Integration
 
-# {{{ Orcid
+# Orcid
 ORCID_LOGIN_ENABLED=false
 ORCID_CONNECT_ENABLED=false
 ORCID_KEY=
@@ -75,31 +73,41 @@ ORCID_SECRET=
 ORCID_API_VERSION=
 ORCID_SITE_HOST=sandbox.orcid.org
 ORCID_API_HOST=api.sandbox.orcid.org
-# }}} Orcid
 
-# {{{ Router API
-ROUTER_URL='some internal url'
-# }}} Router API
-
-# {{{ Amazon
-AWS_ACCESS_KEY_ID=ur-id
-AWS_REGION=your-aws-region
-AWS_SECRET_ACCESS_KEY=ur-key
-S3_BUCKET=tahi-test
-S3_URL="http://${S3_BUCKET}.s3.amazonaws.com"
-# }}}
-
-# {{{ Third Party Config
-BUGSNAG_API_KEY='rails_api_key'
-BUGSNAG_JAVASCRIPT_API_KEY='javascript_api_key'
-SEGMENT_IO_WRITE_KEY=write_key
-SENDGRID_PASSWORD=password
-SENDGRID_USERNAME=username
-# }}}
-
-# iThenticate
-ITHENTICATE_ENABLED=false
-
+# Puma
 # prevents our development environments from running more
 # than one puma worker which causes issues with ember-cli-rails.
 PUMA_WORKERS=1
+
+# Pusher/Slanger
+PUSHER_URL=http://765ec374ae0a69f4ce44:509e5d114295@localhost:4567/apps/es-development-abc123
+EVENT_STREAM_WS_HOST=localhost
+EVENT_STREAM_WS_PORT=40604
+PUSHER_VERBOSE_LOGGING=true
+PUSHER_SSL_VERIFY=true
+
+# Redis
+REDIS_PROVIDER="redis://localhost:6379"
+REDIS_SENTINEL_ENABLED='false'
+REDIS_SENTINELS="sentinel://localhost:6379 sentinel://localhost:6379"
+
+# RouterApi
+ROUTER_URL='some internal url'
+
+# Salesforce
+SALESFORCE_ENABLED=false
+#DATABASEDOTCOM_USERNAME=
+#DATABASEDOTCOM_PASSWORD=
+#DATABASEDOTCOM_HOST=
+#DATABASEDOTCOM_CLIENT_ID=
+#DATABASEDOTCOM_CLIENT_SECRET=
+
+# Sendgrid
+SENDGRID_PASSWORD=password
+SENDGRID_USERNAME=username
+
+# Capybara
+CAPYBARA_SERVER_PORT=31337
+
+# Segment.io
+SEGMENT_IO_WRITE_KEY=write_key

--- a/lib/tahi_env.rb
+++ b/lib/tahi_env.rb
@@ -15,9 +15,9 @@ class TahiEnv
   extend DslMethods
   include ActiveModel::Validations
 
-  class Error < ::StandardError ; end
-  class InvalidEnvironment < Error ; end
-  class MissingEnvVarRegistration < Error ; end
+  class Error < ::StandardError; end
+  class InvalidEnvironment < Error; end
+  class MissingEnvVarRegistration < Error; end
 
   def self.validate!
     instance.validate!
@@ -50,18 +50,20 @@ class TahiEnv
 
   # App
   required :APP_NAME
-  required :ADMIN_EMAIL
   required :PASSWORD_AUTH_ENABLED, :boolean
   required :RAILS_ASSET_HOST, if: :staging_or_production?
   required :RAILS_ENV
   required :RAILS_SECRET_TOKEN
-  required :DEFAULT_MAILER_URL
-  required :FROM_EMAIL
   optional :FORCE_SSL, :boolean, default: true
   optional :MAX_ABSTRACT_LENGTH
   optional :PING_URL
   optional :PUSHER_SOCKET_URL
+
+  # Email
+  required :ADMIN_EMAIL
+  required :FROM_EMAIL
   optional :REPORTING_EMAIL
+  required :DEFAULT_MAILER_URL
 
   # Amazon S3
   required :S3_URL
@@ -196,7 +198,7 @@ class TahiEnv
   private
 
   def staging_or_production?
-    %w(staging production).include? ENV['RAILS_ENV']
+    %w[staging production].include? ENV['RAILS_ENV']
   end
 
   def validate_at_least_one_form_of_auth


### PR DESCRIPTION

For easier visual comparison, this aligns the groups of config vars in the dotenv file `.env` to match those in `TahiEnv`.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
