### PR TITLE
APERTA-13007 add email pdfs and rename files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ gem 'tiny_tds'
 gem 'twitter-text'
 gem 'unf'
 gem 'yaml_db'
+gem 'eml_to_pdf', require: false
 
 # has_secure_token has been accepted into rails, but isn't yet in the most
 # recent release (4.2.5) Remove this gem when we upgrade to a rails version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,10 @@ GEM
       html_page (~> 0.1.0)
       railties (>= 3.2)
     ember-cli-rails-assets (0.6.2)
+    eml_to_pdf (0.4.1)
+      filesize (~> 0.1.1)
+      mail (~> 2.5, >= 2.5.4)
+      nokogiri (~> 1.7)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
@@ -223,6 +227,7 @@ GEM
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.9.23)
+    filesize (0.1.1)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (1.36.0)
@@ -717,6 +722,7 @@ DEPENDENCIES
   dotenv-rails
   email_spec
   ember-cli-rails
+  eml_to_pdf
   equivalent-xml
   factory_girl_rails
   fake_ftp
@@ -806,4 +812,4 @@ RUBY VERSION
    ruby 2.3.6p384
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -20,6 +20,7 @@
 
 require 'zip'
 require 'fileutils'
+require 'eml_to_pdf'
 
 # This pollutes the global namespace
 def append_paper_metadata_header(csv)
@@ -73,6 +74,34 @@ def export_question(csv, node, level = nil)
   return unless node.key?('children')
   node['children'].each_with_index do |child, i|
     export_question(csv, child, [level, i + 1].compact.join("."))
+  end
+end
+
+def export_email(email, prefix, zos)
+  subject = (email.subject || 'no subject').gsub(' ', '_').gsub(/[^0-9a-z_]/i, '')
+  # some subjects have special cahrs in them, which messes with the wkhtmltopdf bash
+  # truncate at 200 char or filename migh tbe too long
+  filename = [email.sent_at.to_formatted_s(:number), subject].join('_')[0..200]
+  mk_zip_entry(zos, "#{prefix}/email/#{filename}.eml", email.sent_at) do
+    zos << email.raw_source
+  end
+
+  # pdf creation
+  begin
+    temp_eml = Tempfile.new("#{filename}.eml")
+    sanitized_email_data = email.raw_source
+      .gsub(/<img.*?>/m, '') # generally the images link to expired s3 sources which fail the conversion
+      .gsub('=0D', '') # Odd artifacts, maybe from copying stuff from office?
+      .gsub('=3D', '=')
+    temp_eml.write(sanitized_email_data)
+    temp_eml.close
+    temp_pdf = Tempfile.new("#{filename}.pdf")
+    EmlToPdf.convert(temp_eml.path, temp_pdf.path)
+    mk_zip_entry(zos, "#{prefix}/email/#{filename}.pdf", email.sent_at) do
+      zos << temp_pdf.read
+    end
+  rescue EmlToPdf::Wkhtmltopdf::ConversionError
+    puts "Failed to convert Correspondence ID: #{email.id} to pdf, filename: #{filename}"
   end
 end
 
@@ -148,9 +177,7 @@ def export_paper(paper)
       end
     end
     Correspondence.where(paper: paper, versioned_text: nil).each do |email|
-      mk_zip_entry(zos, "#{prefix}/email/#{email.message_id}.eml", email.sent_at) do
-        zos << email.raw_source
-      end
+      export_email(email, prefix, zos)
     end
     paper.versioned_texts.each do |vt|
       version = "v" + (vt.major_version || "0").to_s + "." + (vt.minor_version || "0").to_s
@@ -158,9 +185,7 @@ def export_paper(paper)
       zip_add_url(zos, "#{dir}/#{vt.manuscript_filename}", Attachment.authenticated_url_for_key(vt.manuscript_s3_path + '/' + vt.manuscript_filename)) if vt.manuscript_s3_path.present?
       zip_add_url(zos, "#{dir}/#{vt.sourcefile_filename}", Attachment.authenticated_url_for_key(vt.s3_full_sourcefile_path)) if vt.sourcefile_s3_path.present?
       Correspondence.where(versioned_text: vt).each do |email|
-        mk_zip_entry(zos, "#{dir}/email/#{email.message_id}.eml", email.sent_at) do
-          zos << email.raw_source
-        end
+        export_email(email, dir, zos)
       end
       ExportProxy.figures_from_versioned_text(vt).each do |figure|
         zip_add_url(zos, "#{dir}/figures/#{figure.filename}", figure.href)
@@ -206,11 +231,23 @@ namespace :export do
       papers.append(paper)
       reviewer = ReviewerReport.where(task_id: paper.tasks.pluck(:id)).map(&:user).uniq.compact.sample
       paper2 = reviewer.reviewer_reports.first.try(:paper) unless reviewer.nil?
-      papers.append(paper2) unless paper2.nil?
+      papers.append(paper2) unless paper2.nil? || papers.include?(paper2)
     end
-    papers.each do |paper|
-      export_paper(paper)
-    end
+
+    # papers.each do |paper|
+    #   export_paper(paper)
+    # end
+
+    paper_queue = Queue.new
+    papers.each { |paper| paper_queue << paper}
+    (0...4).map do |i|
+      Thread.new do
+        loop do
+          paper = paper_queue.pop(true) rescue break
+          export_paper(paper)
+        end
+      end
+    end.map(&:join)
   end
 
   task manuscripts_csv: :environment do


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-13007

#### What this PR does:

This converts email correspondence to pdfs as well, and renames it to be timestamp + sanitized subject truncated at 200 chars.

#### Special instructions for Review or PO:

Is there anything out of the ordinary in how the AC for the ticket needs to be evaluated?
Does the reviewer have to run a rake task? Is there specific seed data they should use?
If PO needs specific guidance on how to evaluate this feature please add that information to the JIRA ticket itself (add a link here if needed)

#### Notes

I fixed `rake export:random_manuscript_zips` to not run duplicate papers. I also threaded the network and IO intensive exporting (just for the random task, not for the full task). Its limited by the the db connection pool. I'm not married to it, if we want it for the main task we can do that too.

#### Code Review Tasks:

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [x] I read through the JIRA ticket's AC before doing the rest of the review
- [x] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [x] I read the code; it looks good
- [x] I have found the tests to be sufficient for both positive and negative test cases