### PR TITLE
Fix nil expectation warning

### DIFF
--- a/app/models/reviewer_report.rb
+++ b/app/models/reviewer_report.rb
@@ -148,6 +148,10 @@ class ReviewerReport < ActiveRecord::Base
   end
 
   def user_can_view?(check_user)
+    # Yeah, this seems crazy. See the reviewer report controller,
+    # which has the same logic. Shawn Gatchell and Erik Hetzner
+    # confirm that this behavior is intended, but we do not know the
+    # reason for it. Future visitors, feel free to fix this.
     check_user.can?(:edit, task)
   end
 

--- a/spec/support/shared_examples/reviewer_report_task_serializer_shared_examples.rb
+++ b/spec/support/shared_examples/reviewer_report_task_serializer_shared_examples.rb
@@ -1,4 +1,6 @@
 RSpec.shared_examples_for :reviewer_report_task_serializer do
+  include_context "serialized json"
+  let(:user) { FactoryGirl.create(:user) }
   let(:task_class) { described_class.name.gsub(/Serializer$/, '').constantize }
   let(:paper) { FactoryGirl.create(:paper) }
   let!(:reviewer_report) do
@@ -17,15 +19,14 @@ RSpec.shared_examples_for :reviewer_report_task_serializer do
   end
   let(:object_for_serializer) { reviewer_report_task }
   let(:decision) { FactoryGirl.create(:decision, :pending, paper: paper) }
-  let(:serializer) { described_class.new(reviewer_report_task) }
 
   before do
     allow(reviewer_report_task).to receive(:submitted?).and_return true
     allow(reviewer_report_task).to receive(:display_status).and_return :submitted
-
-    allow(user).to receive(:can?)
-      .with(:view, reviewer_report_task)
-      .and_return true
+    allow(user).to receive(:can?).with(:edit, reviewer_report_task).and_return true
+    allow(user).to receive(:can?).with(:view, reviewer_report_task).and_return true
+    allow(user).to receive(:can?).with(:view, paper).and_return true
+    allow(user).to receive(:can?).with(:view_decisions, paper).and_return true
   end
 
   let(:task_content) { deserialized_content[:task] }


### PR DESCRIPTION
Previous, tests would warn:

```
  WARNING: An expectation of `:can?` was set on `nil`. To allow
  expectations on `nil` and suppress this message, set
  `config.allow_message_expectations_on_nil` to `true`. To disallow
  expectations on `nil`, set
  `config.allow_message_expectations_on_nil` to `false`.
```

This should correct that, by ensuring that the user is properly used.

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases
