### PR TITLE
Provide sensible default settings for all boolean configurations

### DIFF
--- a/lib/tahi_env.rb
+++ b/lib/tahi_env.rb
@@ -51,7 +51,7 @@ class TahiEnv
   # App
   required :APP_NAME
   required :ADMIN_EMAIL
-  required :PASSWORD_AUTH_ENABLED, :boolean
+  optional :PASSWORD_AUTH_ENABLED, :boolean, default: true
   required :RAILS_ASSET_HOST, if: :staging_or_production?
   required :RAILS_ENV
   required :RAILS_SECRET_TOKEN
@@ -76,11 +76,11 @@ class TahiEnv
   required :BASIC_HTTP_PASSWORD, if: :basic_auth_required?
 
   # Apex FTP
-  required :APEX_FTP_ENABLED, :boolean
+  optional :APEX_FTP_ENABLED, :boolean, default: false
   required :APEX_FTP_URL, if: :apex_ftp_enabled?
 
   # Billing FTP
-  required :BILLING_FTP_ENABLED, :boolean
+  optional :BILLING_FTP_ENABLED, :boolean, default: false
   required :BILLING_FTP_URL, if: :billing_ftp_enabled?
 
   # Bugsnag
@@ -88,7 +88,7 @@ class TahiEnv
   optional :BUGSNAG_JAVASCRIPT_API_KEY
 
   # CAS
-  required :CAS_ENABLED, :boolean
+  optional :CAS_ENABLED, :boolean, default: false
   required :CAS_SIGNUP_URL, if: :cas_enabled?
   required :CAS_SSL_VERIFY, :boolean, if: :cas_enabled?
   required :CAS_HOST, if: :cas_enabled?
@@ -137,7 +137,7 @@ class TahiEnv
   required :NED_CAS_APP_ID
   required :NED_CAS_APP_PASSWORD
   optional :NED_SSL_VERIFY, :boolean, default: true
-  required :USE_NED_INSTITUTIONS, :boolean
+  optional :USE_NED_INSTITUTIONS, :boolean, default: false
 
   # Newrelic
   optional :NEWRELIC_KEY
@@ -160,8 +160,8 @@ class TahiEnv
 
   # Pusher / Slanger
   required :PUSHER_URL
-  required :PUSHER_SSL_VERIFY, :boolean
-  required :PUSHER_VERBOSE_LOGGING, :boolean
+  optional :PUSHER_SSL_VERIFY, :boolean, default: true
+  optional :PUSHER_VERBOSE_LOGGING, :boolean, default: false
 
   # Redis
   optional :REDIS_SENTINEL_ENABLED, :boolean, default: false
@@ -171,7 +171,7 @@ class TahiEnv
   optional :ROUTER_URL
 
   # Salesforce
-  optional :SALESFORCE_ENABLED, :boolean, default: true
+  optional :SALESFORCE_ENABLED, :boolean, default: false
   required :DATABASEDOTCOM_HOST, if: :salesforce_enabled?
   required :DATABASEDOTCOM_CLIENT_ID, if: :salesforce_enabled?
   required :DATABASEDOTCOM_CLIENT_SECRET, if: :salesforce_enabled?

--- a/spec/lib/tahi_env_spec.rb
+++ b/spec/lib/tahi_env_spec.rb
@@ -57,7 +57,7 @@ describe TahiEnv do
   # App
   it_behaves_like 'required env var', var: 'APP_NAME'
   it_behaves_like 'required env var', var: 'ADMIN_EMAIL'
-  it_behaves_like 'required boolean env var', var: 'PASSWORD_AUTH_ENABLED'
+  it_behaves_like 'optional boolean env var', var: 'PASSWORD_AUTH_ENABLED', default_value: true
   it_behaves_like 'required env var', var: 'RAILS_ENV'
   it_behaves_like 'dependent required env var', var: 'RAILS_ASSET_HOST', dependent_key: 'RAILS_ENV', dependent_values: %w(staging production)
   it_behaves_like 'required env var', var: 'RAILS_SECRET_TOKEN'
@@ -70,7 +70,7 @@ describe TahiEnv do
   it_behaves_like 'optional env var', var: 'REPORTING_EMAIL'
 
   # Apex FTP
-  include_examples 'required boolean env var', var: 'APEX_FTP_ENABLED'
+  it_behaves_like 'optional boolean env var', var: 'APEX_FTP_ENABLED', default_value: false
   include_examples 'dependent required env var', var: 'APEX_FTP_URL', dependent_key: 'APEX_FTP_ENABLED'
 
   # Amazon S3
