### PR TITLE
Implemented workflow with two named workflows: build_includes_test an…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,3 +182,20 @@ jobs:
 
       - store_artifacts:
           path: tmp/capybara
+# implement a workflow so we can force a 1x/w build job (on Thursday at midnight) even if no changes
+workflows:
+  version: 2
+  build_includes_test:
+    jobs:
+      - build
+  weekly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 4"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - build
+


### PR DESCRIPTION
…d weekly. build_includes_test will run on git push as is currently the case, weekly build will ensure we validate build on at least a weekly schedule.

JIRA issue: None - empowerment

#### What this PR does:

It is current policy that for any PLOS project we perform at least one weekly build/test cycle to ensure code and deploy pipelines are functional ahead of need. The Aperta project previously has been busy enough that there did not need to be a weekly build schedule established - now that the project has been downgraded in usage by PLOS - it is now necessary to build in a weekly build.

#### Special instructions for Review or PO:

Circle requires the use of workflows to schedule builds - this change establishes two workflows: 'build_includes_test' and 'weekly'. The first workflow will be triggered on git push as our builds have been happening to date. The second will be triggered once a week on Thursdays at midnight.'
https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow

#### Notes

None


#### Major UI changes

N/A

---

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read the code; it looks good
