### PR TITLE
APERTA-13009 Export cards as HTML; Include missing context

### DIFF
--- a/app/views/export/generic.html.erb
+++ b/app/views/export/generic.html.erb
@@ -21,7 +21,7 @@
     </div><div class="divider">
     <% id_count = data[0].to_i.truncate %>
   <% end %>
-  <p><%= data[0] %> - <%= raw data[1] %>: <span style="color:#137300"><%= data[2] %></span></p>
+  <p><%= data[0] %> - <%= raw data[1] %>: <span style="color:#137300"><%= raw data[2] %></span></p>
 <% end %>
 </div>
 </body>

--- a/app/views/export/generic.html.erb
+++ b/app/views/export/generic.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .divider:nth-child(odd) {
+      border-top: thick double;
+      border-bottom: thick double;
+      background-color: #e3e3e3;
+    }
+  </style>
+  <title><%= "test" %></title>
+</head>
+<body>
+<% id_count = nil %>
+<% @data.each do |data| %>
+  <% if id_count == nil %>
+    <% id_count = data[0].to_i.truncate %>
+    <div class="divider">
+  <% end %>
+  <% if id_count != data[0].to_i.truncate %>
+    </div><div class="divider">
+    <% id_count = data[0].to_i.truncate %>
+  <% end %>
+  <p><%= data[0] %> - <%= raw data[1] %>: <span style="color:#137300"><%= data[2] %></span></p>
+<% end %>
+</div>
+</body>
+</html>

--- a/exports/.gitignore
+++ b/exports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -21,6 +21,9 @@
 require 'zip'
 require 'fileutils'
 require 'eml_to_pdf'
+require 'openssl'
+
+# OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE # Temporary patch around OS X Mojave/Ruby 2.3 SSL issue
 
 # monkey patch em_to_pdf to use local bins
 module EmlToPdf

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -21,7 +21,6 @@
 require 'zip'
 require 'fileutils'
 require 'eml_to_pdf'
-require 'openssl'
 
 # monkey patch em_to_pdf to use local bins
 module EmlToPdf
@@ -247,7 +246,7 @@ def export_paper(paper)
 end
 
 namespace :export do
-  task :manuscript_zip, [:short_doi] => [:environment] do |_, args  |
+  task :manuscript_zip, [:short_doi] => [:environment] do |_, args|
     export_paper(Paper.find_by(short_doi: args.fetch(:short_doi)))
   end
 


### PR DESCRIPTION
Signed-off-by: Michael Walsh <noxiousthing@gmail.com>

JIRA issue: https://jira.plos.org/jira/browse/APERTA-13009

#### What this PR does:

Updates the exports.rake task to export a lot of cards with missing information (primarily Author information) and converting the CSV generation into HTML.  This is to allow consumers of these documents to better read and understand the primary gist of a card.

The HTML generation has really basic styling that is mainly used to separate unique sets of data together (for example, an author from the author card will have all of their information in one "box"). 

#### Special instructions for Review or PO:

I highly recommend you get a diverse set of papers to look at in various states (which does exist to an extend with existing seeds).  Even better, if there is a dump from a real-life production use-case, that would be even better.

After a dump is retrieved, run the following Rake task for a semi-random sampling of papers in different publishing states:

```sh
bundle exec rake export:random_manuscript_zips
```

For just a single specific paper, just pass in doi into this Rake task:

```sh
bundle exec rake export:manuscript_zip[pbio.2000123] 
```

Both commands should generate zip files in the export directory.  Unzip it and you should be able to see a series of .csv, .html, and other assets in the directory.

#### Notes

The project currently needs a lot of help since it's now on an unsupported Ruby version.  On modern OS X machines, for example, it has a lot of difficulties getting started on a fresh Ruby 2.3.6 build due to OpenSSL, ZIP, and other lesser capability issues.  If you're reviewing this and run into similar problems that I have, please feel free to reach out to me for workarounds.

#### Major UI changes

A lot of files that were CSV are now HTML.  It's not the prettiest, but I think it's better than what it looked like before.

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [] If I made any UI changes at all, I've let the entire QA team know in the JIRA ticket and in the Aperta QA hipchat room.
- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have set an appropriate resolution in the JIRA ticket
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] If I modified `app/services/journal_factory.rb`, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.
- [ ] I added an entry to `## [Unreleased]` in CHANGELOG.md

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data_migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results with `rake db:test_migrations` (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