@@ -86,7 +86,7 @@ describe TahiEnv do
   it_behaves_like 'dependent required env var', var: 'BASIC_HTTP_PASSWORD', dependent_key: 'BASIC_AUTH_REQUIRED'
 
   # Billing FTP
-  include_examples 'required boolean env var', var: 'BILLING_FTP_ENABLED'
+  it_behaves_like 'optional boolean env var', var: 'BILLING_FTP_ENABLED', default_value: false
   include_examples 'dependent required env var', var: 'BILLING_FTP_URL', dependent_key: 'BILLING_FTP_ENABLED'
 
   # Bugsnag
@@ -94,7 +94,7 @@ describe TahiEnv do
   it_behaves_like 'optional env var', var: 'BUGSNAG_JAVASCRIPT_API_KEY'
 
   # CAS
-  it_behaves_like 'required boolean env var', var: 'CAS_ENABLED'
+  it_behaves_like 'optional boolean env var', var: 'CAS_ENABLED', default_value: false
   it_behaves_like 'dependent required env var', var: 'CAS_SIGNUP_URL', dependent_key: 'CAS_ENABLED'
   it_behaves_like 'dependent required boolean env var', var: 'CAS_SSL_VERIFY', dependent_key: 'CAS_ENABLED'
   it_behaves_like 'dependent required env var', var: 'CAS_HOST', dependent_key: 'CAS_ENABLED'
@@ -126,7 +126,7 @@ describe TahiEnv do
   it_behaves_like 'required env var', var: 'NED_CAS_APP_ID'
   it_behaves_like 'required env var', var: 'NED_CAS_APP_PASSWORD'
   it_behaves_like 'optional boolean env var', var: 'NED_SSL_VERIFY', default_value: true
-  it_behaves_like 'required boolean env var', var: 'USE_NED_INSTITUTIONS'
+  it_behaves_like 'optional boolean env var', var: 'USE_NED_INSTITUTIONS', default_value: false
 
   # Newrelic
   it_behaves_like 'optional env var', var: 'NEWRELIC_KEY'
@@ -155,11 +155,11 @@ describe TahiEnv do
 
   # Pusher / Slanger
   it_behaves_like 'required env var', var: 'PUSHER_URL'
-  it_behaves_like 'required boolean env var', var: 'PUSHER_SSL_VERIFY'
-  it_behaves_like 'required boolean env var', var: 'PUSHER_VERBOSE_LOGGING'
+  it_behaves_like 'optional boolean env var', var: 'PUSHER_SSL_VERIFY', default_value: true
+  it_behaves_like 'optional boolean env var', var: 'PUSHER_VERBOSE_LOGGING', default_value: false
 
   # Salesforce
-  it_behaves_like 'optional boolean env var', var: 'SALESFORCE_ENABLED', default_value: true
+  it_behaves_like 'optional boolean env var', var: 'SALESFORCE_ENABLED', default_value: false
   it_behaves_like 'dependent required env var', var: 'DATABASEDOTCOM_HOST', dependent_key: 'SALESFORCE_ENABLED'
   it_behaves_like 'dependent required env var', var: 'DATABASEDOTCOM_CLIENT_ID', dependent_key: 'SALESFORCE_ENABLED'
   it_behaves_like 'dependent required env var', var: 'DATABASEDOTCOM_CLIENT_SECRET', dependent_key: 'SALESFORCE_ENABLED'
@@ -172,7 +172,7 @@ describe TahiEnv do
 
   describe 'when no authentication is enabled' do
     it 'is not valid' do
-      ClimateControl.modify CAS_ENABLED: nil, ORCID_LOGIN_ENABLED: nil, PASSWORD_AUTH_ENABLED: nil do
+      ClimateControl.modify CAS_ENABLED: "false", ORCID_LOGIN_ENABLED: "false", PASSWORD_AUTH_ENABLED: "false" do
         expect(env.errors.full_messages).to include \
           "Expected at least one form of authentication to be enabled, but none were. Possible forms: CAS, ORCID, PASSWORD_AUTH"
       end

--- a/spec/services/salesforce_services/api_spec.rb
+++ b/spec/services/salesforce_services/api_spec.rb
@@ -29,8 +29,7 @@ describe SalesforceServices::API do
     context "SALESFORCE_ENABLED is not set" do
       it "salesforce_active returns true" do
         ClimateControl.modify SALESFORCE_ENABLED: nil do
-          expect(SalesforceServices::API).to receive(:client)
-          expect(SalesforceServices::API.salesforce_active).to eq(true)
+          expect(SalesforceServices::API.salesforce_active).to eq(false)
         end
       end
     end


### PR DESCRIPTION
#### What this PR does:

As part of simplifying our setup, I believe it would be nice to provide sensible defaults for all our boolean configurations. This will allow smaller `.env` files in development.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
