### PR TITLE
Use TahiEnv (not ENV directly) to decide if password are enabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,7 +71,7 @@ class User < ActiveRecord::Base
 
   after_create :add_user_role!, :associate_invites, :ensure_orcid_acccount!
 
-  if Rails.configuration.password_auth_enabled
+  if TahiEnv.password_auth_enabled?
     devise(
       :trackable, :omniauthable, :database_authenticatable, :registerable,
       :recoverable, :rememberable, :validatable,
@@ -103,7 +103,7 @@ class User < ActiveRecord::Base
   end
 
   def password_required?
-    Rails.configuration.password_auth_enabled && super
+    TahiEnv.password_auth_enabled? && super
   end
 
   def full_name

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -37,7 +37,7 @@
 
   <div class="methods">
 
-    <% if Rails.configuration.password_auth_enabled %>
+    <% if TahiEnv.password_auth_enabled? %>
       <div class="auth-left auth-group">
         <%= form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f| %>
           <div class="auth-field auth-field--text-input">

--- a/config/initializers/password_auth.rb
+++ b/config/initializers/password_auth.rb
@@ -1,4 +1,0 @@
-Tahi::Application.configure do
-  config.password_auth_enabled = ENV['PASSWORD_AUTH_ENABLED'] == 'true'
-end
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Tahi::Application.routes.draw do
     registrations: 'tahi_devise/registrations'
   }
   devise_scope :user do
-    unless Rails.configuration.password_auth_enabled
+    unless TahiEnv.password_auth_enabled?
       # devise will not auto create this route if :database_authenticatable is not enabled
       get 'users/sign_in' => 'devise/sessions#new', as: :new_user_session
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -174,7 +174,12 @@ describe User do
 
   context "password authentication" do
     let(:user) { User.new }
-    before { expect(Rails.configuration).to receive(:password_auth_enabled).and_return(enabled) }
+
+    around do |example|
+      ClimateControl.modify(PASSWORD_AUTH_ENABLED: enabled.to_s) do
+        example.run
+      end
+    end
 
     context "is enabled" do
       let(:enabled) { true }


### PR DESCRIPTION
JIRA issue: None

#### What this PR does:

When working on cleaning up the settings in `.env`, I noticed that the `password_auth_enabled`'s default setting was not being honored. This was because we were not actually using the value in `TahiEnv`.

This PR ensures we are using `TahiEnv`.

---

#### Code Review Tasks:
- [x] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.
- [ ] ~~I added an entry to `## [Unreleased]` in CHANGELOG.md~~

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] ~~I read through the JIRA ticket's AC before doing the rest of the review~~
- [x] I ran the code (in the review environment or locally). ~~I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket~~
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
