### PR TITLE
APERTA-12575 Increase local build timeout

### DIFF
--- a/.env
+++ b/.env
@@ -101,3 +101,6 @@ ITHENTICATE_ENABLED=false
 # prevents our development environments from running more
 # than one puma worker which causes issues with ember-cli-rails.
 PUMA_WORKERS=1
+
+# Ember build can be quite slow at first
+RACK_TIMEOUT=120

--- a/config/initializers/ember.rb
+++ b/config/initializers/ember.rb
@@ -3,7 +3,7 @@ EmberCli.configure do |c|
     path: Rails.root.join('client'),
     # use locally installed bower bin
     bower_path: Rails.root.join('client', 'node_modules', '.bin', 'bower'),
-    build_timeout: 40,
+    build_timeout: (ENV['RACK_TIMEOUT'] || 30).to_i,
     yarn: true
   })
 end


### PR DESCRIPTION
Should help avoid the dreaded "Exectution expired" on slow machines.

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12575

#### What this PR does:

- Increase the dev build time to 120.

Jeffrey was seeing "execution expired" on bighector.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
