### PR TITLE
APERTA-12840 add author to invitation scenario subcontext

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,9 @@ Layout/AlignParameters:
   # or to align subsequent lines with the first parameter
   Enabled: false
 
+Layout/ExtraSpacing:
+  Enabled:  false
+
 Style/StringLiterals:
   # English text needs double quotes, to avoid escaping the very
   # common apostrophe.

--- a/app/models/author_context.rb
+++ b/app/models/author_context.rb
@@ -19,5 +19,5 @@
 # DEALINGS IN THE SOFTWARE.
 
 class AuthorContext < TemplateContext
-  whitelist :first_name, :last_name, :email, :author_initial, :affiliation
+  whitelist :first_name, :last_name, :email, :author_initial, :affiliation, :full_name
 end

--- a/app/models/invitation_scenario.rb
+++ b/app/models/invitation_scenario.rb
@@ -19,14 +19,13 @@
 # DEALINGS IN THE SOFTWARE.
 
 class InvitationScenario < TemplateContext
-  # rubocop:disable Layout/ExtraSpacing
   subcontext :journal,                  source: [:object, :paper, :journal]
   subcontext :manuscript, type: :paper, source: [:object, :paper]
   subcontext :invitation,               source: :object
   subcontext :inviter,    type: :user
   subcontext :invitee,    type: :user
-  subcontext :author,     type: :user,  source: [:object, :paper, :corresponding_authors, :first]
-  # rubocop:enable Layout/ExtraSpacing
+  subcontext :author,                   source: [:object, :paper, :corresponding_authors, :first]
+
   def invitee_name_or_email
     @object.invitee.try(:full_name) || @object.email
   end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-12840

#### What this PR does:

HACK ALERT! Uhmm, i know the dev notes said a lot about this and that, but here's a super sweet one-liner. What makes this kinda whacky is that `Paper#corresponding_authors` can return an array populated with a single `User`, or several `Author` objects. Since we only care about `author.full_name` it doesnt really matter which object it is, we just wrap it in the user context where `full_name` is whitelisted. Boom! Alternately I can set the type to `AuthorContext` and whitelist `:full_name`. Or this all might be the ravings of a lazy madman who found a short cut. 

#### Special instructions for Review or PO:

Invitations should populate author name.

#### Notes

Some mixed feelings.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases