### PR TITLE
Eng 102

### DIFF
--- a/app/views/export/_invitation.html.erb
+++ b/app/views/export/_invitation.html.erb
@@ -1,6 +1,50 @@
 <tr>
-<td><%= invitation.email %></td>
-<td><%= invitation.state %></td>
-<td>v<%= invitation.decision.major_version || 0 %>.<%= invitation.decision.minor_version || 0 %> - <%= invitation.decision.verdict %></td>
-<td><%= invitation.decline_reason %></td>
+<td>
+  <%= invitation.invitee.try(:full_name) %> <%= invitation.email %>
+</td>
+<td>
+  <%if invitation.decision.major_version%>
+    v<%= invitation.decision.major_version %>.<%= invitation.decision.minor_version %>
+    <%= invitation.decision.verdict.try(:humanize) %>
+  <% end %>
+</td>
+<td>
+  <%if !invitation.pending? %>
+    <%if invitation.invited? %>
+      Invited <%= invitation.invited_at%>
+    <% else %>
+      <%if invitation.accepted? %>
+        <%if ReviewerReport.for_invitation(invitation) %>
+          <%if ReviewerReport.for_invitation(invitation).status == 'completed' %>
+            Completed <%= ReviewerReport.for_invitation(invitation).datetime %>
+          <% else %>
+            <%if ReviewerReport.for_invitation(invitation).due_datetime.due_at %>
+              Review due <%= ReviewerReport.for_invitation(invitation).due_datetime.due_at %>
+            <% else %>
+              Review pending
+            <% end %>
+            <%if invitation.actor && !invitation.is_accepted_by_invitee %>
+              Accepted by <%= invitation.actor.full_name %>
+            <% end %>
+          <% end %>
+        <% else %>
+          Accepted <%= invitation.accepted_at%>
+        <% end %>
+      <% else %>
+        <%if invitation.declined? %>
+          Declined <%= invitation.declined_at%>
+        <% else %>
+          <%if invitation.rescinded? %>
+            Rescinded <%= invitation.rescinded_at%><% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</td>
+<td>
+  <%if invitation.declined? %>
+    <p><%= invitation.decline_reason%></p>
+  <% end %>
+  <%= invitation.body %>
+</td>
 </tr> 

--- a/app/views/export/_invitation.html.erb
+++ b/app/views/export/_invitation.html.erb
@@ -18,7 +18,7 @@
           <%if ReviewerReport.for_invitation(invitation).status == 'completed' %>
             Completed <%= ReviewerReport.for_invitation(invitation).datetime %>
           <% else %>
-            <%if ReviewerReport.for_invitation(invitation).due_datetime.due_at %>
+            <%if ReviewerReport.for_invitation(invitation).try(:due_datetime).try(:due_at) %>
               Review due <%= ReviewerReport.for_invitation(invitation).due_datetime.due_at %>
             <% else %>
               Review pending

--- a/app/views/export/_invitation.html.erb
+++ b/app/views/export/_invitation.html.erb
@@ -3,7 +3,7 @@
   <%= invitation.invitee.try(:full_name) %> <%= invitation.email %>
 </td>
 <td>
-  <%if invitation.decision.major_version%>
+  <%if invitation.decision.try(:major_version)%>
     v<%= invitation.decision.major_version %>.<%= invitation.decision.minor_version %>
     <%= invitation.decision.verdict.try(:humanize) %>
   <% end %>

--- a/app/views/export/_invitation.html.erb
+++ b/app/views/export/_invitation.html.erb
@@ -1,0 +1,6 @@
+<tr>
+<td><%= invitation.email %></td>
+<td><%= invitation.state %></td>
+<td>v<%= invitation.decision.major_version || 0 %>.<%= invitation.decision.minor_version || 0 %> - <%= invitation.decision.verdict %></td>
+<td><%= invitation.decline_reason %></td>
+</tr> 

--- a/app/views/export/_invitation.html.erb
+++ b/app/views/export/_invitation.html.erb
@@ -23,7 +23,7 @@
             <% else %>
               Review pending
             <% end %>
-            <%if invitation.actor && !invitation.is_accepted_by_invitee %>
+            <%if invitation.actor && invitation.actor.id != invitation.invitee.id %>
               Accepted by <%= invitation.actor.full_name %>
             <% end %>
           <% end %>

--- a/app/views/export/generic_answers.html.erb
+++ b/app/views/export/generic_answers.html.erb
@@ -34,5 +34,12 @@
         <%= render partial: "export/comment", collection: @owner.comments %>
       </div>
     <% end %>
+
+    <% if @owner.try(:invitations).present? && @owner.invitations.size > 0 %>
+        <h2>Invitations</h2>
+        <table>
+          <%= render partial: "export/invitation", collection: @owner.invitations %>
+        </table>
+    <% end %>
   </body>
 </html>

