### PR TITLE
APERTA-13013 Add hierarchical improvements and minor touchups

### DIFF
--- a/app/views/export/_comment.html.erb
+++ b/app/views/export/_comment.html.erb
@@ -1,4 +1,5 @@
-<div>
+<div class="comments">
+  <h1>Comments</h1>
   <h2><%= comment.commenter.full_name %> @ <%= comment.created_at %></h2>
   <div>
     <%= comment.body.gsub("\n", "<br>").html_safe %>

--- a/app/views/export/_content.html.erb
+++ b/app/views/export/_content.html.erb
@@ -1,5 +1,5 @@
 <% if content.present? %>
-  <% if content.content_type == 'display-children' %>
+  <% if content.content_type == 'display-children'%>
     <div style="margin-left: 1em;">
       <%= render partial: 'export/content', collection: content.children, locals: {owner: owner} %>
     </div>

--- a/app/views/export/_content.html.erb
+++ b/app/views/export/_content.html.erb
@@ -1,5 +1,5 @@
 <% if content.present? %>
-  <% if content.content_type == 'display-children'%>
+  <% if content.content_type == 'display-children' %>
     <div style="margin-left: 1em;">
       <%= render partial: 'export/content', collection: content.children, locals: {owner: owner} %>
     </div>

--- a/app/views/export/generic_answers.html.erb
+++ b/app/views/export/generic_answers.html.erb
@@ -7,8 +7,24 @@
        border-bottom: thick double;
        background-color: #e3e3e3;
      }
+     .answer {
+       color: green;
+     }
+     .depth-level-0 {
+       margin-left: 10px;
+     }
+     .depth-level-1 {
+       margin-left: 20px;
+     }
+     .depth-level-2 {
+       margin-left: 30px;
+     }
+     .depth-level-3 {
+       margin-left: 40px;
+     }
+
     </style>
-    <title><%= "test" %></title>
+    <title></title>
   </head>
   <body>
     <%= render partial: "export/content", object: @content, locals: {owner: @owner} %>

--- a/app/views/export/generic_snapshot.html.erb
+++ b/app/views/export/generic_snapshot.html.erb
@@ -7,12 +7,35 @@
       border-bottom: thick double;
       background-color: #e3e3e3;
     }
+    .comments {
+      border-top: thick double;
+      border-bottom: thick double;
+      background-color: #fbffcf;
+    }
+    .answer {
+      color: green;
+    }
+    .depth-level-0 {
+      margin-left: 10px;
+    }
+    .depth-level-1 {
+      margin-left: 20px;
+    }
+    .depth-level-2 {
+      margin-left: 30px;
+    }
+    .depth-level-3 {
+      margin-left: 40px;
+    }
   </style>
-  <title><%= "test" %></title>
 </head>
 <body>
-<% id_count = nil %>
+<%
+  id_count = nil
+  depth = 1
+%>
 <% @data.each do |data| %>
+  <% depth = data[0].scan('.').size %>
   <% if id_count == nil %>
     <% id_count = data[0].to_i.truncate %>
     <div class="divider">
@@ -21,8 +44,12 @@
     </div><div class="divider">
     <% id_count = data[0].to_i.truncate %>
   <% end %>
-  <p><%= data[0] %> - <%= raw data[1] %>: <span style="color:#137300"><%= raw data[2] %></span></p>
+  <p class="depth-level-<%= depth %>">
+    <span class="question"><%= raw data[1] %>:</span>
+    <span class="answer"><%= data[2] %></span>
+  </p>
 <% end %>
 </div>
 </body>
 </html>
+


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/APERTA-13013

#### What this PR does:

This PR provides hierarchical improvements to certain cards (for example, if there's a display-children element with children, they are indented now) and minor enhancements to provide additional clarity.

#### Special instructions for Review or PO:

I highly recommend you get a diverse set of papers to look at in various states (which does exist to an extend with existing seeds). Even better, if there is a dump from a real-life production use-case, that would be even better.

After a dump is retrieved, run the following Rake task for a semi-random sampling of papers in different publishing states:

bundle exec rake export:random_manuscript_zips
For just a single specific paper, just pass in doi into this Rake task:

bundle exec rake export:manuscript_zip[pbio.2000123] 
Both commands should generate zip files in the export directory. Unzip it and you should be able to see a series of .csv, .html, and other assets in the directory.

#### Notes

I had to abandon using proper list elements due to various ways that children parts of having a lot of edge cases.  The option I went with seems the most consistent along all the cards.

#### Major UI changes

N/A, although the look of the generated cards themeselves is different.

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes at all, I've let the entire QA team know in the JIRA ticket and in the Aperta QA hipchat room.
- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have set an appropriate resolution in the JIRA ticket
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] If I modified `app/services/journal_factory.rb`, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.
- [ ] I added an entry to `## [Unreleased]` in CHANGELOG.md

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data_migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results with `rake db:test_migrations` (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
