### PR TITLE
APERTA-6864 Provide a no-op response when on CAS logout callback

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,9 @@ Tahi::Application.routes.draw do
     get 'users/sign_out' => 'devise/sessions#destroy'
   end
 
+  # No-op for the callback from CAS
+  post 'users/auth/cas/callback', to: proc { [200, {}, ['']] }
+
   authenticate :user, ->(u) { u.site_admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-6864

#### What this PR does:

Every time a user logs out via CAS, it sends a callback request to
this endpoint. Previously this would error. After this change it will
do nothing.

To test, you can visit https://app.bugsnag.com/tahi-project/soma-prod-tahi/errors/572bb5556601a0b58e8274bc and copy the request to a curl command, then change `https://www.aperta.tech` to `http://localhost:5000`

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [x] I have set the correct component(s) in the JIRA ticket
- [x] I have set an appropriate resolution in the JIRA ticket

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