--- a/app/views/export/task.html.erb
+++ b/app/views/export/task.html.erb
@@ -34,5 +34,12 @@
         <%= render partial: "export/comment", collection: @owner.comments %>
       </div>
     <% end %>
+
+    <% if @owner.try(:invitations).try(:any?) %>
+        <h2>Invitations</h2>
+        <table>
+          <%= render partial: "export/invitation", collection: @owner.invitations %>
+        </table>
+    <% end %>
   </body>
 </html>

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -277,7 +277,7 @@ def export_paper(paper)
       # Skip any tasks that have been snapshotted, they should be in
       # the version directories.
       next if Snapshot.find_by(source: task).present?
-      next if task.answers.size == 0 && task.comments.size == 0
+      next if task.answers.empty? && task.comments.empty? && (task.try(:invitations).nil? || task.invitations.empty?)
       zip_add_rendered_html(zos,
                             "#{prefix}/#{task.title.parameterize}-task.html",
                             nil,

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -285,7 +285,7 @@ def export_paper(paper)
       zip_add_rendered_html(zos,
                             "#{prefix}/#{task.title.parameterize}-task.html",
                             nil,
-                            'export/generic_answers.html.erb',
+                            'export/task.html.erb',
                             content: task.card_version.card_contents.root,
                             owner: task)
     end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -130,7 +130,7 @@ def export_email(email, prefix, zos)
   temp_eml = Tempfile.new("#{filename}.eml")
 
   # generally the images link to expired s3 sources which fail the conversion
-  sanitized_email_data = email.raw_source.gsub(/<img.*?>/m, '')
+  sanitized_email_data = email.try(:raw_source) ? email.raw_source.gsub(/<img.*?>/m, '') : ''
 
   temp_eml.write(sanitized_email_data)
   temp_eml.close

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -120,7 +120,8 @@ def export_email(email, prefix, zos)
   subject = (email.subject || 'no subject')[0..200].gsub(' ', '_').gsub(/[^0-9a-z_]/i, '')
   # some subjects have special chars in them, which messes with the wkhtmltopdf bash
   # truncate at 200 char or filename might be too long
-  filename = [email.sent_at.iso8601, subject].join('_')
+  filename_sent_at = email.sent_at.try(&:iso8601) || "unsent#{SecureRandom.hex(3)}"
+  filename = [filename_sent_at, subject].join('_')
   mk_zip_entry(zos, "#{prefix}/email/#{filename}.eml", email.sent_at) do
     zos << email.raw_source
   end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -274,10 +274,14 @@ def export_paper(paper)
       end
     end
     paper.tasks.each do |task|
+      next unless task.answers.any? ||
+          task.comments.any? ||
+          task.try(:invitations).try(:any?)
+
       # Skip any tasks that have been snapshotted, they should be in
       # the version directories.
       next if Snapshot.find_by(source: task).present?
-      next if task.answers.empty? && task.comments.empty? && (task.try(:invitations).nil? || task.invitations.empty?)
+
       zip_add_rendered_html(zos,
                             "#{prefix}/#{task.title.parameterize}-task.html",
                             nil,

--- a/spec/support/rich_text_editor_helpers.rb
+++ b/spec/support/rich_text_editor_helpers.rb
@@ -30,7 +30,7 @@ module RichTextEditorHelpers
     page.execute_script("#{instance}.target.triggerSave()")
   end
 
-  def wait_for_editors(timeout: Capybara.default_max_wait_time + 5, count: 1)
+  def wait_for_editors(timeout: Capybara.default_max_wait_time + 25, count: 1)
     Timeout.timeout(timeout) do
       sleep 0.5
       loop until page.evaluate_script("$('iframe').length").to_i >= count


### PR DESCRIPTION
JIRA issue: https://jira.plos.org/jira/browse/ENG-102

The Invite Reviewers card now exports invitation data.
![image](https://user-images.githubusercontent.com/1165691/82586252-23e12980-9b4c-11ea-9b6c-ac2ffd8a2541.png)
![image](https://user-images.githubusercontent.com/1165691/82586408-5a1ea900-9b4c-11ea-8bb4-c6d0b2362768.png)

To test:
- run `bin/setup` to populate sample manuscripts
- run `bundle exec rake export:manuscript_zip['yetijour.1000002']`
- extract and open the file `invite-reviewers-task.html` from the archive `Aperta/export/yetijour.1000002.zip`
- confirm it has the sender, status, and invitation info as in the above screenshot and the logic in https://github.com/Aperta-project/Aperta/blob/develop/client/app/pods/components/invitation-detail-row/template.hbs