### PR TITLE
Remove several n + 1 queries

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -29,7 +29,7 @@ class PapersController < ApplicationController
   def index
     papers = current_user.filter_authorized(
       :view,
-      Paper.all.includes(:roles, journal: :creator_role)
+      Paper.all.includes(:file, :export_deliveries, :roles, journal: :creator_role)
     ).objects
     active_papers, inactive_papers = papers.partition(&:active?)
     respond_with(papers, each_serializer: LitePaperSerializer,

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -696,7 +696,8 @@ class Paper < ActiveRecord::Base
   end
 
   def preprint_posted?
-    export_deliveries.where(state: 'preprint_posted').any?
+    # Optimized for PapersController#index serializer which includes this assoc
+    export_deliveries.any?(&:preprint_posted?)
   end
 
   def front_matter?

--- a/app/serializers/lite_paper_serializer.rb
+++ b/app/serializers/lite_paper_serializer.rb
@@ -63,6 +63,6 @@ class LitePaperSerializer < AuthzSerializer
   end
 
   def reviewer_report
-    @reviewer_report ||= scope.reviewer_reports.joins(:task, :paper).where(papers: {id: id}).first
+    @reviewer_report ||= scope.reviewer_reports.includes(:task).detect { |rr| rr.task.paper_id == id }
   end
 end


### PR DESCRIPTION
#### What this PR does:

We were making n + 1 queries for `:file`, `:export_deliveries` and `:reviewer_reports`. I fixed the first two, and the last is now a cacheable sql query.

This affects our editors the hardest, since they have lots of papers returned from `/api/papers`. I saw a 6 second reduction from ~18s  for user 3415 with production data.

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases