### PR TITLE
APERTA-12575 pg 9.4 is not available in recent distros

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -101,7 +101,12 @@ Dir.chdir APP_ROOT do
       brew_install package
     end
   when :linux
-    system "sudo apt-get install -y imagemagick wget redis-server postgresql-9.4 qpdf libsqlite3-dev zlib1g-dev libpq-dev ghostscript"
+    pg_versions = ["9.4", "9.5", "9.6"] # Prefer 9.4, our prod version.
+    pg_versions.each do |pg_version|
+      # Keep trying until a pg is installed
+      break if system "sudo apt-get install -y postgresql-#{pg_version}"
+    end
+    system "sudo apt-get install -y imagemagick wget redis-server qpdf libsqlite3-dev zlib1g-dev libpq-dev ghostscript"
   end
 
   header 'Installing nvm'


### PR DESCRIPTION
Prefer 9.4, then 9.5 then 9.6.

JIRA issue: https://jira.plos.org/jira/browse/APERTA-12575

- Because pg 9.4 is not available in more recent ubuntu/debian versions, this will install 9.4, 9.5 or 9.6 (in that order)

Based on feedback from @jgray-PLOS 's experience.
**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read the code; it looks good
