### PR TITLE
APERTA-12835 Use has_many to cache relation on user object

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,8 @@ class User < ActiveRecord::Base
   has_many :affiliations, inverse_of: :user
 
   has_many :reviewer_reports
+  has_many :reviewer_reports_with_tasks, -> { includes(:task) },
+           class_name: ReviewerReport
 
   has_many :comments, inverse_of: :commenter, foreign_key: 'commenter_id'
   has_many \

--- a/app/serializers/lite_paper_serializer.rb
+++ b/app/serializers/lite_paper_serializer.rb
@@ -63,6 +63,6 @@ class LitePaperSerializer < AuthzSerializer
   end
 
   def reviewer_report
-    @reviewer_report ||= scope.reviewer_reports.includes(:task).detect { |rr| rr.task.paper_id == id }
+    @reviewer_report ||= scope.reviewer_reports_with_tasks.detect { |rr| rr.task.paper_id == id }
   end
 end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12835

#### What this PR does:

Previously, because of the way the serializer was implement, each paper serialized in `/api/papers.json` would generate the same query. This prevents this from happening.

This works because it turns a one-off query into a `has_many` relation which is cached on the user that is passed into the serializer.

With a dashboard of about 2100 papers this can shave ~1 second off the request.

Before:
```
14:35:44 web.1     | D, [2018-04-26T14:35:44.083868 #4954] DEBUG -- :   ReviewerReport Load (0.8ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
14:35:44 web.1     | D, [2018-04-26T14:35:44.084462 #4954] DEBUG -- :   CACHE (0.0ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
14:35:44 web.1     | D, [2018-04-26T14:35:44.085963 #4954] DEBUG -- :   CACHE (0.0ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
14:35:44 web.1     | D, [2018-04-26T14:35:44.086378 #4954] DEBUG -- :   CACHE (0.0ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
14:35:44 web.1     | D, [2018-04-26T14:35:44.087542 #4954] DEBUG -- :   CACHE (0.0ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
14:35:44 web.1     | D, [2018-04-26T14:35:44.087863 #4954] DEBUG -- :   CACHE (0.0ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
14:35:44 web.1     | D, [2018-04-26T14:35:44.089174 #4954] DEBUG -- :   CACHE (0.0ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
...
14:35:57 web.1     | Completed 200 OK in 6331ms (Views: 5067.7ms | ActiveRecord: 174.1ms)
```

After:
```
14:47:45 web.1     | D, [2018-04-26T14:47:45.755241 #7159] DEBUG -- :   Role Load (0.3ms)  SELECT "roles".* FROM "roles" WHERE "roles"."name" = 'Creator' AND "roles"."journal_id" IN (1)  [["name", "Creator"]]
14:47:45 web.1     | D, [2018-04-26T14:47:45.841537 #7159] DEBUG -- :   ReviewerReport Load (1.1ms)  SELECT "reviewer_reports".* FROM "reviewer_reports" WHERE "reviewer_reports"."user_id" = 24  ORDER BY decision_id DESC  [["user_id", 24]]
14:47:49 web.1     | Completed 200 OK in 5528ms (Views: 3604.6ms | ActiveRecord: 166.2ms)
```

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket


**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
