### PR TITLE
APERTA-12735 Make google tag manager container IDs configurable

### DIFF
--- a/app/views/ember_cli/ember/index.html.erb
+++ b/app/views/ember_cli/ember/index.html.erb
@@ -17,26 +17,9 @@
   <% end %>
 
   <% body.append do %>
-    <% unless Rails.env.test? %>
-      <!-- Tag manager immediately after opening body. https://support.google.com/tagmanager/answer/6103696?hl=en -->
-      <!-- Google Tag Manager -->
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TP26BH"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-TP26BH');</script>
+    <%# Tag manager immediately after opening body. https://support.google.com/tagmanager/answer/6103696?hl=en %>
+    <%= render "shared/gtm" %>
 
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-MQQMGF"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-MQQMGF');</script>
-      <!-- End Google Tag Manager -->
-    <% end %>
     <script type="text/javascript">
       window.eventStreamConfig = <%= TahiPusher::Config.to_json.html_safe %>;
       <% if current_user %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,26 +18,8 @@
     <% end %>
   </head>
   <body class="sessions">
-    <% unless Rails.env.test? %>
-      <!-- Google Tag Manager -->
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-TP26BH"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-TP26BH');</script>
-
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-MQQMGF"
-      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-MQQMGF');</script>
-      <!-- End Google Tag Manager -->
-    <% end %>
-
+    <%# Tag manager immediately after opening body. https://support.google.com/tagmanager/answer/6103696?hl=en %>
+    <%= render "shared/gtm" %>
     <div id="aperta-container" class="<%= yield(:tahi_container_class) %>">
       <%= yield %>
     </div>

--- a/app/views/shared/_gtm.html.erb
+++ b/app/views/shared/_gtm.html.erb
@@ -1,0 +1,11 @@
+<% if Rails.env.production? and TahiEnv.gtm_container_ids.present? %>
+  <% TahiEnv.gtm_container_ids.each do |container_id| %>
+    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= container_id %>"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= container_id %>');</script>
+  <% end %>
+<% end %>

--- a/lib/tahi_env.rb
+++ b/lib/tahi_env.rb
@@ -181,6 +181,9 @@ class TahiEnv
   required :SENDGRID_USERNAME
   required :SENDGRID_PASSWORD
 
+  # GTM
+  optional :GTM_CONTAINER_IDS, :array
+
   def validate!
     unless valid?
       error_message = "Environment validation failed:\n\n"

--- a/spec/lib/tahi_env_spec.rb
+++ b/spec/lib/tahi_env_spec.rb
@@ -169,6 +169,9 @@ describe TahiEnv do
   it_behaves_like 'required env var', var: 'SENDGRID_USERNAME'
   it_behaves_like 'required env var', var: 'SENDGRID_PASSWORD'
 
+  # GTM
+  it_behaves_like 'optional array env var', var: 'GTM_CONTAINER_IDS'
+
   describe 'when no authentication is enabled' do
     it 'is not valid' do
       ClimateControl.modify CAS_ENABLED: "false", ORCID_LOGIN_ENABLED: "false", PASSWORD_AUTH_ENABLED: "false" do

--- a/spec/support/shared_examples/tahi_env_shared_examples.rb
+++ b/spec/support/shared_examples/tahi_env_shared_examples.rb
@@ -144,6 +144,29 @@ shared_examples_for 'required array env var' do |var:|
   end
 end
 
+shared_examples_for 'optional array env var' do |var:|
+  describe "Optional array env var: #{var}" do
+    it 'shows up in the list of known about env vars' do
+      expect(TahiEnv.registered_env_vars[var.to_s]).to eq(TahiEnv::OptionalEnvVar.new(var))
+    end
+
+    query_method_name = "#{var.downcase}?"
+    describe "TahiEnv.#{query_method_name}" do
+      it "returns an array when set to 'server1 server2'" do
+        ClimateControl.modify valid_env.merge("#{var}": 'server1 server2') do
+          expect(TahiEnv.send(var.downcase)).to be_a Array
+        end
+      end
+
+      it 'returns splits a space-separated string into an array' do
+        ClimateControl.modify valid_env.merge("#{var}": 'server1 server2 server3') do
+          expect(TahiEnv.send(var.downcase).count).to be 3
+        end
+      end
+    end
+  end
+end
+
 shared_examples_for 'dependent required boolean env var' do |var:, dependent_key:|
   describe "Dependent required boolean env var: #{var}" do
     it_behaves_like 'dependent required env var', var: var, dependent_key: dependent_key


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12735

#### What this PR does:

- Changes google tag manager tags to be configurable.
- Also changes them to only display on "production", e.g. not local development or testing or heroku
- Also extracts the GTM stuff to a partial since it is used in 2 places

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):
- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

If I modified any environment variables:
- [x] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) https://github.com/PLOS/molten/pull/851 
https://github.com/PLOS-Formulas/aperta-formula/pull/81
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
